### PR TITLE
Show total search count in overview

### DIFF
--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -89,6 +89,7 @@ export const search = ({ overwrite } = { overwrite: false }) => async (
 
     const searchParams = {
         ...currentQueryParams,
+        getTotalCount: true,
         showOnlyBookmarks,
         limit: constants.PAGE_SIZE,
         skip,

--- a/src/overview/components/Overview.css
+++ b/src/overview/components/Overview.css
@@ -103,7 +103,7 @@
     }
 }
 
-.noResultMessage {
+.resultMessage {
     text-align: center;
     margin-top: 80px;
     font-size: 20px;
@@ -114,6 +114,20 @@
     animation-duration: 0.5s;
     animation-iteration-count: 1;
     animation-timing-function: ease-in;
+}
+
+.smallMessage {
+    position: relative;
+    left: -200px;
+    top: -15px;
+    margin: 0;
+    color: #4abf9d;
+    font-size: 15px;
+    font-style: normal;
+
+    & + ul {
+        margin-top: -30px;
+    }
 }
 
 @keyframes fadeIn {

--- a/src/overview/components/Overview.css
+++ b/src/overview/components/Overview.css
@@ -118,8 +118,8 @@
 
 .smallMessage {
     position: relative;
-    left: -200px;
-    top: -15px;
+    left: -221px;
+    top: -13px;
     margin: 0;
     color: #4abf9d;
     font-size: 15px;

--- a/src/overview/components/PageResultItem.jsx
+++ b/src/overview/components/PageResultItem.jsx
@@ -54,7 +54,7 @@ const PageResultItem = props => (
 )
 
 PageResultItem.propTypes = {
-    _attachments: PropTypes.object.isRequired,
+    _attachments: PropTypes.object,
     displayTime: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/overview/components/ResultList.jsx
+++ b/src/overview/components/ResultList.jsx
@@ -6,7 +6,10 @@ import styles from './ResultList.css'
 const ResultList = ({ children }) => <ul className={styles.root}>{children}</ul>
 
 ResultList.propTypes = {
-    children: PropTypes.arrayOf(PropTypes.node).isRequired,
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]).isRequired,
 }
 
 export default ResultList

--- a/src/overview/components/ResultsMessage.js
+++ b/src/overview/components/ResultsMessage.js
@@ -1,14 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import styles from './Overview.css'
 
-const ResultsMessage = ({ children }) => (
-    <p className={styles.noResultMessage}>{children}</p>
+const ResultsMessage = ({ children, small = false }) => (
+    <p className={cx(styles.resultMessage, { [styles.smallMessage]: small })}>
+        {children}
+    </p>
 )
 
 ResultsMessage.propTypes = {
-    children: PropTypes.string.isRequired,
+    small: PropTypes.bool,
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+        .isRequired,
 }
 
 export default ResultsMessage

--- a/src/overview/container.js
+++ b/src/overview/container.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import Waypoint from 'react-waypoint'
 
-import { LoadingIndicator } from 'src/common-ui/components'
+import { Wrapper, LoadingIndicator } from 'src/common-ui/components'
 import * as actions from './actions'
 import * as selectors from './selectors'
 import ResultList from './components/ResultList'
@@ -23,6 +23,8 @@ class OverviewContainer extends Component {
         isBadTerm: PropTypes.bool.isRequired,
         showInitSearchMsg: PropTypes.bool.isRequired,
         searchResults: PropTypes.arrayOf(PropTypes.object).isRequired,
+        totalResultCount: PropTypes.number.isRequired,
+        shouldShowCount: PropTypes.bool.isRequired,
         needsWaypoint: PropTypes.bool.isRequired,
         handleTrashBtnClick: PropTypes.func.isRequired,
         handleToggleBookmarkClick: PropTypes.func.isRequired,
@@ -124,13 +126,25 @@ class OverviewContainer extends Component {
         if (this.props.isNewSearchLoading) {
             return (
                 <ResultList>
-                    {[<LoadingIndicator key="loadingIndicator" />]}
+                    <LoadingIndicator />
                 </ResultList>
             )
         }
 
         // No issues; render out results list view
-        return <ResultList>{this.renderResultItems()}</ResultList>
+        return (
+            <Wrapper>
+                {this.props.shouldShowCount && (
+                    <ResultsMessage small>
+                        Found <strong>
+                            {this.props.totalResultCount}
+                        </strong>{' '}
+                        results in your digital memory
+                    </ResultsMessage>
+                )}
+                <ResultList>{this.renderResultItems()}</ResultList>
+            </Wrapper>
+        )
     }
 
     render() {
@@ -158,6 +172,8 @@ const mapStateToProps = state => ({
     showFilter: selectors.showFilter(state),
     showOnlyBookmarks: selectors.showOnlyBookmarks(state),
     showInitSearchMsg: selectors.showInitSearchMsg(state),
+    totalResultCount: selectors.totalResultCount(state),
+    shouldShowCount: selectors.shouldShowCount(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/overview/reducer.js
+++ b/src/overview/reducer.js
@@ -8,7 +8,11 @@ import * as actions from './actions'
 const defaultState = {
     searchCount: 0,
     currentPage: 0, // Pagination state
-    searchResult: { docs: [], resultsExhausted: false }, // The current search result list
+    searchResult: {
+        docs: [], // The current search result list
+        resultsExhausted: false,
+        totalCount: 0,
+    },
     // The current search input values
     currentQueryParams: {
         query: '',
@@ -80,8 +84,8 @@ const handleSearchResult = ({ overwrite }) => (state, newSearchResult) => {
     const searchResult = overwrite
         ? newSearchResult
         : {
+              ...newSearchResult,
               docs: [...state.searchResult.docs, ...newSearchResult.docs],
-              resultsExhausted: newSearchResult.resultsExhausted,
           }
 
     return { ...state, searchResult }

--- a/src/overview/selectors.js
+++ b/src/overview/selectors.js
@@ -82,6 +82,18 @@ const resultsExhausted = createSelector(
     searchResult,
     results => results.resultsExhausted,
 )
+
+export const totalResultCount = createSelector(
+    searchResult,
+    results => results.totalCount,
+)
+
+export const shouldShowCount = createSelector(
+    currentQueryParams,
+    ({ query, startDate, endDate }) =>
+        query.length > 0 || startDate != null || endDate != null,
+)
+
 export const needsPagWaypoint = createSelector(
     resultsExhausted,
     isLoading,


### PR DESCRIPTION
- fixes #200 
- just needed some extra state for overview UI, update to an existing view, and additional parameter to send to backend search request
- TODO: make the state derivation determining when to show the count message wait until search has changed before showing (e.g., don't show count on blank search, but if you enter terms/time filter it should come up and wait for the new results - now it shows instantly due to React rerendering on prop change)

![screen shot 2017-11-16 at 20 04 32](https://user-images.githubusercontent.com/1130716/32892790-f1e30936-cb09-11e7-982f-3ccd1790475c.png)
