### PR TITLE
Store unprocessed page text content in page doc

### DIFF
--- a/src/page-analysis/background/index.js
+++ b/src/page-analysis/background/index.js
@@ -30,10 +30,10 @@ async function performPageAnalysis({ pageId, tabId }) {
     })
 
     // Extract the text and metadata
-    const storePageContent = extractPageContent().then(async content => {
+    const storePageContent = extractPageContent().then(
         // Add the info to the doc's (possibly already existing) doc.content.
-        await updateDoc(db, pageId, doc => merge({ content })(doc))
-    })
+        content => updateDoc(db, pageId, doc => merge({ content })(doc)),
+    )
 
     // When every task has either completed or failed, update the search index.
     await whenAllSettled([storeFavIcon, storeScreenshot, storePageContent])

--- a/src/page-analysis/content_script/extract-page-content.js
+++ b/src/page-analysis/content_script/extract-page-content.js
@@ -1,9 +1,10 @@
 import pick from 'lodash/fp/pick'
 import { getMetadata, metadataRules } from 'page-metadata-parser'
 
-import transformPageText from 'src/util/transform-page-text'
 import transformPageHTML from 'src/util/transform-page-html'
 import extractPdfContent from './extract-pdf-content'
+
+export const DEF_LANG = 'en'
 
 // Extract the text content from web pages and PDFs.
 export default async function extractPageContent(
@@ -18,15 +19,9 @@ export default async function extractPageContent(
         return await extractPdfContent({ url })
     }
 
-    const lang = doc.documentElement.lang
-
     // // Apply simple transformations to clean the page's HTML
     const { text: processedHtml } = transformPageHTML({
         html: doc.body.innerHTML,
-    })
-    const { text: processedText } = transformPageText({
-        text: processedHtml,
-        lang,
     })
 
     // Metadata of web page
@@ -39,7 +34,8 @@ export default async function extractPageContent(
     const metadata = getMetadata(doc, url, selectedMetadataRules)
 
     return {
-        fullText: processedText,
+        fullText: processedHtml,
+        lang: doc.documentElement.lang || DEF_LANG,
         // Picking desired fields, as getMetadata adds some unrequested stuff.
         ...pick(Object.keys(selectedMetadataRules))(metadata),
     }

--- a/src/search/search-index/pipeline.js
+++ b/src/search/search-index/pipeline.js
@@ -70,13 +70,14 @@ export default function pipeline({
 
     // Throw error if no searchable content; we don't really want to index these (for now) so allow callers
     //  to handle (probably by ignoring)
-    if (!content || !content.fullText || !content.fullText.length === 0) {
+    if (!content || !content.fullText || !content.fullText.length) {
         return Promise.reject(new Error('Page has no searchable content'))
     }
 
     // Run the searchable content through our text transformations, attempting to discard useless data.
     const { text: transformedContent } = transformPageText({
         text: content.fullText,
+        lang: content.lang,
     })
     const { text: transformedTitle } = transformPageText({
         text: content.title,

--- a/src/util/transform-page-text.js
+++ b/src/util/transform-page-text.js
@@ -20,12 +20,15 @@ const removePunctuation = (text = '') => text.replace(nonWordsPattern, ' ')
 const cleanupWhitespaces = (text = '') =>
     text.replace(allWhitespacesPattern, ' ').trim()
 
-// Split strings on non-words, filtering out duplicates, before rejoining them with single space
-const removeDuplicateWords = (text = '') =>
-    text
-        .split(' ')
-        .filter((word, i, allWords) => i === allWords.indexOf(word))
-        .join(' ')
+/**
+ * Split string into strings of words, then remove duplicates (using `Set` constructor).
+ *
+ * @param {string} [text=''] Input string
+ * @param {string|RegExp} [wordDelim=' '] Delimiter to split `input` into words.
+ * @returns {string} Version of `text` param without duplicate words.
+ */
+export const removeDupeWords = (text = '', wordDelim = ' ') =>
+    [...new Set(text.split(wordDelim))].join(wordDelim)
 
 const removeUselessWords = (text = '', lang) => {
     const oldString = text.split(' ')
@@ -102,7 +105,7 @@ export default function transform({ text = '', lang = 'en' }) {
     // Removes all words containing 4+ consonants such as "hellllo"
     searchableText = removeGiberishWords(searchableText)
 
-    searchableText = removeDuplicateWords(searchableText)
+    searchableText = removeDupeWords(searchableText)
 
     const lengthAfter = searchableText.length
 


### PR DESCRIPTION
- page text content goes through two main stages: 1) HTML preproc -> 2) plain-text preproc
- previously storing result of 2) at path `content.fullText` in page docs - pretty much the same content as will go into the terms index
- now storing result of 1) in page docs, while terms index source remains unchanged
- language, extracted from the DOM, is also used in 2), although only available from the source data of 1) - now simply adding that as an additional `content.lang` key in the page doc for access in 2)
- seems to be functional in both importing and page visit scenarios