### PR TITLE
Update page metadata extraction rules

### DIFF
--- a/src/page-analysis/background/fetch-page-data.js
+++ b/src/page-analysis/background/fetch-page-data.js
@@ -56,7 +56,7 @@ export default function fetchPageData(
                     ? await extractFavIcon(doc)
                     : undefined,
                 content: opts.includePageContent
-                    ? await extractPageContent({ doc, url })
+                    ? await extractPageContent(doc, url)
                     : undefined,
             }
         }

--- a/src/page-analysis/content_script/extract-page-content.js
+++ b/src/page-analysis/content_script/extract-page-content.js
@@ -4,7 +4,12 @@ import { getMetadata, metadataRules } from 'page-metadata-parser'
 import transformPageHTML from 'src/util/transform-page-html'
 import extractPdfContent from './extract-pdf-content'
 
+<<<<<<< HEAD
 export const DEF_LANG = 'en'
+=======
+// Fathom rule to only get document's title (`page-metadata-parser` default rules prioritise OG tags)
+export const onlyDocTitle = ['title', node => node.element.text]
+>>>>>>> Update fathom rule used to extract page titles
 
 // Extract the text content from web pages and PDFs.
 export default async function extractPageContent(
@@ -27,9 +32,9 @@ export default async function extractPageContent(
     // Metadata of web page
     const selectedMetadataRules = {
         canonicalUrl: metadataRules.url,
-        title: metadataRules.title,
         keywords: metadataRules.keywords,
         description: metadataRules.description,
+        title: { rules: [onlyDocTitle] },
     }
     const metadata = getMetadata(doc, url, selectedMetadataRules)
 

--- a/src/page-analysis/content_script/extract-page-content.js
+++ b/src/page-analysis/content_script/extract-page-content.js
@@ -1,23 +1,23 @@
 import pick from 'lodash/fp/pick'
-import { getMetadata, metadataRules } from 'page-metadata-parser'
+import keys from 'lodash/fp/keys'
+import { getMetadata } from 'page-metadata-parser'
 
 import transformPageHTML from 'src/util/transform-page-html'
+import PAGE_METADATA_RULES from './page-metadata-rules'
 import extractPdfContent from './extract-pdf-content'
 
-<<<<<<< HEAD
 export const DEF_LANG = 'en'
-=======
-// Fathom rule to only get document's title (`page-metadata-parser` default rules prioritise OG tags)
-export const onlyDocTitle = ['title', node => node.element.text]
->>>>>>> Update fathom rule used to extract page titles
 
-// Extract the text content from web pages and PDFs.
+/**
+ * Extracts content from the DOM, both searchable terms and other metadata.
+ *
+ * @param {Document} [doc=document] A DOM tree's Document instance.
+ * @param {string} [url=location.href]
+ * @returns {any} Object containing `fullText` text and other extracted meta content from the input page.
+ */
 export default async function extractPageContent(
-    {
-        // By default, use the globals window and document.
-        url = window.location.href,
-        doc = document,
-    } = {},
+    doc = document,
+    url = location.href,
 ) {
     // If it is a PDF, run code for pdf instead.
     if (url.endsWith('.pdf')) {
@@ -29,19 +29,12 @@ export default async function extractPageContent(
         html: doc.body.innerHTML,
     })
 
-    // Metadata of web page
-    const selectedMetadataRules = {
-        canonicalUrl: metadataRules.url,
-        keywords: metadataRules.keywords,
-        description: metadataRules.description,
-        title: { rules: [onlyDocTitle] },
-    }
-    const metadata = getMetadata(doc, url, selectedMetadataRules)
+    const metadata = getMetadata(doc, url, PAGE_METADATA_RULES)
 
     return {
         fullText: processedHtml,
         lang: doc.documentElement.lang || DEF_LANG,
         // Picking desired fields, as getMetadata adds some unrequested stuff.
-        ...pick(Object.keys(selectedMetadataRules))(metadata),
+        ...pick(keys(PAGE_METADATA_RULES))(metadata),
     }
 }

--- a/src/page-analysis/content_script/page-metadata-rules.js
+++ b/src/page-analysis/content_script/page-metadata-rules.js
@@ -1,0 +1,35 @@
+import { metadataRules } from 'page-metadata-parser'
+
+/**
+ * Collection of fathom rules to tell `page-metadata-parser` where to extract certain metadata from
+ */
+
+// We only want to fallback to the opengraph URL
+const canonicalUrl = {
+    ...metadataRules.url,
+    rules: [
+        ['link[rel="canonical"]', node => node.element.getAttribute('href')],
+        [
+            'meta[property="og:url"]',
+            node => node.element.getAttribute('content'),
+        ],
+    ],
+}
+
+// We mainly want whatever the browser-facing title is, which can change - OG tags don't need to change
+const title = {
+    rules: [
+        ['title', node => node.element.text],
+        [
+            'meta[property="og:title"]',
+            node => node.element.getAttribute('content'),
+        ],
+    ],
+}
+
+export default {
+    canonicalUrl,
+    title,
+    keywords: metadataRules.keywords,
+    description: metadataRules.description,
+}

--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -47,8 +47,8 @@ export const addPage = req => performIndexing(pipeline(req))
  * @returns {Promise<void>} Promise resolving when indexing is complete, or rejecting for any index errors.
  */
 export const addPageConcurrent = req =>
-    new Promise((resolve, reject) => {
-        const indexDoc = pipeline(req).catch(reject)
+    new Promise(async (resolve, reject) => {
+        const indexDoc = await pipeline(req).catch(reject)
 
         indexQueue.push(() =>
             performIndexing(indexDoc)


### PR DESCRIPTION
Fixes part of #225 - titles and some other metadata content was being extracted wrong on certain dynamic sites (`qz.com` given as example).

As URL state changes, new page visits and recording happens, but as our data extraction rules was giving priority to certain parts of the DOM that are not commonly updated with other dynamic content (OG tags - meant for single-visit bots, like FB bot), extracted titles and other content were not correct.
These changes update the fathom rules used to extract the needed data - prioritise parts of the DOM that face standard user rather than bots.

Would be good to get examples of other sites with dynamic URL state updates from general interaction, to test with.

Other minor cleanups and added missing docs - this part of codebase not touched in a while.