### PR TITLE
Bookmarking via Overview UI without page content reindexing

### DIFF
--- a/src/bookmarks/background/addition.js
+++ b/src/bookmarks/background/addition.js
@@ -50,7 +50,14 @@ export async function createNewPageForBookmark(id, bookmarkInfo) {
     }
 }
 
-export async function createBookmarkByExtension(url) {
+/**
+ * TODO: Decided if we actually need these bookmark docs in Pouch; I don't think they're being used for anything.
+ *
+ * @param {string} url URL to generate page ID from to associate bookmark with.
+ * @throws {Error} Error thrown if page for supplied URL not indexed.
+ * @returns {Promise<void>}
+ */
+export async function createBookmarkByUrl(url) {
     const pageId = generatePageDocId({ url })
     const pageDoc = await db.get(pageId)
 
@@ -59,6 +66,9 @@ export async function createBookmarkByExtension(url) {
         title: pageDoc.content.title,
         url: pageDoc.url,
     })
-    index.addPageConcurrent({ pageDoc, bookmarkDocs: [bookmarkDoc] })
-    db.put(bookmarkDoc)
+
+    return await Promise.all([
+        index.addBookmarkConcurrent(pageId),
+        db.put(bookmarkDoc),
+    ])
 }

--- a/src/bookmarks/background/deletion.js
+++ b/src/bookmarks/background/deletion.js
@@ -4,31 +4,37 @@ import * as index from 'src/search'
 import deleteDocsByUrl, { deleteDocs } from 'src/page-storage/deletion'
 import { bookmarkKeyPrefix } from '..'
 
+/**
+ * TODO: Decided if we actually need these bookmark docs in Pouch; I don't think they're being used for anything.
+ *
+ * @param {string} url URL to remove _all_ bookmarks for.
+ * @throws {Error} Error thrown when `pageId` param does not correspond to existing document (or any other
+ *  standard indexing-related Error encountered during updates).
+ * @returns {Promise<void>}
+ */
 async function removeBookmarkByUrl(url) {
     const pageId = generatePageDocId({ url })
     const reverseIndexDoc = await index.initSingleLookup()(pageId)
 
     if (reverseIndexDoc == null) {
-        console.warn(
-            'Cannot remove bookmark with no corresponding reverse index entry',
-            pageId,
+        throw new Error(
+            `No document exists in reverse page index for the supplied page ID: ${pageId}`,
         )
-        return
     }
 
     // If no visits, we don't want an orphaned page, so remove everything for given URL
     if (!reverseIndexDoc.visits.size) {
-        return deleteDocsByUrl(url)
+        await deleteDocsByUrl(url)
+    } else {
+        // Standard case where only bookmarks removed from index
+
+        // Deindex from bookmarks index
+        await index.del([...reverseIndexDoc.bookmarks.values()])
+
+        // Update reverse index bookmarks for current doc
+        reverseIndexDoc.bookmarks.clear()
+        await index.put(pageId, reverseIndexDoc)
     }
-
-    // Deindex from bookmarks index
-    await index.del([...reverseIndexDoc.bookmarks.values()])
-
-    // Update reverse index bookmarks for current doc
-    await index.put(pageId, {
-        ...reverseIndexDoc,
-        bookmarks: new Set(),
-    })
 
     // Remove corresponding bookmark docs from pouch
     const fetchDocsByType = fetchDocTypesByUrl(url)

--- a/src/bookmarks/background/index.js
+++ b/src/bookmarks/background/index.js
@@ -1,8 +1,8 @@
 import removeBookmarkByUrl from './deletion'
-import { createBookmarkByExtension, createNewPageForBookmark } from './addition'
+import { createBookmarkByUrl, createNewPageForBookmark } from './addition'
 import { makeRemotelyCallable } from 'src/util/webextensionRPC'
 
-makeRemotelyCallable({ createBookmarkByExtension })
+makeRemotelyCallable({ createBookmarkByUrl })
 makeRemotelyCallable({ removeBookmarkByUrl })
 
 const removeBookmarkHandler = (id, { node }) =>

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -173,6 +173,7 @@ export const deleteDocs = () => async (dispatch, getState) => {
 export const toggleBookmark = (url, index) => async (dispatch, getState) => {
     const results = selectors.results(getState())
     const { hasBookmark } = results[index]
+    dispatch(changeHasBookmark(index)) // Reset UI state in case of error
 
     analytics.trackEvent({
         category: 'Overview',
@@ -181,9 +182,14 @@ export const toggleBookmark = (url, index) => async (dispatch, getState) => {
             : 'Create result bookmark',
     })
 
-    if (hasBookmark) {
-        await removeBookmarkByUrl(url)
-    } else {
-        await createBookmarkByExtension(url)
+    try {
+        // Either perform adding or removal of bookmark if
+        if (hasBookmark) {
+            await removeBookmarkByUrl(url)
+        } else {
+            await createBookmarkByExtension(url)
+        }
+    } catch (error) {
+        dispatch(changeHasBookmark(index)) // Reset UI state in case of error
     }
 }

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -30,7 +30,7 @@ export const incSearchCount = createAction('overview/incSearchCount')
 export const initSearchCount = createAction('overview/initSearchCount')
 
 const deleteDocsByUrl = remoteFunction('deleteDocsByUrl')
-const createBookmarkByExtension = remoteFunction('createBookmarkByExtension')
+const createBookmarkByUrl = remoteFunction('createBookmarkByUrl')
 const removeBookmarkByUrl = remoteFunction('removeBookmarkByUrl')
 
 const getCmdMessageHandler = dispatch => ({ cmd, ...payload }) => {
@@ -187,7 +187,7 @@ export const toggleBookmark = (url, index) => async (dispatch, getState) => {
         if (hasBookmark) {
             await removeBookmarkByUrl(url)
         } else {
-            await createBookmarkByExtension(url)
+            await createBookmarkByUrl(url)
         }
     } catch (error) {
         dispatch(changeHasBookmark(index)) // Reset UI state in case of error

--- a/src/overview/components/PageResultItem.jsx
+++ b/src/overview/components/PageResultItem.jsx
@@ -13,44 +13,51 @@ const getBookmarkClass = ({ hasBookmark }) =>
     })
 
 const PageResultItem = props => (
-    <a className={styles.root} href={props.url} target="_blank">
-        <div className={styles.screenshotContainer}>
-            {props._attachments && props._attachments.screenshot ? (
-                <ImgFromPouch
-                    className={styles.screenshot}
-                    doc={props}
-                    attachmentId="screenshot"
-                />
-            ) : (
-                <img className={styles.screenshot} src="/img/null-icon.png" />
-            )}
-        </div>
-        <div className={styles.descriptionContainer}>
-            <div className={styles.title} title={props.title}>
-                {props._attachments &&
-                    props._attachments.favIcon && (
-                        <ImgFromPouch
-                            className={styles.favIcon}
-                            doc={props}
-                            attachmentId="favIcon"
-                        />
-                    )}
-                {props.title}
+    <li>
+        <a className={styles.root} href={props.url} target="_blank">
+            <div className={styles.screenshotContainer}>
+                {props._attachments && props._attachments.screenshot ? (
+                    <ImgFromPouch
+                        className={styles.screenshot}
+                        doc={props}
+                        attachmentId="screenshot"
+                    />
+                ) : (
+                    <img
+                        className={styles.screenshot}
+                        src="/img/null-icon.png"
+                    />
+                )}
             </div>
-            <div className={styles.url}>{props.url}</div>
-            <div className={styles.time}>{niceTime(+props.displayTime)}</div>
-        </div>
-        <div className={styles.buttonsContainer}>
-            <button
-                className={getBookmarkClass(props)}
-                onClick={props.onToggleBookmarkClick}
-            />
-            <button
-                className={classNames(styles.button, styles.trash)}
-                onClick={props.onTrashBtnClick}
-            />
-        </div>
-    </a>
+            <div className={styles.descriptionContainer}>
+                <div className={styles.title} title={props.title}>
+                    {props._attachments &&
+                        props._attachments.favIcon && (
+                            <ImgFromPouch
+                                className={styles.favIcon}
+                                doc={props}
+                                attachmentId="favIcon"
+                            />
+                        )}
+                    {props.title}
+                </div>
+                <div className={styles.url}>{props.url}</div>
+                <div className={styles.time}>
+                    {niceTime(+props.displayTime)}
+                </div>
+            </div>
+            <div className={styles.buttonsContainer}>
+                <button
+                    className={getBookmarkClass(props)}
+                    onClick={props.onToggleBookmarkClick}
+                />
+                <button
+                    className={classNames(styles.button, styles.trash)}
+                    onClick={props.onTrashBtnClick}
+                />
+            </div>
+        </a>
+    </li>
 )
 
 PageResultItem.propTypes = {

--- a/src/overview/container.js
+++ b/src/overview/container.js
@@ -15,7 +15,7 @@ import ResultsMessage from './components/ResultsMessage'
 class OverviewContainer extends Component {
     static propTypes = {
         grabFocusOnMount: PropTypes.bool.isRequired,
-        onInputChange: PropTypes.func.isRequired,
+        handleInputChange: PropTypes.func.isRequired,
         onBottomReached: PropTypes.func.isRequired,
         isLoading: PropTypes.bool.isRequired,
         isNewSearchLoading: PropTypes.bool.isRequired,
@@ -38,12 +38,6 @@ class OverviewContainer extends Component {
 
     setInputRef = element => {
         this.inputQueryEl = element
-    }
-
-    handleInputChange = event => {
-        const input = event.target
-
-        this.props.onInputChange(input.value)
     }
 
     renderResultItems() {
@@ -148,7 +142,7 @@ class OverviewContainer extends Component {
             <Overview
                 {...this.props}
                 setInputRef={this.setInputRef}
-                onInputChange={this.handleInputChange}
+                onInputChange={this.props.handleInputChange}
             >
                 {this.renderResults()}
             </Overview>
@@ -175,7 +169,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     ...bindActionCreators(
         {
-            onInputChange: actions.setQuery,
             onStartDateChange: actions.setStartDate,
             onEndDateChange: actions.setEndDate,
             onBottomReached: actions.getMoreResults,
@@ -186,6 +179,10 @@ const mapDispatchToProps = dispatch => ({
         },
         dispatch,
     ),
+    handleInputChange: event => {
+        const input = event.target
+        dispatch(actions.setQuery(input.value))
+    },
     handleTrashBtnClick: url => event => {
         event.preventDefault()
         dispatch(actions.showDeleteConfirm(url))

--- a/src/overview/container.js
+++ b/src/overview/container.js
@@ -27,7 +27,7 @@ class OverviewContainer extends Component {
         shouldShowCount: PropTypes.bool.isRequired,
         needsWaypoint: PropTypes.bool.isRequired,
         handleTrashBtnClick: PropTypes.func.isRequired,
-        handleToggleBookmarkClick: PropTypes.func.isRequired,
+        handleToggleBm: PropTypes.func.isRequired,
     }
 
     componentDidMount() {
@@ -47,17 +47,13 @@ class OverviewContainer extends Component {
     }
 
     renderResultItems() {
-        const resultItems = this.props.searchResults.map((doc, index) => (
-            <li key={index}>
-                <PageResultItem
-                    onTrashBtnClick={this.props.handleTrashBtnClick(doc.url)}
-                    onToggleBookmarkClick={this.props.handleToggleBookmarkClick(
-                        index,
-                        doc.url,
-                    )}
-                    {...doc}
-                />
-            </li>
+        const resultItems = this.props.searchResults.map((doc, i) => (
+            <PageResultItem
+                key={i}
+                onTrashBtnClick={this.props.handleTrashBtnClick(doc.url)}
+                onToggleBookmarkClick={this.props.handleToggleBm(doc.url, i)}
+                {...doc}
+            />
         ))
 
         // Insert waypoint at the end of results to trigger loading new items when
@@ -194,10 +190,9 @@ const mapDispatchToProps = dispatch => ({
         event.preventDefault()
         dispatch(actions.showDeleteConfirm(url))
     },
-    handleToggleBookmarkClick: (index, url) => event => {
+    handleToggleBm: (url, index) => event => {
         event.preventDefault()
         dispatch(actions.toggleBookmark(url, index))
-        dispatch(actions.changeHasBookmark(index))
     },
 })
 

--- a/src/page-storage/deletion.js
+++ b/src/page-storage/deletion.js
@@ -8,12 +8,18 @@ import { pageKeyPrefix } from 'src/page-storage'
 import { visitKeyPrefix } from 'src/activity-logger'
 import { bookmarkKeyPrefix } from 'src/bookmarks'
 
+/**
+ * @param {any} input
+ * @param {'domain'|'regex'|'url'} type
+ * @returns {Promise<void>}
+ */
 export default (input, type = 'url') => {
     switch (type) {
         case 'domain':
             return deleteDomain(input)
         case 'regex':
             return deleteByRegex(input)
+        case 'url':
         default:
             return deleteSpecificSite(input)
     }

--- a/src/popup/container.js
+++ b/src/popup/container.js
@@ -52,9 +52,7 @@ class PopupContainer extends Component {
 
         this.toggleLoggingPause = remoteFunction('toggleLoggingPause')
         this.deleteDocs = remoteFunction('deleteDocsByUrl')
-        this.createBookmarkByExtension = remoteFunction(
-            'createBookmarkByExtension',
-        )
+        this.createBookmarkByUrl = remoteFunction('createBookmarkByUrl')
         this.removeBookmarkByUrl = remoteFunction('removeBookmarkByUrl')
 
         this.onSearchChange = this.onSearchChange.bind(this)
@@ -262,7 +260,7 @@ class PopupContainer extends Component {
         if (
             this.state.bookmarkBtn === constants.BOOKMARK_BTN_STATE.UNBOOKMARK
         ) {
-            this.createBookmarkByExtension(this.state.url)
+            this.createBookmarkByUrl(this.state.url)
         } else if (
             this.state.bookmarkBtn === constants.BOOKMARK_BTN_STATE.BOOKMARK
         ) {

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -71,7 +71,12 @@ async function indexSearch({
 }
 
 // Export index interface
-export { addPage, addPageConcurrent, put } from './search-index/add'
+export {
+    addPage,
+    addPageConcurrent,
+    addBookmarkConcurrent,
+    put,
+} from './search-index/add'
 export { initSingleLookup, keyGen } from './search-index/util'
 export { delPages, delPagesConcurrent, del } from './search-index/del'
 export { indexSearch as search }


### PR DESCRIPTION
- fixes #218 
- new bookmark-only adding method on search-index interface (assumes existence of assoc. page - 3ee4199)
- bookmark removal code cleaned up + missing docs added + minor logical bug fixed with orphan page cases (overall flow remains unchanged, however - 69efc43)
- UI state actions for bookmark toggle button in Overview cleaned up a bit (41ef856)