### PR TITLE
Quick fix to kill gulp process when a bundle build fails

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -114,7 +114,13 @@ async function createBundle(
         const startTime = Date.now()
         b
             .bundle()
-            .on('error', console.error)
+            .on('error', err => {
+                console.error(err.stack)
+                // Fail entire gulp build if browserify emits error, but not in dev/watch mode
+                if (!watch) {
+                    process.exit(1)
+                }
+            })
             .pipe(source(output))
             .pipe(buffer())
             .pipe(


### PR DESCRIPTION
- explicitly `process.exit(1)` when any bundle's browserify stream emits a build error
- only in standard build; watch/dev mode shouldn't exit the process
- also only printing out the stack trace now - should have done that ages ago
- should ensure CI build fails on JS build failure