### PR TITLE
Increase 20 word char limit in preproc to 30

### DIFF
--- a/src/util/transform-page-text.js
+++ b/src/util/transform-page-text.js
@@ -9,7 +9,7 @@ const apostrophePattern = /['’]/g
 const allWordsWithDigits = /[a-z]+\d\w*|\w*\d[a-z]+/gi // /\w*\d\w*/g
 const dashPattern = /[-]/g
 const giberishWords = /\S*([b-df-hj-np-tv-z]){5,}\S*/gi
-const longWords = /\b\w{20,}\b/gi
+const longWords = /\b\w{30,}\b/gi
 const randomDigits = /\b(\d{1,3}|\d{5,})\b/gi
 const urlPattern = urlRegex()
 


### PR DESCRIPTION
- now words with >= 30 chars should make it through our text preprocessing pipeline for indexing and querying

https://worldbrain.slack.com/archives/C9297H925/p1518429732000487?thread_ts=1518402101.000107&cid=C9297H925