### PR TITLE
Skip import items where TransitionType of all visits not wanted 

### DIFF
--- a/src/imports/background/import-item-processor.js
+++ b/src/imports/background/import-item-processor.js
@@ -33,6 +33,13 @@ const wantedTransitionTypes = new Set([
 ])
 
 /**
+ * @param {history.VisitItem} item VisitItem object received from the WebExt History API.
+ * @returns {boolean}
+ */
+const filterVisitItemByTransType = item =>
+    wantedTransitionTypes.has(item.transition)
+
+/**
  * @param {IImportItem} importItem
  * @throws {Error} Allows short-circuiting of the import process for current item if no VisitItems left after
  *  filtering.
@@ -41,9 +48,7 @@ async function checkVisitItemTransitionTypes({ url }) {
     const visitItems = await browser.history.getVisits({ url })
 
     // Only keep VisitItems with wanted TransitionType
-    const filteredVisitItems = visitItems.filter(item =>
-        wantedTransitionTypes.has(item.transition),
-    )
+    const filteredVisitItems = visitItems.filter(filterVisitItemByTransType)
 
     // Throw if no VisitItems left post-filtering (only if there was items to begin with)
     if (visitItems.length > 0 && filteredVisitItems.length === 0) {
@@ -74,7 +79,7 @@ async function createAssociatedVisitDocs(pageDoc) {
     const visitItems = await browser.history.getVisits({ url: pageDoc.url })
 
     return visitItems
-        .filter(item => wantedTransitionTypes.has(item.transition))
+        .filter(filterVisitItemByTransType)
         .map(transformToVisitDoc(pageDoc))
 }
 

--- a/src/imports/background/import-item-processor.js
+++ b/src/imports/background/import-item-processor.js
@@ -60,13 +60,19 @@ const formatFavIconAttachment = async favIconURL => {
 }
 
 /**
+ * Create visit docs from each of the WebExt history API's VisitItems. VisitItems with
+ * TransitionTypes not wanted in the context of the extension will be ignored. More info:
+ *  - https://developer.chrome.com/extensions/history#transition_types
+ *
  * @param {PageDoc} pageDoc Page doc to get visits and create visit docs for.
  * @returns {Array<IVisitDoc>} Array of visit docs gotten from URLs in `pageDoc`.
  */
 async function createAssociatedVisitDocs(pageDoc) {
     const visitItems = await browser.history.getVisits({ url: pageDoc.url })
 
-    return visitItems.map(transformToVisitDoc(pageDoc))
+    return visitItems
+        .filter(item => wantedTransitionTypes.has(item.transition))
+        .map(transformToVisitDoc(pageDoc))
 }
 
 async function createAssociatedBookmarkDoc(pageDoc, importItem) {

--- a/src/imports/background/import-item-processor.js
+++ b/src/imports/background/import-item-processor.js
@@ -27,6 +27,9 @@ const wantedTransitionTypes = new Set([
     'generated',
     'keyword',
     'keyword_generated',
+    'typed',
+    'auto_bookmark',
+    'manual_subframe',
 ])
 
 /**


### PR DESCRIPTION
- relates to an idea from this comment: https://github.com/WorldBrain/Memex/issues/143#issuecomment-349243147
- at start of import process for each import item (before any expensive XHR or indexing logic performed), grab all `VisitItem`s from WebExt History API and filter out the items where `TransitionType` is not of interest in our context
- if there's no items left post-filtering, "Redirection URL" Error gets thrown, allowing the current item to be skipped over
- also in the later "`VisitItem` to visit doc" mapping stage, only those `VisitItem`s with wanted `TransitionType`s will be mapped to ensure consistency

- docs for ref on these types:
  - `history.VisitItem`: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/VisitItem
  - `history.TransitionType`: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/TransitionType

`TransitionType`s we are keeping (so far):
- link
- generated
- keyword
- keyword_generated