### PR TITLE
Fix default blacklist entries sometimes not being set

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -47,11 +47,12 @@ browser.commands.onCommand.addListener(command => {
 browser.runtime.onInstalled.addListener(async details => {
     switch (details.reason) {
         case 'install':
+            // Ensure default blacklist entries are stored (before doing anything else)
+            await addToBlacklist(defaultEntries)
             // Open onboarding page
             browser.tabs.create({ url: '/options/options.html#/new_install' })
             // Store the timestamp of when the extension was installed + default blacklist
             browser.storage.local.set({ [installTimeStorageKey]: Date.now() })
-            addToBlacklist(defaultEntries)
             break
         case 'update':
             // If no prior conversion, convert old ext blacklist + show static notif page


### PR DESCRIPTION
- fixes #206 
- make sure to wait for async blacklist stuff to finish before doing the other stuff (like opening the welcome page)
- bigger issue than reported as: if the user interacts with the empty blacklist, they will never get the default entries
- always been a hard bug to reproduce, but this seems to fix it for me (installed ~15 times and have no encountered it); report if still able to reproduce