### PR TITLE
Range lookup during terms indexing for pages with large amounts of terms

### DIFF
--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -8,6 +8,8 @@ import {
     idbBatchToPromise,
 } from './util'
 
+// Used to decide whether or not to do a range lookup for terms vs N single lookups
+const termsSizeLimit = 1000
 const lookupByKeys = initLookupByKeys()
 const singleLookup = initSingleLookup()
 
@@ -77,7 +79,9 @@ const initIndexTerms = (termsField, termKey) => async indexDoc => {
         return Promise.resolve()
     }
 
-    const termValuesMap = await termRangeLookup(termKey, termsSet)
+    const termValuesMap = await (termsSet.size > termsSizeLimit
+        ? termRangeLookup(termKey, termsSet)
+        : lookupByKeys([...termsSet]))
 
     for (const [term, currTermVal] of termValuesMap) {
         const termValue = reduceTermValue(currTermVal, indexDoc)

--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -8,8 +8,8 @@ import {
     idbBatchToPromise,
 } from './util'
 
-// Used to decide whether or not to do a range lookup for terms vs N single lookups
-const termsSizeLimit = 1000
+// Used to decide whether or not to do a range lookup for terms (if # terms gt) or N single lookups
+const termsSizeLimit = 3000
 const lookupByKeys = initLookupByKeys()
 const singleLookup = initSingleLookup()
 


### PR DESCRIPTION
Discussion in #187 prompted me to look more into the indexing algo to find slowdown on larger pages (this page is a good example with ~6.5k terms: https://en.wikipedia.org/wiki/United_States - takes me ~90s to index the terms with 6k pages in my DB). After putting some timers around the place, it was pretty clear the main slowdown was from the lookup of existing terms ([this line](https://github.com/WorldBrain/Memex/blob/master/src/search/search-index/add.js#L80)). Specifically it does N lookups for N terms.

For pages with large amount of terms, it can take a while to do all the queries and get all this data back. This change makes a decision based on the # of terms needed to index whether to do a single range lookup over the entire terms index vs doing the N individual lookups. For large pages this speeds up the process by a lot (the above wiki page goes from ~90s to ~20s for me) - for smaller pages it increases time, hence the decision based on # of terms.

Currently it simply does the old N lookups behaviour on pages with < 1000 terms, and range lookup otherwise. This 1000 number is completely arbitrary, so will play around with it and try to get a more meaningful value but it's definitely a big improvement for now on larger pages!