### PR TITLE
Fix delete-by-domain functionality

### DIFF
--- a/src/popup/container.js
+++ b/src/popup/container.js
@@ -46,6 +46,7 @@ class PopupContainer extends Component {
             blacklistChoice: false,
             blacklistConfirm: false,
             bookmarkBtn: constants.BOOKMARK_BTN_STATE.DISABLED,
+            domainDelete: false,
         }
 
         this.toggleLoggingPause = remoteFunction('toggleLoggingPause')
@@ -116,8 +117,10 @@ class PopupContainer extends Component {
         return { bookmarkBtn: getBookmarkButtonState(result) }
     }
 
-    onBlacklistBtnClick(domain = false) {
-        const url = domain ? new URL(this.state.url).hostname : this.state.url
+    onBlacklistBtnClick(domainDelete = false) {
+        const url = domainDelete
+            ? new URL(this.state.url).hostname
+            : this.state.url
 
         return event => {
             event.preventDefault()
@@ -128,6 +131,7 @@ class PopupContainer extends Component {
                 blacklistConfirm: true,
                 blacklistBtn: constants.BLACKLIST_BTN_STATE.BLACKLISTED,
                 url,
+                domainDelete,
             }))
         }
     }
@@ -178,7 +182,7 @@ class PopupContainer extends Component {
         this.setState(state => ({ ...state, blacklistConfirm: false }))
 
     handleDeleteBlacklistData = () => {
-        this.deleteDocs(this.state.url)
+        this.deleteDocs(this.state.url, this.state.domainDelete)
         this.resetBlacklistConfirmState()
     }
 

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -70,6 +70,6 @@ async function indexSearch({
 
 // Export index interface
 export { addPage, addPageConcurrent, put } from './search-index/add'
-export { initSingleLookup } from './search-index/util'
+export { initSingleLookup, keyGen } from './search-index/util'
 export { delPages, delPagesConcurrent, del } from './search-index/del'
 export { indexSearch as search }


### PR DESCRIPTION
- fixes #177 
- deletion module regressed after being forgotten during recent data model changes (new index)
- now rewritten to work by grabbing the domains index entry and deleting all pages in that (+ lookups to get all assoc. meta docs for Pouch deletion)