### PR TITLE
Update time filter back search logic for bookmark filter

### DIFF
--- a/src/search/search-index/search.js
+++ b/src/search/search-index/search.js
@@ -52,13 +52,24 @@ async function timeFilterBackSearch({
     skip,
     bookmarksFilter,
 }) {
-    const timeRange = timeFilter.get(bookmarksFilter ? 'bookmark/' : 'visit/')
+    // Back search bookmarks in all cases
     const data = [
         await reverseRangeLookup({
-            ...timeRange,
+            ...timeFilter.get('bookmark/'),
             limit: skip + limit,
         }),
     ]
+
+    // Add result of visit back search if bookmarks flag not set
+    if (!bookmarksFilter) {
+        // Lookup for all time filters for non-bookmark search
+        data.push(
+            await reverseRangeLookup({
+                ...timeFilter.get('visits/'),
+                limit: skip + limit,
+            }),
+        )
+    }
 
     return new Map([...data.reduce((acc, curr) => [...acc, ...curr], [])])
 }

--- a/src/search/search-index/search.js
+++ b/src/search/search-index/search.js
@@ -65,7 +65,7 @@ async function timeFilterBackSearch({
         // Lookup for all time filters for non-bookmark search
         data.push(
             await reverseRangeLookup({
-                ...timeFilter.get('visits/'),
+                ...timeFilter.get('visit/'),
                 limit: skip + limit,
             }),
         )


### PR DESCRIPTION
- previously did search on either bookmark OR visit indexes (oversight in PR #155)
- now in the case of bookmarks filter, only searches bookmarks index, but in the case of standard search, makes sure to search both
- fixes #181 