### PR TITLE
#280 Internal tracking -- Searches

### DIFF
--- a/src/analytics/internal/index.js
+++ b/src/analytics/internal/index.js
@@ -1,0 +1,1 @@
+import './searches'

--- a/src/analytics/internal/searches.js
+++ b/src/analytics/internal/searches.js
@@ -1,0 +1,14 @@
+async function NewSearchTriggered() {
+    const currentCachedNoOfSearches = localStorage.getItem('cachedNoOfSearches')
+    if (currentCachedNoOfSearches === null) {
+        localStorage.setItem('cachedNoOfSearches', 1)
+    } else {
+        UpdateNoOfSearches(parseInt(currentCachedNoOfSearches) + 1)
+    }
+}
+
+async function UpdateNoOfSearches(cachedNoOfSearches) {
+    localStorage.setItem('cachedNoOfSearches', cachedNoOfSearches)
+}
+
+export default NewSearchTriggered

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -1,6 +1,7 @@
 import QueryBuilder from './query-builder'
 import { searchConcurrent } from './search-index/search'
 import mapResultsToPouchDocs from './map-search-to-pouch'
+import NewSearchTriggered from '../analytics/internal/searches'
 
 async function indexSearch({
     query,
@@ -62,6 +63,8 @@ async function indexSearch({
     })
 
     console.log('DEBUG: final UI results', docs)
+
+    NewSearchTriggered()
 
     return {
         docs,


### PR DESCRIPTION
This is with respect to #280. Added a simple boilerplate analytics module and implemented a search trigger.

Trying to be as modular as possible here, since we do not just store the variables locally in future. `analytics` already had `background` packages for croning user activity records. Added a new `internal` package with `searches`, `filters` etc as logical blocks. This might be useful if we want to add more functionalities later. In `searches`, I have currently separated the trigger and update code. I think this way, we could add more event triggers, time-specific methods etc as and when necessary at one single place per logical block and just import the required trigger and call it.

@oliversauter @ShishKabab @poltak, please review and suggest changes. This is my first react code so would be great if you could add any framework specific suggestions too. :) 

