### PR TITLE
Visit interactions data

### DIFF
--- a/src/activity-logger/background/index.js
+++ b/src/activity-logger/background/index.js
@@ -1,41 +1,67 @@
-import debounce from 'lodash/debounce'
+import noop from 'lodash/fp/noop'
 
 import { makeRemotelyCallable } from 'src/util/webextensionRPC'
-import { maybeLogPageVisit } from './log-page-visit'
+import { whenPageDOMLoaded, whenTabActive } from 'src/util/tab-events'
+import { updateTimestampMetaConcurrent } from 'src/search'
+import { logPageVisit } from './log-page-visit'
 import initPauser from './pause-logging'
-import TabTimeTracker from './tab-time-tracker'
-import { isLoggable, getPauseState } from '..'
+import tabTracker from './tab-time-tracker'
+import { isLoggable, getPauseState, visitKeyPrefix } from '..'
 
 // Allow logging pause state toggle to be called from other scripts
 const toggleLoggingPause = initPauser()
 makeRemotelyCallable({ toggleLoggingPause })
 
-// Debounced functions fro each tab are stored here
-const tabs = {}
+// Combines all "logibility" conditions for logging on given tab data
+const shouldLogTab = async tab =>
+    tab.url && isLoggable(tab) && !await getPauseState()
 
-// Set up tab time tracker state to work with tab events
-const tracker = new TabTimeTracker()
-browser.tabs.onCreated.addListener(tab => tracker.trackTab(tab.id))
-browser.tabs.onRemoved.addListener(tabId => tracker.removeTab(tabId))
-browser.tabs.onActivated.addListener(({ tabId }) => tracker.activateTab(tabId))
+/**
+ * Handles update of assoc. visit with derived tab state data, using the tab state.
+ *
+ * @param {TabActiveState} tab The tab state to derive visit meta data from.
+ */
+async function updateVisitForTab({ visitTime, activeTime }) {
+    const visitKey = visitKeyPrefix + visitTime
 
-// Listens for url changes of the page
-browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-    if (changeInfo.url && tab.url && isLoggable(tab)) {
-        // Check if we already have a debounced function for this tab and cancel it
-        if (tabs[tabId]) {
-            tabs[tabId].cancel()
+    try {
+        await updateTimestampMetaConcurrent(visitKey, data => ({
+            ...data,
+            duration: activeTime,
+        }))
+    } catch (error) {
+        // If visit was never indexed for tab, cannot update it - move on
+    }
+}
+
+browser.tabs.onCreated.addListener(tab => tabTracker.trackTab(tab))
+browser.tabs.onActivated.addListener(({ tabId }) =>
+    tabTracker.activateTab(tabId),
+)
+
+// Remove tab from tab tracking state and update the visit with tab-derived metadata
+browser.tabs.onRemoved.addListener(tabId =>
+    updateVisitForTab(tabTracker.removeTab(tabId)),
+)
+
+browser.tabs.onUpdated.addListener(async function(tabId, changeInfo, tab) {
+    // `changeInfo` should only contain `url` prop if URL changed, which is what we care about
+    if (changeInfo.url) {
+        // Ensures the URL change counts as a new visit in tab state (tab ID doesn't change)
+        const oldTab = tabTracker.resetTab(tabId, tab.active)
+        updateVisitForTab(oldTab) // Send off request for updating that prev. visit's tab state
+
+        const shouldLog = await shouldLogTab(tab)
+        if (shouldLog) {
+            tabTracker.scheduleTabLog(
+                tabId,
+                () =>
+                    // Wait until its DOM has loaded, and activated before attemping log
+                    whenPageDOMLoaded({ tabId })
+                        .then(() => whenTabActive({ tabId }))
+                        .then(() => logPageVisit({ url: tab.url, tabId }))
+                        .catch(noop), // Ignore any tab state interuptions
+            )
         }
-
-        // Create debounced function and call it
-        tabs[tabId] = debounce(async () => {
-            // Bail-out if logging paused or imports in progress
-            if (await getPauseState()) {
-                return
-            }
-
-            return maybeLogPageVisit({ url: tab.url, tabId: tabId })
-        }, 10000)
-        tabs[tabId]()
     }
 })

--- a/src/activity-logger/background/index.js
+++ b/src/activity-logger/background/index.js
@@ -3,6 +3,7 @@ import debounce from 'lodash/debounce'
 import { makeRemotelyCallable } from 'src/util/webextensionRPC'
 import { maybeLogPageVisit } from './log-page-visit'
 import initPauser from './pause-logging'
+import TabTimeTracker from './tab-time-tracker'
 import { isLoggable, getPauseState } from '..'
 
 // Allow logging pause state toggle to be called from other scripts
@@ -11,6 +12,12 @@ makeRemotelyCallable({ toggleLoggingPause })
 
 // Debounced functions fro each tab are stored here
 const tabs = {}
+
+// Set up tab time tracker state to work with tab events
+const tracker = new TabTimeTracker()
+browser.tabs.onCreated.addListener(tab => tracker.trackTab(tab.id))
+browser.tabs.onRemoved.addListener(tabId => tracker.removeTab(tabId))
+browser.tabs.onActivated.addListener(({ tabId }) => tracker.activateTab(tabId))
 
 // Listens for url changes of the page
 browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -26,7 +26,7 @@ export async function storeVisit({ timestamp, url, page }) {
  */
 async function updateIndex(storePageResult, visit, pageId) {
     if (storePageResult == null) {
-        await index.addMetaConcurrent('visit', Date.now(), pageId)
+        await index.addTimestampConcurrent('visit', Date.now(), pageId)
     } else {
         // Wait until all page analyis is done
         const { page } = await storePageResult.finalPagePromise

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -1,7 +1,6 @@
 import db from 'src/pouchdb'
 import storePage from 'src/page-storage/store-page'
 import { generatePageDocId } from 'src/page-storage'
-import { blacklist } from 'src/blacklist/background'
 import { generateVisitDocId, visitKeyPrefix } from '..'
 import * as index from 'src/search'
 import tabTracker from './tab-time-tracker'
@@ -53,12 +52,6 @@ async function updateIndex(storePageResult, visit, pageId) {
 
 export async function logPageVisit({ tabId, url }) {
     const threshold = 20000
-
-    // First check if we want to log this page (hence the 'maybe' in the name).
-    const isBlacklisted = await blacklist.checkWithBlacklist()
-    if (isBlacklisted({ url })) {
-        return
-    }
 
     const { visitTime } = tabTracker.getTabState(tabId)
 

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -3,7 +3,7 @@ import storePage from 'src/page-storage/store-page'
 import { generatePageDocId } from 'src/page-storage'
 import { generateVisitDocId, visitKeyPrefix } from '..'
 import * as index from 'src/search'
-import tabTracker from './tab-time-tracker'
+import tabManager from './tab-manager'
 
 // Store the visit in PouchDB.
 export async function storeVisit({ timestamp, url, page }) {
@@ -52,7 +52,7 @@ async function updateIndex(storePageResult, visit, pageId) {
 export async function logPageVisit({ tabId, url }) {
     const threshold = 20000
 
-    const { visitTime } = tabTracker.getTabState(tabId)
+    const { visitTime } = tabManager.getTabState(tabId)
 
     const pageId = generatePageDocId({ url })
     const existingPage = await index.initSingleLookup()(pageId)

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -25,27 +25,28 @@ export async function storeVisit({ timestamp, url, page }) {
  * @param {any} visit The new visit to add to index; should occur regardless of reidentify outcome.
  */
 async function updateIndex(storePageResult, visit, pageId) {
+    // If page wasn't stored again, just add new visit
     if (storePageResult == null) {
-        await index.addTimestampConcurrent(
+        return await index.addTimestampConcurrent(
             pageId,
             visitKeyPrefix + visit.visitStart,
         )
-    } else {
-        // Wait until all page analyis is done
-        const { page } = await storePageResult.finalPagePromise
+    }
 
-        // If no page returned from analysis, we can't index
-        if (!page) {
-            return
-        }
+    // Wait until all page analyis is done
+    const { page } = await storePageResult.finalPagePromise
 
-        try {
-            await index.addPageConcurrent({ pageDoc: page, visitDocs: [visit] })
-        } catch (error) {
-            // Indexing issue; log it for now
-            console.error(error)
-            throw error
-        }
+    // If no page returned from analysis, we can't index
+    if (!page) {
+        return
+    }
+
+    try {
+        await index.addPageConcurrent({ pageDoc: page, visitDocs: [visit] })
+    } catch (error) {
+        // Indexing issue; log it for now
+        console.error(error)
+        throw error
     }
 }
 

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -27,9 +27,8 @@ export async function storeVisit({ timestamp, url, page }) {
 async function updateIndex(storePageResult, visit, pageId) {
     if (storePageResult == null) {
         await index.addTimestampConcurrent(
-            visitKeyPrefix,
-            visit.visitStart,
             pageId,
+            visitKeyPrefix + visit.visitStart,
         )
     } else {
         // Wait until all page analyis is done

--- a/src/activity-logger/background/scroll-state.js
+++ b/src/activity-logger/background/scroll-state.js
@@ -1,0 +1,50 @@
+export default class ScrollState {
+    /**
+     * @property {number} Represents the current Y pixel the user has scrolled to.
+     */
+    _pixel = 0
+
+    /**
+     * @property {number} Represents the furthest Y pixel the user has scrolled to.
+     */
+    _maxPixel = 0
+
+    /**
+     * @property {number} Represents the scrollable height of the page in pixels.
+     */
+    _lastKnownScrollableHeight = 0
+
+    get pixel() {
+        return this._pixel
+    }
+
+    get maxPixel() {
+        return this._maxPixel
+    }
+
+    get percent() {
+        return this._pixelToPercent(this._pixel)
+    }
+
+    get maxPercent() {
+        return this._pixelToPercent(this._maxPixel)
+    }
+
+    _pixelToPercent = pixel =>
+        parseFloat(
+            Number(pixel / this._lastKnownScrollableHeight).toFixed(2),
+        ) || 0
+
+    /**
+     * @param {any} scrollState Derived data from the window and DOM, extracted in content script.
+     */
+    updateState({ scrollOffset, windowHeight, scrollableHeight }) {
+        this._lastKnownScrollableHeight = scrollableHeight
+        this._pixel = scrollOffset + windowHeight
+
+        // Update max recorded pixel if current pixel is bigger
+        if (this._pixel > this._maxPixel) {
+            this._maxPixel = this._pixel
+        }
+    }
+}

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -11,7 +11,7 @@ import ScrollState from './scroll-state'
  * @property {number} [timeout] A timeout ID returned from a `setTimeout` call.
  */
 
-export class TabTimeTracker {
+export class TabManager {
     static DEF_LOG_DELAY = 10000
 
     /**
@@ -20,7 +20,7 @@ export class TabTimeTracker {
     _tabs = new Map()
     _logDelay
 
-    constructor(logDelay = TabTimeTracker.DEF_LOG_DELAY) {
+    constructor(logDelay = TabManager.DEF_LOG_DELAY) {
         this._logDelay = logDelay
     }
 
@@ -145,7 +145,7 @@ export class TabTimeTracker {
     }
 }
 
-// Set up tab time tracker state to work with tab events
-const tracker = new TabTimeTracker()
+// Set up singleton to use throughout bg script
+const manager = new TabManager()
 
-export default tracker
+export default manager

--- a/src/activity-logger/background/tab-time-tracker.js
+++ b/src/activity-logger/background/tab-time-tracker.js
@@ -134,6 +134,5 @@ export class TabTimeTracker {
 
 // Set up tab time tracker state to work with tab events
 const tracker = new TabTimeTracker()
-window.tracker = tracker
 
 export default tracker

--- a/src/activity-logger/background/tab-time-tracker.js
+++ b/src/activity-logger/background/tab-time-tracker.js
@@ -1,0 +1,52 @@
+class TabTimeTracker {
+    tabs = new Map()
+
+    get size() {
+        return this.tabs.size
+    }
+
+    _createNewTab = () => ({
+        activeTime: 0,
+        isActive: false,
+        lastActivated: Date.now(),
+    })
+
+    /**
+     * @param {string} id The ID of the tab to start keeping track of.
+     */
+    trackTab = id => this.tabs.set(id, this._createNewTab())
+
+    /**
+     * @param {string} id The ID of the tab to stop keeping track of.
+     */
+    removeTab = id => this.tabs.delete(id)
+
+    /**
+     * Updates the tab state to be able to calculate active times.
+     *
+     * @param {string} id The ID of the tab to set to active.
+     */
+    activateTab(id) {
+        for (const [tabId, tab] of this.tabs) {
+            // Only one tab can be active; if it is, reset it and count the time since activation
+            if (tab.isActive) {
+                this.tabs.set(tabId, {
+                    ...tab,
+                    isActive: false,
+                    activeTime: tab.activeTime + Date.now() - tab.lastActivated,
+                })
+            }
+
+            // Switch on the current tab's active state and record activation time
+            if (tabId === id) {
+                this.tabs.set(tabId, {
+                    ...tab,
+                    isActive: true,
+                    lastActivated: Date.now(),
+                })
+            }
+        }
+    }
+}
+
+export default TabTimeTracker

--- a/src/activity-logger/background/tab-time-tracker.js
+++ b/src/activity-logger/background/tab-time-tracker.js
@@ -1,3 +1,5 @@
+import ScrollState from './scroll-state'
+
 /**
  * @typedef TabActiveState
  * @type Object
@@ -5,6 +7,7 @@
  * @property {boolean} isActive Flag that denotes activity.
  * @property {number} lastActivated Epoch timestamp representing last time being activated.
  * @property {string} visitTime Epoch timestamp representing the time of the visit event associated with this tab.
+ * @property {ScrollState} scrollState Each tab will have their scroll state tracked.
  * @property {number} [timeout] A timeout ID returned from a `setTimeout` call.
  */
 
@@ -33,6 +36,7 @@ export class TabTimeTracker {
         lastActivated: Date.now(),
         isActive,
         visitTime,
+        scrollState: new ScrollState(),
         timeout: null,
     })
 
@@ -129,6 +133,15 @@ export class TabTimeTracker {
             ...tab,
             timeout: setTimeout(cb, this._logDelay),
         })
+    }
+
+    /**
+     * @param {string} id The ID of the tab to set to associate the debounced log with.
+     * @param {any} newState The new scroll state to set.
+     */
+    updateTabScrollState(id, newState) {
+        const tab = this.getTabState(id)
+        tab.scrollState.updateState(newState)
     }
 }
 

--- a/src/activity-logger/content_script/index.js
+++ b/src/activity-logger/content_script/index.js
@@ -1,3 +1,15 @@
-// Report interactions with the page
+import throttle from 'lodash/fp/throttle'
 
-// TODO
+import * as scrollStateFetchers from './scroll-state-fetchers'
+
+// Set up sending of current scroll state data to the background script's tab states whenever
+//  the 'scroll' event fires for this particular script
+const sendCurrentSrollState = () =>
+    browser.runtime.sendMessage({
+        funcName: 'updateScrollState',
+        scrollOffset: scrollStateFetchers.fetchScrollOffset(),
+        windowHeight: scrollStateFetchers.fetchWindowHeight(),
+        scrollableHeight: scrollStateFetchers.fetchScrollableHeight(),
+    })
+
+window.addEventListener('scroll', throttle(500)(sendCurrentSrollState))

--- a/src/activity-logger/content_script/scroll-state-fetchers.js
+++ b/src/activity-logger/content_script/scroll-state-fetchers.js
@@ -1,0 +1,22 @@
+export const fetchScrollableHeight = (
+    body = document.body,
+    html = document.documentElement,
+) =>
+    Math.max(
+        body.scrollHeight,
+        body.offsetHeight,
+        html.clientHeight,
+        html.scrollHeight,
+        html.offsetHeight,
+    ) || null
+
+export const fetchScrollOffset = () =>
+    window.pageYOffset !== undefined
+        ? window.pageYOffset
+        : (document.documentElement ||
+              document.body.parentNode ||
+              document.body
+          ).scrollTop
+
+export const fetchWindowHeight = () =>
+    window.innerHeight || document.documentElement.clientHeight

--- a/src/page-analysis/background/index.js
+++ b/src/page-analysis/background/index.js
@@ -1,7 +1,6 @@
 import merge from 'lodash/fp/merge'
 import { dataURLToBlob } from 'blob-util'
 
-import { whenPageDOMLoaded } from 'src/util/tab-events'
 import { remoteFunction } from 'src/util/webextensionRPC'
 import whenAllSettled from 'when-all-settled'
 import db from 'src/pouchdb'
@@ -41,8 +40,6 @@ async function performPageAnalysis({ pageId, tabId }) {
 }
 
 export default async function analysePage({ pageId, tabId }) {
-    // Wait until its DOM has loaded, in case we got invoked before that.
-    await whenPageDOMLoaded({ tabId }) // TODO: catch e.g. tab close.
     await performPageAnalysis({ pageId, tabId })
     // Get and return the page.
     const page = revisePageFields(await db.get(pageId))

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -78,7 +78,7 @@ export {
     addPageConcurrent,
     addBookmarkConcurrent,
     put,
-    addMetaConcurrent,
+    addTimestampConcurrent,
 } from './search-index/add'
 export { initSingleLookup, keyGen, grabExistingKeys } from './search-index/util'
 export { delPages, delPagesConcurrent, del } from './search-index/del'

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -79,6 +79,7 @@ export {
     addBookmarkConcurrent,
     put,
     addTimestampConcurrent,
+    updateTimestampMetaConcurrent,
 } from './search-index/add'
 export { initSingleLookup, keyGen, grabExistingKeys } from './search-index/util'
 export { delPages, delPagesConcurrent, del } from './search-index/del'

--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -292,5 +292,3 @@ export const updateTimestampMetaConcurrent = (...args) =>
                 .catch(reject),
         ),
     )
-
-window.adder = updateTimestampMetaConcurrent

--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -212,7 +212,8 @@ async function performIndexing(indexDoc) {
             indexUrlTerms(augIndexDoc),
             indexTitleTerms(augIndexDoc),
             indexTerms(augIndexDoc),
-            indexMetaTimestamps(augIndexDoc),
+            // Note we are only wanting to index new visits/bookmarks, so passing in the unagumented `indexDoc` here
+            indexMetaTimestamps(indexDoc),
         ])
         console.timeEnd('indexing page')
         console.log('indexed', augIndexDoc)


### PR DESCRIPTION
- fixes #231
- adds new metadata to indexed visits based on states accumulated over the course of the visit:
    - `duration: number`: time in ms associated tab was active during that visit
    - `scrollPx: number`: pixel user was scrolled to at end of visit
    - `scrollPercent: number`: percentage of page user was scrolled to at end of visit
    - `scrollMaxPx: number`: furthest pixel user scrolled to during entire visit
    - `scrollPercent: number`: furthest percentage of page user scrolled to during entire visit
- new background script tabs state that keeps track of active states, active times, scroll states (derives from DOM data sent from running content scripts when user scrolls), scheduling page analysis
- a lot of inspiration for the logic behind keeping track of tab active states to derive active duration taken from @NimmiW's attempt in [PR#70 on the webmemex repo](https://github.com/WebMemex/webmemex-extension/pull/70) (great ideas!)
- big cleanup of existing `activity-logger` module code (focused around page visits) and the tab events that invoke all the different analysis logic and state changes

### TODO
- ~~may look into adding in logic needed for #232 if wanted as it's related to this stuff (initial page + visit gets indexed at earlier event, then updated at later events if tab still active)~~ __separate branch__
- find other easy-to-derive interactions data that we can assoc. with visits (talked about doing something with click events before)
- go over these changes