### PR TITLE
Initial page visit indexing

### DIFF
--- a/src/activity-logger/README.md
+++ b/src/activity-logger/README.md
@@ -1,0 +1,37 @@
+## `activity-logger` Feature Module
+
+### Purpose
+
+- logging a user's web page visit activity, interactions in each visit
+- keep track of state related to visit activity per browser tab
+
+### How it works
+
+#### Background script:
+
+Keeps all the tab state (includes data about ongoing visits) managed, using `tabs` API events.
+The concept of visits comes into play with the `tabs.onUpdated` event, when a tab's URL is determined
+to be updated - this marks the beginning of a new visit. Logic behind the visit consists of 3 main stages:
+
+1. initial page stub indexing
+2. delayed page content indexing (optional)
+3. final visit interations indexing
+
+Stage 1 consists of indexing the page title, URL, and domain, and indexing the associated visit.
+This is done after the initial DOM is fully loaded. Note that the page data indexing can be skipped
+if there is a recent visit to the same URL. In this case, stage 2 will also be skipped, but the visit
+will be indexed.
+
+Stage 2 consists of indexing the page text, favicon, screenshot, which is far more complex and space-consuming.
+`page-storage` and `page-analysis` modules will be invoked in this process to extract this data from the browser tab.
+This is done after the user has been active on the tab for at least 10s (managed by tabs state). Can be skipped.
+
+Stage 3 consists of indexing the accumulated interaction data for this visit (tabs state). Data
+includes active time on page and scroll states.
+This is done when the user closes the tab or URL is determined to be changed (new visit).
+
+#### Content script:
+
+Simply handles deriving state from the `scroll` event on `window` and sending that to the background script.
+The background script uses this data to derive scroll px/% at any given time and also keep track of the max
+scroll along the y axis.

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -33,7 +33,6 @@ export async function logInitPageVisit(tabId, secsSinceLastIndex = 20) {
                 moment(+visitTime).subtract(secsSinceLastIndex, 'seconds'),
             )
         ) {
-            tabManager.clearScheduledLog(tabId)
             return await index.addTimestampConcurrent(pageId, visitId)
         }
 

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -37,7 +37,7 @@ export async function logInitPageVisit(tabId, secsSinceLastIndex = 20) {
             return await index.addTimestampConcurrent(pageId, visitId)
         }
 
-        const { page: pageDoc } = await storePage({
+        const pageDoc = await storePage({
             tabId,
             url: tab.url,
             content: { title: tab.title },
@@ -65,15 +65,13 @@ export async function logInitPageVisit(tabId, secsSinceLastIndex = 20) {
 export async function logPageVisit(tabId) {
     const { url } = await browser.tabs.get(tabId)
 
-    // Call `storePage` again, this time with analysis enabed to grab further page content
-    const { finalPagePromise } = await storePage({
+    // Call `storePage` again, this time with analysis enabed to grab and store further page content
+    const pageDoc = await storePage({
         tabId,
         url,
         runAnalysis: true,
     })
 
-    const { page } = await finalPagePromise
-
     // Index all the terms for the page
-    await index.addPageTermsConcurrent({ pageDoc: page })
+    await index.addPageTermsConcurrent({ pageDoc })
 }

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -1,79 +1,79 @@
-import db from 'src/pouchdb'
+import moment from 'moment'
+
 import storePage from 'src/page-storage/store-page'
 import { generatePageDocId } from 'src/page-storage'
-import { generateVisitDocId, visitKeyPrefix } from '..'
 import * as index from 'src/search'
+import { visitKeyPrefix } from '..'
 import tabManager from './tab-manager'
 
-// Store the visit in PouchDB.
-export async function storeVisit({ timestamp, url, page }) {
-    const visit = {
-        _id: generateVisitDocId({ url, timestamp }),
-        visitStart: timestamp,
-        url,
-        page: { _id: page._id }, // store only a reference to the page
-    }
-    await db.put(visit)
-    return { visit }
-}
+const singleLookup = index.initSingleLookup()
 
 /**
- * Handles index update, either adding new page + visit, or just adding a visit to existing data.
+ * Performs initial page indexing on small amount of available content (title, URL) + visit.
  *
- * @param {any} reidentifyResult Object containing the existing page/page stub + promise resolving
- *  to the new page.
- * @param {any} visit The new visit to add to index; should occur regardless of reidentify outcome.
+ * @param {number} tabId
+ * @param {number} [secsSinceLastIndex=20]
  */
-async function updateIndex(storePageResult, visit, pageId) {
-    // If page wasn't stored again, just add new visit
-    if (storePageResult == null) {
-        return await index.addTimestampConcurrent(
-            pageId,
-            visitKeyPrefix + visit.visitStart,
-        )
-    }
-
-    // Wait until all page analyis is done
-    const { page } = await storePageResult.finalPagePromise
-
-    // If no page returned from analysis, we can't index
-    if (!page) {
-        return
-    }
-
-    try {
-        await index.addPageConcurrent({ pageDoc: page, visitDocs: [visit] })
-    } catch (error) {
-        // Indexing issue; log it for now
-        console.error(error)
-        throw error
-    }
-}
-
-export async function logPageVisit({ tabId, url }) {
-    const threshold = 20000
+export async function logInitPageVisit(tabId, secsSinceLastIndex = 20) {
+    const tab = await browser.tabs.get(tabId)
 
     const { visitTime } = tabManager.getTabState(tabId)
 
-    const pageId = generatePageDocId({ url })
-    const existingPage = await index.initSingleLookup()(pageId)
+    const pageId = generatePageDocId({ url: tab.url })
+    const visitId = `${visitKeyPrefix}${visitTime}`
 
-    let storePageResult
-    // If there exist the page and the time difference between last index and current timestamp less than {threshold} then we can store the page.
-    if (existingPage == null || visitTime - existingPage.latest > threshold) {
-        // First create an identifier for the page being visited.
-        storePageResult = await storePage({ tabId, url })
+    try {
+        const existingPage = await singleLookup(pageId)
+
+        // Store just new visit if existing page has been indexed recently (`secsSinceLastIndex`)
+        //  also clear scheduled content indexing
+        if (
+            existingPage != null &&
+            moment(+existingPage.latest).isAfter(
+                moment(+visitTime).subtract(secsSinceLastIndex, 'seconds'),
+            )
+        ) {
+            tabManager.clearScheduledLog(tabId)
+            return await index.addTimestampConcurrent(pageId, visitId)
+        }
+
+        const { page: pageDoc } = await storePage({
+            tabId,
+            url: tab.url,
+            content: { title: tab.title },
+            runAnalysis: false,
+        })
+
+        await index.addPageConcurrent({
+            pageDoc,
+            visits: [visitTime],
+            rejectNoContent: false, // No page content available yet; don't reject during pre-processing pipeline
+        })
+    } catch (err) {
+        // If any problems in this stage, clear the later-scheduled content indexing stage
+        tabManager.clearScheduledLog(tabId)
+        throw err
     }
+}
 
-    // Create a visit pointing to this page (analysing/storing it may still be in progress)
-    const { visit } = await storeVisit({
-        page: { _id: pageId },
+/**
+ * Performs page content indexing page text, screenshot, etc. Should happen only after a user has been active on a
+ * tab for a certain amount of time.
+ *
+ * @param {number} tabId
+ */
+export async function logPageVisit(tabId) {
+    const { url } = await browser.tabs.get(tabId)
+
+    // Call `storePage` again, this time with analysis enabed to grab further page content
+    const { finalPagePromise } = await storePage({
+        tabId,
         url,
-        timestamp: visitTime,
+        runAnalysis: true,
     })
 
-    await updateIndex(storePageResult, visit, pageId)
+    const { page } = await finalPagePromise
 
-    // TODO possibly deduplicate the visit if the page was deduped too.
-    void visit
+    // Index all the terms for the page
+    await index.addPageTermsConcurrent({ pageDoc: page })
 }

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -33,6 +33,7 @@ export async function logInitPageVisit(tabId, secsSinceLastIndex = 20) {
                 moment(+visitTime).subtract(secsSinceLastIndex, 'seconds'),
             )
         ) {
+            tabManager.clearScheduledLog(tabId)
             return await index.addTimestampConcurrent(pageId, visitId)
         }
 

--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -16,6 +16,7 @@ const singleLookup = index.initSingleLookup()
  */
 export async function logInitPageVisit(tabId, secsSinceLastIndex = 20) {
     const tab = await browser.tabs.get(tabId)
+    console.log('indexing page title & url:', tab.url)
 
     const { visitTime } = tabManager.getTabState(tabId)
 

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -31,12 +31,17 @@ export class TabManager {
     /**
      * @returns {TabActiveState}
      */
-    _createNewTab = ({ isActive = false, visitTime = `${Date.now()}` }) => ({
+    _createNewTab = ({
+        isActive = false,
+        visitTime = `${Date.now()}`,
+        navState = {},
+    }) => ({
         activeTime: 0,
         lastActivated: Date.now(),
         isActive,
         visitTime,
         scrollState: new ScrollState(),
+        navState,
         timeout: null,
     })
 
@@ -98,7 +103,13 @@ export class TabManager {
      */
     resetTab(id, activeState) {
         const oldTab = this.removeTab(id)
-        this.trackTab({ id, active: activeState })
+        this._tabs.set(
+            id,
+            this._createNewTab({
+                isActive: activeState,
+                navState: oldTab.navState,
+            }),
+        )
         return oldTab
     }
 
@@ -146,13 +157,25 @@ export class TabManager {
     }
 
     /**
-     * @param {string} id The ID of the tab to set to associate the debounced log with.
+     * @param {string} id The ID of the tab to set to update scroll state for.
      * @param {any} newState The new scroll state to set.
      */
     updateTabScrollState(id, newState) {
         try {
             const tab = this.getTabState(id)
             tab.scrollState.updateState(newState)
+        } catch (err) {}
+    }
+
+    /**
+     * @param {string} id The ID of the tab to set to update navigation state for.
+     * @param {any} navState Object containing `webNavigation.TransitionQualifier`s under `qualifiers` prop
+     *  and ` webNavigation.TransitionType` under `type` prop.
+     */
+    updateNavState(id, navState) {
+        try {
+            const tab = this.getTabState(id)
+            this._tabs.set(id, { ...tab, navState })
         } catch (err) {}
     }
 }

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -135,6 +135,16 @@ export class TabManager {
         })
     }
 
+    clearScheduledLog(id) {
+        const tab = this.getTabState(id)
+
+        if (tab.timeout != null) {
+            clearTimeout(tab.timeout)
+        }
+
+        this._tabs.set(id, { ...tab, timeout: null })
+    }
+
     /**
      * @param {string} id The ID of the tab to set to associate the debounced log with.
      * @param {any} newState The new scroll state to set.

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -1,71 +1,24 @@
-import ScrollState from './scroll-state'
-
-/**
- * @typedef TabActiveState
- * @type Object
- * @property {number} activeTime Non-neg int representing accumulated active time in ms.
- * @property {boolean} isActive Flag that denotes activity.
- * @property {number} lastActivated Epoch timestamp representing last time being activated.
- * @property {string} visitTime Epoch timestamp representing the time of the visit event associated with this tab.
- * @property {ScrollState} scrollState Each tab will have their scroll state tracked.
- * @property {number} [timeout] A timeout ID returned from a `setTimeout` call.
- */
+import Tab from './tab-state'
 
 export class TabManager {
-    static DEF_LOG_DELAY = 10000
-
     /**
-     * @property {Map<string, TabActiveState>}
+     * @property {Map<number, Tab>}
      */
     _tabs = new Map()
-    _logDelay
-
-    constructor(logDelay = TabManager.DEF_LOG_DELAY) {
-        this._logDelay = logDelay
-    }
 
     get size() {
         return this._tabs.size
     }
 
     /**
-     * @returns {TabActiveState}
-     */
-    _createNewTab = ({
-        isActive = false,
-        visitTime = `${Date.now()}`,
-        navState = {},
-    }) => ({
-        activeTime: 0,
-        lastActivated: Date.now(),
-        isActive,
-        visitTime,
-        scrollState: new ScrollState(),
-        navState,
-        timeout: null,
-    })
-
-    /**
-     * Reduces a tab's state to toggle between active and inactive. Time updates are performed based on active state change.
-     */
-    _toggleActiveState = ({ isActive, activeTime, lastActivated, ...tab }) => ({
-        ...tab,
-        isActive: !isActive,
-        activeTime: isActive
-            ? activeTime + Date.now() - lastActivated
-            : activeTime,
-        lastActivated: isActive ? lastActivated : Date.now(),
-    })
-
-    /**
      * @param {tabs.Tab} tab The browser tab to start keeping track of.
      */
     trackTab = ({ id, active }) =>
-        this._tabs.set(id, this._createNewTab({ isActive: active }))
+        this._tabs.set(id, new Tab({ isActive: active }))
 
     /**
-     * @param {string} id The ID of the tab as assigned by web ext API.
-     * @returns {TabActiveState} The state for tab stored under given ID.
+     * @param {number} id The ID of the tab as assigned by web ext API.
+     * @returns {Tab} The state for tab stored under given ID.
      * @throws {Error} If input `id` does not correspond to any tab stored in state.
      */
     getTabState(id) {
@@ -78,34 +31,30 @@ export class TabManager {
     }
 
     /**
-     * @param {string} id The ID of the tab to stop keeping track of.
-     * @returns {TabActiveState}
+     * @param {number} id The ID of the tab to stop keeping track of.
+     * @returns {Tab}
      */
     removeTab(id) {
         const toRemove = this.getTabState(id)
-
-        // Cancel any pending operations
-        if (toRemove.timeout != null) {
-            clearTimeout(toRemove.timeout)
-        }
-
+        toRemove.cancelPendingOps()
         this._tabs.delete(id)
 
         // If still active when closed, toggle active state to force time recalc
-        return this._toggleActiveState(toRemove)
+        toRemove.toggleActiveState()
+        return toRemove
     }
 
     /**
      * Resets the state of a given tab, persisting active state.
      *
-     * @param {string} id The ID of the tab to stop reset tracking of.
-     * @returns {TabActiveState} The state of the previously tracked tab assoc. with `id`.
+     * @param {number} id The ID of the tab to stop reset tracking of.
+     * @returns {Tab} The state of the previously tracked tab assoc. with `id`.
      */
     resetTab(id, activeState) {
         const oldTab = this.removeTab(id)
         this._tabs.set(
             id,
-            this._createNewTab({
+            new Tab({
                 isActive: activeState,
                 navState: oldTab.navState,
             }),
@@ -116,48 +65,33 @@ export class TabManager {
     /**
      * Updates the tab state to be able to calculate active times.
      *
-     * @param {string} id The ID of the tab to set to active.
+     * @param {number} id The ID of the tab to set to active.
      */
     activateTab(id) {
         for (const [tabId, tab] of this._tabs) {
             // Toggle active state on currently active and the new candidate tab
             if (tab.isActive || tabId === id) {
-                this._tabs.set(tabId, this._toggleActiveState(tab))
+                tab.toggleActiveState()
             }
         }
     }
 
     /**
-     * @param {string} id The ID of the tab to set to associate the debounced log with.
-     * @param {() => void} cb The page log logic to delay.
+     * @param {number} id The ID of the tab to set to associate the debounced log with.
+     * @param {() => Promise<void>} cb The page log logic to delay.
      */
-    scheduleTabLog(id, cb) {
+    scheduleTabLog(id, logCb) {
         const tab = this.getTabState(id)
-
-        // Check if we already have a delayed  function for this tab and cancel it
-        if (tab.timeout != null) {
-            clearTimeout(tab.timeout)
-        }
-
-        // Set up new delayed  page log, updating state
-        this._tabs.set(id, {
-            ...tab,
-            timeout: setTimeout(cb, this._logDelay),
-        })
+        tab.scheduledLog = logCb
     }
 
     clearScheduledLog(id) {
         const tab = this.getTabState(id)
-
-        if (tab.timeout != null) {
-            clearTimeout(tab.timeout)
-        }
-
-        this._tabs.set(id, { ...tab, timeout: null })
+        tab.cancelPendingOps()
     }
 
     /**
-     * @param {string} id The ID of the tab to set to update scroll state for.
+     * @param {number} id The ID of the tab to set to update scroll state for.
      * @param {any} newState The new scroll state to set.
      */
     updateTabScrollState(id, newState) {
@@ -168,14 +102,14 @@ export class TabManager {
     }
 
     /**
-     * @param {string} id The ID of the tab to set to update navigation state for.
+     * @param {number} id The ID of the tab to set to update navigation state for.
      * @param {any} navState Object containing `webNavigation.TransitionQualifier`s under `qualifiers` prop
      *  and ` webNavigation.TransitionType` under `type` prop.
      */
     updateNavState(id, navState) {
         try {
             const tab = this.getTabState(id)
-            this._tabs.set(id, { ...tab, navState })
+            tab.navState = navState
         } catch (err) {}
     }
 }

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -82,7 +82,7 @@ export class TabManager {
      */
     scheduleTabLog(id, logCb) {
         const tab = this.getTabState(id)
-        tab.scheduledLog = logCb
+        tab.scheduleLog(logCb)
     }
 
     clearScheduledLog(id) {
@@ -116,5 +116,7 @@ export class TabManager {
 
 // Set up singleton to use throughout bg script
 const manager = new TabManager()
+
+window.man = manager
 
 export default manager

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -150,8 +150,10 @@ export class TabManager {
      * @param {any} newState The new scroll state to set.
      */
     updateTabScrollState(id, newState) {
-        const tab = this.getTabState(id)
-        tab.scrollState.updateState(newState)
+        try {
+            const tab = this.getTabState(id)
+            tab.scrollState.updateState(newState)
+        } catch (err) {}
     }
 }
 

--- a/src/activity-logger/background/tab-state.js
+++ b/src/activity-logger/background/tab-state.js
@@ -1,0 +1,52 @@
+import ScrollState from './scroll-state'
+
+/**
+ * @class Tab
+ * @property {number} activeTime Non-neg int representing accumulated active time in ms.
+ * @property {boolean} isActive Flag that denotes activity.
+ * @property {number} lastActivated Epoch timestamp representing last time being activated.
+ * @property {string} visitTime Epoch timestamp representing the time of the visit event associated with this tab.
+ * @property {ScrollState} scrollState Each tab will have their scroll state tracked.
+ * @property {number} [timeout] A timeout ID returned from a `setTimeout` call.
+ */
+class Tab {
+    static DEF_LOG_DELAY = 10000
+
+    constructor(
+        { isActive = false, visitTime = `${Date.now()}`, navState = {} },
+        logDelay = Tab.DEF_LOG_DELAY,
+    ) {
+        this.isActive = isActive
+        this.visitTime = visitTime
+        this.navState = navState
+        this.scrollState = new ScrollState()
+        this.activeTime = 0
+        this.lastActivated = Date.now()
+        this._timeout = null
+        this._logDelay = logDelay
+    }
+
+    set scheduledLog(logCb) {
+        this.cancelPendingOps()
+        this._timeout = setTimeout(logCb, this._logDelay)
+    }
+
+    toggleActiveState(now = Date.now()) {
+        if (this.isActive) {
+            this.activeTime = this.activeTime + now - this.lastActivated
+        } else {
+            this.lastActivated = now
+        }
+
+        this.isActive = !this.isActive
+    }
+
+    cancelPendingOps() {
+        if (this._timeout != null) {
+            clearTimeout(this._timeout)
+            this._timeout = null
+        }
+    }
+}
+
+export default Tab

--- a/src/activity-logger/background/tab-state.js
+++ b/src/activity-logger/background/tab-state.js
@@ -2,16 +2,25 @@ import PausableTimer from 'src/util/pausable-timer'
 import ScrollState from './scroll-state'
 
 /**
+ * Tab state contains user interaction data for the current ongoing visit in this tab. It can also
+ * handle scheduling a future logging event. TODO: do we need to pass this down here?
+ *
  * @class Tab
  * @property {number} activeTime Non-neg int representing accumulated active time in ms.
  * @property {boolean} isActive Flag that denotes activity.
  * @property {number} lastActivated Epoch timestamp representing last time being activated.
  * @property {string} visitTime Epoch timestamp representing the time of the visit event associated with this tab.
  * @property {ScrollState} scrollState Each tab will have their scroll state tracked.
+ * @property {any} navState Each tab will have their last `webNavigation` nav event's data tracked
+ *  (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation).
  */
 class Tab {
     static DEF_LOG_DELAY = 10000
 
+    /**
+     * @param {any} args
+     * @param {number} [logDelay] The # of ms a user must be active on this tab before calling scheduled log.
+     */
     constructor(
         { isActive = false, visitTime = `${Date.now()}`, navState = {} },
         logDelay = Tab.DEF_LOG_DELAY,
@@ -27,13 +36,17 @@ class Tab {
         this._logDelay = logDelay
     }
 
+    /**
+     * Sets up a PausableTimer to run the given log function. This can be stopped, started, or cancelled.
+     *
+     * @param {() => any} logCb Logic to schedule to run on this tab later.
+     */
     scheduleLog(logCb) {
         this.cancelPendingOps()
         this._timer = new PausableTimer({
             delay: this._logDelay,
             cb: logCb,
-            // Start timer if currently active
-            start: this.isActive,
+            start: this.isActive, // Start timer if currently active
         })
     }
 
@@ -49,6 +62,12 @@ class Tab {
         }
     }
 
+    /**
+     * Updates the active and possibly ongoing timer states either to
+     * mark being made active or inactive by the user.
+     *
+     * @param {number} [now=Date.now()] When the active state changed.
+     */
     toggleActiveState(now = Date.now()) {
         if (this.isActive) {
             this.activeTime = this.activeTime + now - this.lastActivated
@@ -61,6 +80,9 @@ class Tab {
         this.isActive = !this.isActive
     }
 
+    /**
+     * Cancels any scheduled log created from `scheduleLog` calls.
+     */
     cancelPendingOps() {
         if (this._timer != null) {
             this._timer.clear()

--- a/src/activity-logger/background/tab-state.js
+++ b/src/activity-logger/background/tab-state.js
@@ -7,7 +7,6 @@ import ScrollState from './scroll-state'
  * @property {number} lastActivated Epoch timestamp representing last time being activated.
  * @property {string} visitTime Epoch timestamp representing the time of the visit event associated with this tab.
  * @property {ScrollState} scrollState Each tab will have their scroll state tracked.
- * @property {number} [timeout] A timeout ID returned from a `setTimeout` call.
  */
 class Tab {
     static DEF_LOG_DELAY = 10000
@@ -22,30 +21,54 @@ class Tab {
         this.scrollState = new ScrollState()
         this.activeTime = 0
         this.lastActivated = Date.now()
+
+        this._logCb = null
         this._timeout = null
-        this._logDelay = logDelay
+        this._timeoutRemain = logDelay
     }
 
-    set scheduledLog(logCb) {
+    scheduleLog(logCb) {
         this.cancelPendingOps()
-        this._timeout = setTimeout(logCb, this._logDelay)
+        this._logCb = logCb
+
+        // Start timer if currently active
+        if (this.isActive) {
+            this._resumeLogTimer()
+        }
+    }
+
+    _pauseLogTimer() {
+        // If there is a pending timeout
+        if (this._timeout != null) {
+            clearTimeout(this._timeout)
+            this._timeout = null
+            this._timeoutRemain -= Date.now() - this.lastActivated
+        }
+    }
+
+    _resumeLogTimer() {
+        // If log still has not occurred
+        if (this._logCb != null && this._timeoutRemain > 0) {
+            this._timeout = setTimeout(this._logCb, this._timeoutRemain)
+        }
     }
 
     toggleActiveState(now = Date.now()) {
         if (this.isActive) {
             this.activeTime = this.activeTime + now - this.lastActivated
+            this._pauseLogTimer()
         } else {
             this.lastActivated = now
+            this._resumeLogTimer()
         }
 
         this.isActive = !this.isActive
     }
 
     cancelPendingOps() {
-        if (this._timeout != null) {
-            clearTimeout(this._timeout)
-            this._timeout = null
-        }
+        clearTimeout(this._timeout)
+        this._timeout = null
+        this._logCb = null
     }
 }
 

--- a/src/activity-logger/background/tab-state.js
+++ b/src/activity-logger/background/tab-state.js
@@ -1,3 +1,4 @@
+import PausableTimer from 'src/util/pausable-timer'
 import ScrollState from './scroll-state'
 
 /**
@@ -22,34 +23,29 @@ class Tab {
         this.activeTime = 0
         this.lastActivated = Date.now()
 
-        this._logCb = null
-        this._timeout = null
-        this._timeoutRemain = logDelay
+        this._timer = null
+        this._logDelay = logDelay
     }
 
     scheduleLog(logCb) {
         this.cancelPendingOps()
-        this._logCb = logCb
-
-        // Start timer if currently active
-        if (this.isActive) {
-            this._resumeLogTimer()
-        }
+        this._timer = new PausableTimer({
+            delay: this._logDelay,
+            cb: logCb,
+            // Start timer if currently active
+            start: this.isActive,
+        })
     }
 
     _pauseLogTimer() {
-        // If there is a pending timeout
-        if (this._timeout != null) {
-            clearTimeout(this._timeout)
-            this._timeout = null
-            this._timeoutRemain -= Date.now() - this.lastActivated
+        if (this._timer != null) {
+            this._timer.pause()
         }
     }
 
     _resumeLogTimer() {
-        // If log still has not occurred
-        if (this._logCb != null && this._timeoutRemain > 0) {
-            this._timeout = setTimeout(this._logCb, this._timeoutRemain)
+        if (this._timer != null) {
+            this._timer.resume()
         }
     }
 
@@ -66,9 +62,10 @@ class Tab {
     }
 
     cancelPendingOps() {
-        clearTimeout(this._timeout)
-        this._timeout = null
-        this._logCb = null
+        if (this._timer != null) {
+            this._timer.clear()
+            this._timer = null
+        }
     }
 }
 

--- a/src/bookmarks/background/addition.js
+++ b/src/bookmarks/background/addition.js
@@ -101,8 +101,7 @@ export async function createBookmarkByUrl(url, tabId = null) {
     } catch (err) {
         if (err.status === 404) {
             pageExist = 0
-            const storePageResult = await storePage({ tabId, url })
-            pageDoc = (await storePageResult.finalPagePromise).page
+            pageDoc = await storePage({ tabId, url })
         }
     }
 

--- a/src/imports/background/import-item-processor.js
+++ b/src/imports/background/import-item-processor.js
@@ -132,7 +132,11 @@ export default class ImportItemProcessor {
         this._checkCancelled()
 
         return await Promise.all([
-            index.addPageConcurrent({ pageDoc, visitDocs, bookmarkDocs }),
+            index.addPageConcurrent({
+                pageDoc,
+                visits: visitDocs.map(doc => doc.visitStart),
+                bookmarkDocs,
+            }),
             db.bulkDocs([pageDoc, ...bookmarkDocs, ...visitDocs]),
         ])
     }

--- a/src/page-analysis/background/index.js
+++ b/src/page-analysis/background/index.js
@@ -42,11 +42,16 @@ async function performPageAnalysis({ pageId, tabId }) {
     await whenAllSettled([storeFavIcon, storeScreenshot, storePageContent])
 }
 
+/**
+ * Performs page content analysis and storage for an existing page doc in Pouch.
+ *
+ * @param {string} args.pageId ID of pouch doc to add analysed content to.
+ * @param {number} args.tabId ID of browser tab to use as data source.
+ * @returns {Promise<IPageDoc>} Resolves to the stored page doc in post-analysis state.
+ */
 export default async function analysePage({ pageId, tabId }) {
     // Wait until its DOM has loaded, in case we got invoked before that.
     await whenPageDOMLoaded({ tabId }) // TODO: catch e.g. tab close.
     await performPageAnalysis({ pageId, tabId })
-    // Get and return the page.
-    const page = revisePageFields(await db.get(pageId))
-    return { page }
+    return revisePageFields(await db.get(pageId))
 }

--- a/src/page-storage/store-page.js
+++ b/src/page-storage/store-page.js
@@ -7,7 +7,12 @@ import { generatePageDocId } from '.'
  * @param {any} {tabId, url}
  * @returns
  */
-export default async function storePage({ tabId, url }) {
+export default async function storePage({
+    tabId,
+    url,
+    runAnalysis = true,
+    ...pageData
+}) {
     const pageDocId = generatePageDocId({ url })
     let pageDoc
 
@@ -16,7 +21,7 @@ export default async function storePage({ tabId, url }) {
     } catch (error) {
         // Create a new page doc stub in the database if not found
         if (error.status === 404) {
-            pageDoc = { _id: pageDocId, url }
+            pageDoc = { _id: pageDocId, url, ...pageData }
             await db.put(pageDoc)
         } else {
             throw error // Can't handle other errors; throw up stack
@@ -24,7 +29,9 @@ export default async function storePage({ tabId, url }) {
     }
 
     // Start analysis, but do not wait for it.
-    const finalPagePromise = analysePage({ tabId, pageId: pageDoc._id })
+    const finalPagePromise = runAnalysis
+        ? analysePage({ tabId, pageId: pageDoc._id })
+        : Promise.resolve()
 
     // Return the page stub, and a promise of the analysed page.
     return { page: pageDoc, finalPagePromise }

--- a/src/page-storage/store-page.js
+++ b/src/page-storage/store-page.js
@@ -3,9 +3,13 @@ import analysePage from 'src/page-analysis/background'
 import { generatePageDocId } from '.'
 
 /**
- * Given a tabId
- * @param {any} {tabId, url}
- * @returns
+ * @param {number} args.tabId
+ * @param {string} args.url
+ * @param {any} args.* Any further static property values to include in stored page.
+ * @param {boolean} [args.runAnalysis=true] Whether or not to run complex analysis via content script to extract
+ *  further content data.
+ * @returns {Promise<any>} Resolves to the initial created+stored `pageDoc` along with `finalPagePromise` which
+ *  will resolve with the further filled-out page doc when/if analysis is performed.
  */
 export default async function storePage({
     tabId,

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -74,6 +74,7 @@ async function indexSearch({
 // Export index interface
 export {
     addPageConcurrent,
+    addPageTermsConcurrent,
     addBookmarkConcurrent,
     put,
     addTimestampConcurrent,

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -73,7 +73,6 @@ async function indexSearch({
 
 // Export index interface
 export {
-    addPage,
     addPageConcurrent,
     addBookmarkConcurrent,
     put,

--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -1,6 +1,6 @@
 import { bookmarkKeyPrefix } from 'src/bookmarks'
 import { visitKeyPrefix } from 'src/activity-logger'
-import index, { indexQueue } from '.'
+import index from '.'
 import pipeline from './pipeline'
 import {
     augmentIndexLookupDoc,
@@ -9,6 +9,7 @@ import {
     termRangeLookup,
     idbBatchToPromise,
     fetchExistingPage,
+    makeIndexFnConcSafe,
 } from './util'
 
 // Used to decide whether or not to do a range lookup for terms (if # terms gt) or N single lookups
@@ -38,30 +39,19 @@ export const put = (key, val) => index.put(key, val)
  * @param {IndexRequest} req A `pageDoc` (required) and optionally any associated `visitDocs` and `bookmarkDocs`.
  * @returns {Promise<void>} Promise resolving when indexing is complete, or rejecting for any index errors.
  */
-export const addPageConcurrent = req =>
-    new Promise((resolve, reject) =>
-        indexQueue.push(() =>
-            pipeline(req)
-                .then(performIndexing)
-                .then(resolve)
-                .catch(reject),
-        ),
-    )
+export const addPageConcurrent = makeIndexFnConcSafe(req =>
+    pipeline(req).then(performIndexing),
+)
 
 /**
- * @param {string} pageId ID/key of document to associate new bookmark entry with.
- * @param {number|string} [timestamp=Date.now()]
- * @throws {Error} Error thrown when `pageId` param does not correspond to existing document (or any other
- *  standard indexing-related Error encountered during updates).
+ * @param {IndexRequest} req Note that only the `pageDoc` will be used from the request params to update terms.
+ * @returns {Promise<void>} Promise resolving when indexing is complete, or rejecting for any index errors.
  */
-export const addBookmarkConcurrent = (pageId, timestamp = Date.now()) =>
-    new Promise((resolve, reject) =>
-        indexQueue.push(() =>
-            addBookmark(pageId)
-                .then(resolve)
-                .catch(reject),
-        ),
-    )
+export const addPageTermsConcurrent = makeIndexFnConcSafe(req =>
+    pipeline(req).then(addPageTerms),
+)
+
+export const addBookmarkConcurrent = makeIndexFnConcSafe(addBookmark)
 
 /**
  * @param {string} pageId ID/key of document to associate new bookmark entry with.
@@ -204,6 +194,35 @@ async function performIndexing(indexDoc) {
 }
 
 /**
+ * Updates an indexing indexed page doc with new terms.
+ *
+ * @param {IndexLookupDoc} indexDoc Contains at least `terms` and `id` props.
+ * @returns {Promise<void>}
+ * @throws {Error} If `indexDoc.id` has no indexed value.
+ */
+async function addPageTerms(indexDoc) {
+    const existingDoc = await singleLookup(indexDoc.id)
+
+    if (existingDoc == null) {
+        throw new Error(`Cannot add terms for unknown page "${indexDoc.id}"`)
+    }
+
+    // Update only the page terms
+    const augIndexDoc = {
+        ...existingDoc,
+        terms: new Set([...existingDoc.terms, ...indexDoc.terms]),
+    }
+    const timer = `indexing page content (${augIndexDoc.terms.size} terms)`
+
+    console.time(timer)
+    await Promise.all([
+        index.put(indexDoc.id, augIndexDoc),
+        indexTerms(augIndexDoc),
+    ])
+    console.timeEnd(timer)
+}
+
+/**
  * Adds a meta (bookmark or visit) entry into specified reverse index doc.
  * NOTE: Assumes the existence of indexed `pageId`.
  *
@@ -229,15 +248,12 @@ async function addTimestamp(pageId, timestampKey) {
  * @param {string} timestampKey Key of timestamp event to add.
  * @param {any} [meta={}] Object of any associated meta data to store with the indexed event value.
  */
-export const addTimestampConcurrent = (pageId, timestampKey, meta = {}) =>
-    new Promise((resolve, reject) =>
-        indexQueue.push(() => {
-            addTimestamp(pageId, timestampKey)
-                .then(() => index.put(timestampKey, { pageId, ...meta }))
-                .then(resolve)
-                .catch(reject)
-        }),
-    )
+export const addTimestampConcurrent = makeIndexFnConcSafe(
+    (pageId, timestampKey, meta = {}) =>
+        addTimestamp(pageId, timestampKey).then(() =>
+            index.put(timestampKey, { pageId, ...meta }),
+        ),
+)
 
 /**
  * @param {string} timestampId ID of an existing timestamp index value to update.
@@ -263,11 +279,6 @@ async function updateTimestampMeta(timestampId, updateCb) {
     return index.put(timestampId, newVal)
 }
 
-export const updateTimestampMetaConcurrent = (...args) =>
-    new Promise((resolve, reject) =>
-        indexQueue.push(() =>
-            updateTimestampMeta(...args)
-                .then(resolve)
-                .catch(reject),
-        ),
-    )
+export const updateTimestampMetaConcurrent = makeIndexFnConcSafe(
+    updateTimestampMeta,
+)

--- a/src/search/search-index/add.js
+++ b/src/search/search-index/add.js
@@ -212,7 +212,8 @@ async function addPageTerms(indexDoc) {
         ...existingDoc,
         terms: new Set([...existingDoc.terms, ...indexDoc.terms]),
     }
-    const timer = `indexing page content (${augIndexDoc.terms.size} terms)`
+    const timer = `indexing page content (${augIndexDoc.terms
+        .size} terms): ${indexDoc.id}`
 
     console.time(timer)
     await Promise.all([

--- a/src/search/search-index/pipeline.js
+++ b/src/search/search-index/pipeline.js
@@ -48,6 +48,10 @@ export function transformUrl(url) {
  * @returns {Set<string>} Set of "words-of-interest" - determined by pre-proc logic in `transformPageText` - extracted from `text`.
  */
 export function extractTerms(text, key) {
+    if (!text || !text.length) {
+        return new Set()
+    }
+
     const { text: transformedText } = transformPageText({ text })
 
     if (!transformedText || !transformedText.length) {
@@ -82,8 +86,8 @@ export function extractTerms(text, key) {
  * @returns {IndexLookupDoc} Doc structured for indexing.
  */
 export default function pipeline({
-    pageDoc: { _id: id, content, url },
-    visitDocs = [],
+    pageDoc: { _id: id, content = {}, url },
+    visits = [],
     bookmarkDocs = [],
     rejectNoContent = true,
 }) {
@@ -94,7 +98,7 @@ export default function pipeline({
     //  to handle (probably by ignoring)
     if (
         rejectNoContent &&
-        (!content || !content.fullText || !content.fullText.length)
+        (content == null || !content.fullText || !content.fullText.length)
     ) {
         return Promise.reject(new Error('Page has no searchable content'))
     }
@@ -105,7 +109,6 @@ export default function pipeline({
     const urlTerms = extractTerms(pathname, 'url')
 
     // Create timestamps to be indexed as Sets
-    const visits = visitDocs.map(transformMetaDoc)
     const bookmarks = bookmarkDocs.map(transformMetaDoc)
 
     return Promise.resolve({

--- a/src/search/search-index/pipeline.js
+++ b/src/search/search-index/pipeline.js
@@ -85,13 +85,17 @@ export default function pipeline({
     pageDoc: { _id: id, content, url },
     visitDocs = [],
     bookmarkDocs = [],
+    rejectNoContent = true,
 }) {
     // First apply transformations to the URL
     const { pathname, hostname } = transformUrl(url)
 
     // Throw error if no searchable content; we don't really want to index these (for now) so allow callers
     //  to handle (probably by ignoring)
-    if (!content || !content.fullText || !content.fullText.length) {
+    if (
+        rejectNoContent &&
+        (!content || !content.fullText || !content.fullText.length)
+    ) {
         return Promise.reject(new Error('Page has no searchable content'))
     }
 

--- a/src/search/search-index/pipeline.js
+++ b/src/search/search-index/pipeline.js
@@ -20,11 +20,11 @@ const urlNormalizationOpts = {
 
 /**
  * @param {string} url A raw URL string to attempt to extract parts from.
- * @returns {any} Object containing `domain` and `remainingUrl` keys. Values should be the `domain.tld.cctld` part and
+ * @returns {any} Object containing `hostname` and `pathname` props. Values should be the `domain.tld.cctld` part and
  *  everything after, respectively. If regex matching failed on given URL, error will be logged and simply
  *  the URL with protocol and opt. `www` parts removed will be returned for both values.
  */
-function transformUrl(url) {
+export function transformUrl(url) {
     let parsed
     const normalized = normalizeUrl(url, urlNormalizationOpts)
 
@@ -39,6 +39,27 @@ function transformUrl(url) {
         hostname: parsed ? parsed.hostname : normalized,
         pathname: parsed ? parsed.pathname : normalized,
     }
+}
+
+/**
+ *
+ * @param {string} text
+ * @param {'term'|'title'|'url'} key The key under which the extracted terms are categorized.
+ * @returns {Set<string>} Set of "words-of-interest" - determined by pre-proc logic in `transformPageText` - extracted from `text`.
+ */
+export function extractTerms(text, key) {
+    const { text: transformedText } = transformPageText({ text })
+
+    if (!transformedText || !transformedText.length) {
+        return new Set()
+    }
+
+    return new Set(
+        extractContent(transformedText, {
+            separator: DEFAULT_TERM_SEPARATOR,
+            key,
+        }),
+    )
 }
 
 /**
@@ -74,46 +95,10 @@ export default function pipeline({
         return Promise.reject(new Error('Page has no searchable content'))
     }
 
-    // Run the searchable content through our text transformations, attempting to discard useless data.
-    const { text: transformedContent } = transformPageText({
-        text: content.fullText,
-        lang: content.lang,
-    })
-    const { text: transformedTitle } = transformPageText({
-        text: content.title,
-    })
-    const { text: transformedUrlTerms } = transformPageText({
-        text: pathname,
-    })
-
     // Extract all terms out of processed content
-    let titleTerms, urlTerms
-    const terms = new Set(
-        extractContent(transformedContent, {
-            separator: DEFAULT_TERM_SEPARATOR,
-            key: 'term',
-        }),
-    )
-
-    if (transformedTitle && transformedTitle.length) {
-        // Extract all terms out of processed title
-        titleTerms = new Set(
-            extractContent(transformedTitle, {
-                separator: DEFAULT_TERM_SEPARATOR,
-                key: 'title',
-            }),
-        )
-    }
-
-    if (pathname && pathname.length) {
-        // Extract all terms out of processed URL
-        urlTerms = new Set(
-            extractContent(transformedUrlTerms, {
-                separator: DEFAULT_TERM_SEPARATOR,
-                key: 'url',
-            }),
-        )
-    }
+    const terms = extractTerms(content.fullText, 'term')
+    const titleTerms = extractTerms(content.title, 'title')
+    const urlTerms = extractTerms(pathname, 'url')
 
     // Create timestamps to be indexed as Sets
     const visits = visitDocs.map(transformMetaDoc)
@@ -122,9 +107,9 @@ export default function pipeline({
     return Promise.resolve({
         id,
         terms,
-        urlTerms: urlTerms || new Set(),
+        urlTerms,
+        titleTerms,
         domain: keyGen.domain(hostname),
-        titleTerms: titleTerms || new Set(),
         visits: new Set(visits.map(keyGen.visit)),
         bookmarks: new Set(bookmarks.map(keyGen.bookmark)),
         tags: new Set(),

--- a/src/search/search-index/tags/index.js
+++ b/src/search/search-index/tags/index.js
@@ -1,20 +1,6 @@
-import { indexQueue } from '..'
+import { makeIndexFnConcSafe } from '../util'
 import { setTags as setDef, addTags as addDef } from './add'
 import { delTags as delDef } from './del'
-
-/**
- * @param {(args: any) => Promise<any>} fn Any async function to place on the index operations queue.
- * @returns {(args: any) => Promise<any>} Bound version of `fn` that will finish once `fn` gets run
- *  on the index queue and finishes.
- */
-export const makeIndexFnConcSafe = fn => (...args) =>
-    new Promise((resolve, reject) =>
-        indexQueue.push(() =>
-            fn(...args)
-                .then(resolve)
-                .catch(reject),
-        ),
-    )
 
 // Augment a bunch of methods by placing them on the index queue first
 const setTags = makeIndexFnConcSafe(setDef)

--- a/src/search/search-index/util.js
+++ b/src/search/search-index/util.js
@@ -1,6 +1,20 @@
 import promiseLimit from 'promise-limit'
 
-import index, { DEFAULT_TERM_SEPARATOR } from './'
+import index, { indexQueue, DEFAULT_TERM_SEPARATOR } from './'
+
+/**
+ * @param {(args: any) => Promise<any>} fn Any async function to place on the index operations queue.
+ * @returns {(args: any) => Promise<any>} Bound version of `fn` that will finish once `fn` gets run
+ *  on the index queue and finishes.
+ */
+export const makeIndexFnConcSafe = fn => (...args) =>
+    new Promise((resolve, reject) =>
+        indexQueue.push(() =>
+            fn(...args)
+                .then(resolve)
+                .catch(reject),
+        ),
+    )
 
 // Key generation functions
 export const keyGen = {

--- a/src/util/pausable-timer.js
+++ b/src/util/pausable-timer.js
@@ -1,0 +1,57 @@
+class PausableTimer {
+    _timeoutId
+
+    /**
+     * @param {Object} args
+     * @param {() => any} args.cb The callback to delay.
+     * @param {number} args.delay Time in ms to delay for.
+     * @param {boolean} [args.start=true] Whether or not to start the timeout immediately or on later `.resume()` call.
+     */
+    constructor({ cb, delay, start = true }) {
+        this.cb = cb
+        this._remain = delay
+
+        if (start) {
+            this.resume()
+        }
+    }
+
+    set delay(val) {
+        this._remain = val
+    }
+
+    /**
+     * Resumes a paused timer, storing the resumed time and new timer ID as state.
+     */
+    resume() {
+        if (this._remain <= 0) {
+            return
+        }
+
+        this._start = Date.now()
+        clearTimeout(this._timeoutId)
+        this._timeoutId = setTimeout(this.cb, this._remain)
+    }
+
+    /**
+     * Pauses the timer and stores the remaining state for next `.resume()` invocation.
+     */
+    pause() {
+        if (this._remain <= 0 || this._start == null) {
+            return
+        }
+
+        clearTimeout(this._timeoutId)
+        this._remain -= Date.now() - this._start
+    }
+
+    /**
+     * Clears any ongoing timer and removes it from state.
+     */
+    clear() {
+        clearTimeout(this._timeoutId)
+        this._timeoutId = null
+    }
+}
+
+export default PausableTimer

--- a/src/util/tab-events.js
+++ b/src/util/tab-events.js
@@ -78,3 +78,15 @@ export async function whenTabActive({ tabId }) {
         reject: tabChangedEvents(tabId),
     })
 }
+
+// Resolve if or when the tab title updates.
+// Rejects if it is closed before that.
+export const whenTabTitleUpdates = ({ tabId }) =>
+    eventToPromise({
+        resolve: {
+            event: browser.tabs.onUpdated,
+            filter: (updatedTabId, changeInfo) =>
+                updatedTabId === tabId && changeInfo.title != null,
+        },
+        reject: tabChangedEvents(tabId),
+    })


### PR DESCRIPTION
- fixes #232 
- description of new page visits process in 8cbda3d
- a lot of cleanup of modules related to the page visit process (`log-page-visit`, `store-page`, `page-analysis`)
- new index method for stage ii allowing updating just the terms for an existing page
- removal of unused pouch visits during page visit process
- cleanup of index pipeline code, and allowing it to work with no main terms content (stage i)
- update of terms search implementation to merge in title/URL terms results with content terms results
- implementation of new `PausableTimer` class: state wrapper around `setTimeout` (7b8c4c9)

TODO/enhancements:
- [x] stage ii still does the old behaviour of "waiting" for at least 10s. This waiting includes when the tab is not active. Recent work on the new tabs state means we have access to each tab's accumulated active time. Maybe we could try to use this as a smarter way to decide when to trigger stage ii
- [x] see if we can get the `webNav` API's transition data stored in tabs state. This is only available from `webNav.onCommitted` event (happens before the `webNav.onCompleted` event that we use for stage i), but it should be able to persist in tab state for later use
- [x] the `webNavigation` API events used for stage i seem to both fire on certain pages - find a better way to ensure stage i only can ever happen per page