### PR TITLE
Fix unneeded search lookups in final stage of search

### DIFF
--- a/src/search/index.js
+++ b/src/search/index.js
@@ -9,7 +9,6 @@ async function indexSearch({
     skip = 0,
     limit = 10,
     getTotalCount = false,
-    fullDocs = true,
     showOnlyBookmarks = false,
 }) {
     query = query.trim() // Don't count whitespace searches
@@ -38,7 +37,6 @@ async function indexSearch({
     // Get index results, filtering out any unexpectedly structured results
     const { results, totalCount } = await searchConcurrent(indexQuery, {
         count: getTotalCount,
-        fullDocs,
     })
 
     // Short-circuit if no results


### PR DESCRIPTION
- found this mistake on `dev/playing-with-static-index-values` branch after indexing about 4000 docs and wondering why search time seemed to increase linearly
- one of the final search stages takes the results and does the reverse index lookups to associate them all with their reverse index docs (contains data about latest timestamp, assoc. visits/bookmarks data, etc, all used to derive display state)
- the amount of lookups can be reduced dramatically by doing the pagination stage before lookup stage (__obviously__)
- pagination always leaves us with a constant number of lookups needed: `PAGE_SIZE` docs (10 or 5, depending on UI)
- previously was `N` number of lookups (where `N` is the size of the entire set of pages matched to the query)
- this will change if we go ahead with static index values later (pagination relies on score, which will need to be derived from the reverse index docs), but a good fix for current implementation
- TODO: index thousands of docs again and confirm this solves the linear search time issue I noticed before