### PR TITLE
NLP query behaviour changes

### DIFF
--- a/src/overview/components/DateRangeSelection.jsx
+++ b/src/overview/components/DateRangeSelection.jsx
@@ -82,16 +82,9 @@ class DateRangeSelection extends Component {
             action: nlpDate ? 'Successful NLP query' : 'Unsuccessful NLP query',
         })
 
+        // Get the time from the NLP query, if it could be parsed
         if (nlpDate != null) {
-            const dateToChange = nlpDate.getTime()
-
-            // Set input value state to be date format
-            this.setState(state => ({
-                ...state,
-                [stateKey]: moment(dateToChange).format(FORMAT),
-            }))
-
-            return dateToChange
+            return nlpDate.getTime()
         }
 
         // Reset input value state as NLP value invalid

--- a/src/util/nlp-time-filter.js
+++ b/src/util/nlp-time-filter.js
@@ -1,7 +1,7 @@
 import chrono from 'chrono-node'
 
-const BEFORE_REGEX = /before:"(.*?)"/
-const AFTER_REGEX = /after:"(.*?)"/
+const BEFORE_REGEX = /before:[''"](.+)['"]/i
+const AFTER_REGEX = /after:['"](.+)['"]/i
 
 /**
  * @typedef QueryFilters


### PR DESCRIPTION
- fixes #255 
- `before:""` and `after:""` syntax in the omnibar updated to be case insensitive and also not worry about single or double quotes
- NLP queries typed into the overview time filters no longer get resolved into date strings for display; they stay as the entered NLP query

@oliversauter what about when you type something like `test before:"now"` in omnibar and press enter to go to the overview page for that search? At the moment, as we don't have support for NLP queries in the URL state, it will auto-resolve to the timestamp of the query and build the overview URL state using that (so the date picker value will be set to "2018-10-01", or whatever resolved date, rather than the text "now")