### PR TITLE
Fix history edge case where onboarding import limit can be exceeded

### DIFF
--- a/src/imports/background/import-item-creation.js
+++ b/src/imports/background/import-item-creation.js
@@ -256,11 +256,15 @@ export default class ImportItemCreator {
                 endTime: time.valueOf(),
             })
 
+            const prevCount = itemCount
             const itemsMap = filterByUrl(historyItemBatch)
             itemCount += itemsMap.size
 
             if (itemCount >= this._histLimit) {
-                yield ImportItemCreator._limitMap(itemsMap, this._histLimit)
+                yield ImportItemCreator._limitMap(
+                    itemsMap,
+                    this._histLimit - prevCount,
+                )
                 break
             }
 


### PR DESCRIPTION
- happens if one week of history has < 30 usable items, and the next week exceeds the total count
- this should keep it at the 30 limit in those cases
