### PR TITLE
Add support to query-builder for subdomains

### DIFF
--- a/src/search/query-builder.js
+++ b/src/search/query-builder.js
@@ -1,8 +1,8 @@
 import transform from 'src/util/transform-page-text'
 import { DEFAULT_TERM_SEPARATOR } from './search-index'
 
-// Pattern to match entire string to `domain.tld`-like format + optional ccTLD
-const DOMAIN_TLD_PATTERN = /^\w{2,}\.\w{2,3}(\.\w{2})?$/
+// Pattern to match entire string to `domain.tld`-like format + optional subdomain prefix and ccTLD postfix
+const DOMAIN_TLD_PATTERN = /^(\w+\.)?[\w-]{2,}\.\w{2,3}(\.\w{2})?$/
 
 /**
  * @typedef IndexQuery


### PR DESCRIPTION
- subdomains indexed correctly (eg `gist.github.com`), separate of the root domain entry (eg `github.com`), however the query-builder pattern used to attempt extraction of domain strings from user input doesn't check subdomains
- pattern updated to have optional clause for checking subdomain in the string
- pattern also updated to include hyphen character `-` in domain detection (not in alphanumeric character class `\w`)

Kind of related:
- if you search for a root domain (eg. `github.com`), should pages indexed under related subdomains (eg. `gist.github.com`) also appear in results?

Makes sense to me, but may be quite difficult to implement. One thing we could do is: when indexing a page, if subdomain detected (`gist.github.com`), index the page under __both__ the subdomain + root domain entries in domain index (`github.com`). Would also need to update deletion logic to remove both entries.

Conversely, on pages with lots of different subdomains, searching for a root domain could clutter results with unwanted results from the subdomains of that site, when the user really only wants results from the specified root domain (so, current behaviour would be ideal).

@oliversauter any opinions?