### PR TITLE
Allow search requests highest priority in index queue

### DIFF
--- a/src/search/search-index/index.js
+++ b/src/search/search-index/index.js
@@ -1,6 +1,6 @@
 import levelup from 'levelup'
-import createQueue from 'queue'
 
+import Queue from 'src/util/priority-queue'
 import LevelJS from './level-js-to-leveldown'
 
 export const DEFAULT_TERM_SEPARATOR = /[|' .,\-|(\n)]+/
@@ -9,7 +9,7 @@ export const URL_SEPARATOR = /[/?#=+& _.,\-|(\n)]+/
 const index = levelup(new LevelJS('worldbrain-terms'))
 
 // Set up queue to handle scheduling index update requests
-const indexQueue = createQueue({
+const indexQueue = new Queue({
     autostart: true, // Always running, waiting for jobs to come in
     timeout: 10 * 1000, // Don't hold the queue up forever if something goes wrong
     concurrency: 1, // Only one DB-related task should be happening at once

--- a/src/search/search-index/search.js
+++ b/src/search/search-index/search.js
@@ -305,7 +305,7 @@ export async function search(
 
 export const searchConcurrent = (...req) =>
     new Promise((resolve, reject) =>
-        indexQueue.push(() =>
+        indexQueue.pushPriority(() =>
             search(...req)
                 .then(resolve)
                 .catch(reject),

--- a/src/util/priority-queue.js
+++ b/src/util/priority-queue.js
@@ -1,0 +1,21 @@
+import Queue from 'queue'
+
+/**
+ * A "pretend priority queue" that allows items to be enqueued from the start of the queue.
+ */
+export default class extends Queue {
+    /**
+     * @param {any[]|any} jobs Single or array of jobs to push to the front of the queue.
+     *  If multiple jobs, the priority will be given from lowest to max index.
+     * @returns {number} The new length of the queue.
+     */
+    pushPriority(...jobs) {
+        const res = this.jobs.unshift(...jobs)
+
+        if (this.autostart) {
+            this.start()
+        }
+
+        return res
+    }
+}


### PR DESCRIPTION
- fixes #186 
- we don't really need a proper priority queue, we can get away with just pushing all search requests to the front of the internal data structure, keeping all other existing behaviour
- search will still always wait for the currently running job to finish, which could take a few seconds if a big page (still much better than waiting behind lots of them!)