### PR TITLE
Fix up out-of-date state when deriving search params

### DIFF
--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -111,9 +111,7 @@ export const search = ({ overwrite } = { overwrite: false }) => async (
     dispatch,
     getState,
 ) => {
-    // Grab needed derived state for search
-    const state = getState()
-    const currentQueryParams = selectors.currentQueryParams(state)
+    const currentQueryParams = selectors.currentQueryParams(getState())
 
     if (currentQueryParams.query.includes('#')) {
         return
@@ -130,6 +128,8 @@ export const search = ({ overwrite } = { overwrite: false }) => async (
         return dispatch(easter())
     }
 
+    // Grab needed derived state for search
+    const state = getState()
     const searchParams = {
         ...currentQueryParams,
         getTotalCount: true,
@@ -197,7 +197,7 @@ const handleErrors = ({ query, error }) => dispatch => {
 /**
  * Increments the page state before scheduling another search.
  */
-export const getMoreResults = () => async dispatch => {
+export const getMoreResults = () => dispatch => {
     dispatch(nextPage())
     dispatch(search())
 }


### PR DESCRIPTION
- if you scroll down a few pages, then put some text in, the page state will be reset, but the immediate next search will still use all the old page state (hence skip the first X results)
- fixes when the state is sampled
- [found](https://github.com/WorldBrain/Memex/pull/287#issuecomment-365109944) by @oliversauter