### PR TITLE
Ignore page logging in incognito mode

### DIFF
--- a/src/activity-logger/background/index.js
+++ b/src/activity-logger/background/index.js
@@ -23,7 +23,7 @@ makeRemotelyCallable({ toggleLoggingPause })
  */
 async function shouldLogTab(tab) {
     // Short-circuit before async logic, if possible
-    if (!tab.url || !isLoggable(tab)) {
+    if (tab.incognito || !tab.url || !isLoggable(tab)) {
         return false
     }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
             "run_at": "document_start"
         }
     ],
+    "incognito": "spanning",
     "browser_action": {
         "default_title": "WorldBrain's Memex",
         "default_popup": "./popup/popup.html"


### PR DESCRIPTION
- fixes #291
- apparently that "easiest" option I mentioned in that issue yesterday isn't supported in FF. Doesn't matter too much, just add a quick check to page/tab logging condition to see if current tab is incognito or not
- works on both FF and Chrome