### PR TITLE
Fix bug with PDFs not working in imports

### DIFF
--- a/src/page-analysis/background/fetch-page-data.js
+++ b/src/page-analysis/background/fetch-page-data.js
@@ -1,3 +1,6 @@
+import normalizeUrl from 'normalize-url'
+
+import { normalizationOpts } from 'src/util/encode-url-for-id'
 import extractPageContent from 'src/page-analysis/content_script/extract-page-content'
 import extractFavIcon from 'src/page-analysis/content_script/extract-fav-icon'
 import extractPdfContent from 'src/page-analysis/content_script/extract-pdf-content'
@@ -26,10 +29,15 @@ export const defaultOpts = {
 export default function fetchPageData(
     { url = '', timeout = 10000, opts = defaultOpts } = { opts: defaultOpts },
 ) {
+    const normalizedUrl = normalizeUrl(url, {
+        ...normalizationOpts,
+        removeQueryParameters: [/.*/i],
+    })
+
     let run, cancel
 
     // Check if pdf and run code for pdf instead
-    if (url.endsWith('.pdf')) {
+    if (normalizedUrl.endsWith('.pdf')) {
         run = async () => ({
             content: opts.includePageContent
                 ? await extractPdfContent({ url })

--- a/src/page-analysis/background/fetch-page-data.js
+++ b/src/page-analysis/background/fetch-page-data.js
@@ -30,10 +30,11 @@ export default function fetchPageData(
 
     // Check if pdf and run code for pdf instead
     if (url.endsWith('.pdf')) {
-        run = async () =>
-            opts.includePageContent
+        run = async () => ({
+            content: opts.includePageContent
                 ? await extractPdfContent({ url })
-                : undefined
+                : undefined,
+        })
         cancel = () => {}
     } else {
         const req = fetchDOMFromUrl(url, timeout)
@@ -60,9 +61,9 @@ export default function fetchPageData(
                     : undefined,
             }
         }
-
-        return { run, cancel }
     }
+
+    return { run, cancel }
 }
 
 /**

--- a/src/util/encode-url-for-id.js
+++ b/src/util/encode-url-for-id.js
@@ -4,7 +4,7 @@ import queryParamRules from './query-string-normalization-rules'
 
 export const PROTOCOL_PATTERN = /^\w+:\/\//
 
-const normalizationOpts = {
+export const normalizationOpts = {
     normalizeProtocol: true, // Prepend `http://` if URL is protocol-relative
     stripFragment: true, // Remove trailing hash fragment
     stripWWW: true, // Remove any leading `www.`


### PR DESCRIPTION
- fixes #293 
- `fetch-page-data` module had a bug returning nothing in the case of PDFs; should have returned an object that allows running and cancelling the XHR
- our PDF checking logic is terrible also: it simply checks if the URL ends with ".pdf" - this won't work if the URL has query or hash states, or if the URL doesn't even end in ".pdf" but still responds with a PDF