### PR TITLE
Fix bugs in tagging-ui

### DIFF
--- a/src/common-ui/components/TagRow.js
+++ b/src/common-ui/components/TagRow.js
@@ -4,12 +4,6 @@ import cx from 'classnames'
 
 import localStyles from './Tags.css'
 
-const handleKeyDown = cb => event => {
-    if (event.key === 'Enter') {
-        cb(event)
-    }
-}
-
 const TagRow = ({ value, active, onClick, focused = false }) => (
     <div
         className={cx(localStyles.menuItem, {

--- a/src/common-ui/components/Tags.css
+++ b/src/common-ui/components/Tags.css
@@ -77,7 +77,7 @@
     }
 
     &:focus {
-        outline-color: #3eb995;
+        outline: none;
     }
 }
 

--- a/src/common-ui/components/Tags.css
+++ b/src/common-ui/components/Tags.css
@@ -26,6 +26,10 @@
     width: 100%;
     max-height: 400px;
     overflow-y: scroll;
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .numberTags {

--- a/src/common-ui/components/Tags.js
+++ b/src/common-ui/components/Tags.js
@@ -13,7 +13,6 @@ const Tags = ({
     children,
     onTagSearchChange,
     onTagSearchKeyDown,
-    onTagsKeyDown,
     numberOfTags,
     setTagDivRef,
     setInputRef,
@@ -35,13 +34,7 @@ const Tags = ({
             />
             <i className="material-icons">search</i>
         </form>
-        <div
-            tabIndex={0}
-            className={localStyles.tagContainer}
-            onKeyDown={onTagsKeyDown}
-        >
-            {children}
-        </div>
+        <div className={localStyles.tagContainer}>{children}</div>
         <div className={localStyles.summaryTagContainer}>
             <div className={localStyles.numberTags}>
                 <span className={localStyles.bold}>{numberOfTags}</span> tags
@@ -55,7 +48,6 @@ Tags.propTypes = {
     children: PropTypes.array.isRequired,
     onTagSearchChange: PropTypes.func.isRequired,
     onTagSearchKeyDown: PropTypes.func.isRequired,
-    onTagsKeyDown: PropTypes.func.isRequired,
     numberOfTags: PropTypes.number.isRequired,
     setTagDivRef: PropTypes.func,
     setInputRef: PropTypes.func.isRequired,

--- a/src/common-ui/containers/TagsContainer.js
+++ b/src/common-ui/containers/TagsContainer.js
@@ -163,20 +163,13 @@ class TagsContainer extends Component {
             this.canCreateTag() &&
             this.state.focused === this.state.displayTags.length
         ) {
-            this.addTag()
-        } else {
-            this.handleTagsEnterPress(event)
-        }
-    }
-
-    handleTagsEnterPress(event) {
-        if (this.state.focused === this.state.displayTags.length) {
             return this.addTag()
         }
+
         return this.handleTagSelection(this.state.focused)(event)
     }
 
-    handleTagsArrowPress(event) {
+    handleSearchArrowPress(event) {
         event.preventDefault()
 
         // One extra index if the "add new tag" thing is showing
@@ -208,17 +201,7 @@ class TagsContainer extends Component {
                 return this.handleSearchEnterPress(event)
             case 'ArrowUp':
             case 'ArrowDown':
-                return this.handleTagsArrowPress(event)
-        }
-    }
-
-    handleTagsKeyDown = event => {
-        switch (event.key) {
-            case 'ArrowUp':
-            case 'ArrowDown':
-                return this.handleTagsArrowPress(event)
-            case 'Enter':
-                return this.handleTagsEnterPress(event)
+                return this.handleSearchArrowPress(event)
         }
     }
 
@@ -289,7 +272,6 @@ class TagsContainer extends Component {
             <Tags
                 onTagSearchChange={this.handleSearchChange}
                 onTagSearchKeyDown={this.handleSearchKeyDown}
-                onTagsKeyDown={this.handleTagsKeyDown}
                 setInputRef={this.setInputRef}
                 numberOfTags={this.state.tags.length}
                 tagSearchValue={this.state.searchVal}

--- a/src/common-ui/containers/TagsContainer.js
+++ b/src/common-ui/containers/TagsContainer.js
@@ -63,6 +63,7 @@ class TagsContainer extends Component {
                 isLoading: false,
                 tags,
                 displayTags: tags,
+                focused: tags.length > 0 ? 0 : -1,
             }))
         }
     }
@@ -91,7 +92,7 @@ class TagsContainer extends Component {
 
         return (
             !!searchVal.length &&
-            !this.state.tags.reduce(
+            !this.state.displayTags.reduce(
                 (acc, tag) => acc || tag === searchVal,
                 false,
             )
@@ -116,7 +117,7 @@ class TagsContainer extends Component {
                 searchVal: '',
                 tags: newTags,
                 displayTags: newTags,
-                focused: -1,
+                focused: 0,
             }))
             this.props.onTagAdd(newTag)
         }
@@ -158,8 +159,13 @@ class TagsContainer extends Component {
     handleSearchEnterPress(event) {
         event.preventDefault()
 
-        if (this.canCreateTag()) {
+        if (
+            this.canCreateTag() &&
+            this.state.focused === this.state.displayTags.length
+        ) {
             this.addTag()
+        } else {
+            this.handleTagsEnterPress(event)
         }
     }
 
@@ -200,6 +206,9 @@ class TagsContainer extends Component {
         switch (event.key) {
             case 'Enter':
                 return this.handleSearchEnterPress(event)
+            case 'ArrowUp':
+            case 'ArrowDown':
+                return this.handleTagsArrowPress(event)
         }
     }
 
@@ -247,7 +256,7 @@ class TagsContainer extends Component {
             this.setState(state => ({
                 ...state,
                 displayTags: suggestions,
-                focused: -1,
+                focused: 0,
             }))
         }
     }

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -228,17 +228,12 @@ export const showTags = index => (dispatch, getState) => {
 }
 
 export const filterTag = tag => (dispatch, getState) => {
-    const state = getState()
-    const currentQueryParams = selectors.currentQueryParams(state)
-    const query = selectors.query(state)
+    const query = selectors.query(getState())
+    const transformedTag = `#${tag.replace(' ', '+')} `
 
-    const transformedTag = `#${tag.split(' ').join('+')} `
+    const newQuery = query.includes(transformedTag)
+        ? query.replace(transformedTag, '') // Either remove it, if already there
+        : transformedTag + query // or prepend it, if not there
 
-    if (
-        currentQueryParams.query
-            .split(' ')
-            .indexOf(transformedTag.substr(0, transformedTag.length - 1)) === -1
-    ) {
-        dispatch(setQuery(`${transformedTag}${query}`))
-    }
+    dispatch(setQuery(newQuery))
 }

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -228,8 +228,17 @@ export const showTags = index => (dispatch, getState) => {
 }
 
 export const filterTag = tag => (dispatch, getState) => {
-    const query = selectors.query(getState())
-    const transformedTag = `#${tag.replace(' ', '+')} `
+    const state = getState()
+    const currentQueryParams = selectors.currentQueryParams(state)
+    const query = selectors.query(state)
 
-    dispatch(setQuery(`${transformedTag}${query}`))
+    const transformedTag = `#${tag.split(' ').join('+')} `
+
+    if (
+        currentQueryParams.query
+            .split(' ')
+            .indexOf(transformedTag.substr(0, transformedTag.length - 1)) === -1
+    ) {
+        dispatch(setQuery(`${transformedTag}${query}`))
+    }
 }

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -229,7 +229,7 @@ export const showTags = index => (dispatch, getState) => {
 
 export const filterTag = tag => (dispatch, getState) => {
     const query = selectors.query(getState())
-    const transformedTag = `#${tag.replace(' ', '+')} `
+    const transformedTag = `#${tag.split(' ').join('+')} `
 
     const newQuery = query.includes(transformedTag)
         ? query.replace(transformedTag, '') // Either remove it, if already there

--- a/src/popup/components/Popup.css
+++ b/src/popup/components/Popup.css
@@ -56,6 +56,6 @@ hr {
     }
 
     &:focus {
-        outline-color: #3eb995;
+        outline: none;
     }
 }

--- a/src/search/query-builder.js
+++ b/src/search/query-builder.js
@@ -93,10 +93,7 @@ class QueryBuilder {
 
             if (QueryBuilder.HASH_TAG_PATTERN.test(currTerm)) {
                 // Slice off '#' prefix and replace any '+' with space char
-                currTerm = currTerm
-                    .slice(1)
-                    .split('+')
-                    .join(' ')
+                currTerm = currTerm.slice(1).replace('+', ' ')
                 this.tags.add(currTerm)
                 return terms
             }

--- a/src/search/query-builder.js
+++ b/src/search/query-builder.js
@@ -93,7 +93,10 @@ class QueryBuilder {
 
             if (QueryBuilder.HASH_TAG_PATTERN.test(currTerm)) {
                 // Slice off '#' prefix and replace any '+' with space char
-                currTerm = currTerm.slice(1).replace('+', ' ')
+                currTerm = currTerm
+                    .slice(1)
+                    .split('+')
+                    .join(' ')
                 this.tags.add(currTerm)
                 return terms
             }


### PR DESCRIPTION
Fix bugs that are discussed in #260 
- [x] highlight and select results with up and down of keyboard > does not work on my end
- [x] when clicking on a pill multiple times it searches with that tag multiple times in the query > no harm, but not nice. 
- [x] filtering with tags that have (multiple) spaces does not work (try: "well into it" as tag; then click on pill; 
- [x] when clicking on the list, this frame appears that seems to be from the systems modal. It's really ugly and confusing. Actually that happens also for the search box, but less dramatic. If we can get rid of both, that would be great.