### PR TITLE
Ensure any content script scroll msg errors are caught

### DIFF
--- a/src/activity-logger/content_script/index.js
+++ b/src/activity-logger/content_script/index.js
@@ -2,14 +2,18 @@ import throttle from 'lodash/fp/throttle'
 
 import * as scrollStateFetchers from './scroll-state-fetchers'
 
+const noop = err => {}
+
 // Set up sending of current scroll state data to the background script's tab states whenever
 //  the 'scroll' event fires for this particular script
 const sendCurrentSrollState = () =>
-    browser.runtime.sendMessage({
-        funcName: 'updateScrollState',
-        scrollOffset: scrollStateFetchers.fetchScrollOffset(),
-        windowHeight: scrollStateFetchers.fetchWindowHeight(),
-        scrollableHeight: scrollStateFetchers.fetchScrollableHeight(),
-    })
+    browser.runtime
+        .sendMessage({
+            funcName: 'updateScrollState',
+            scrollOffset: scrollStateFetchers.fetchScrollOffset(),
+            windowHeight: scrollStateFetchers.fetchWindowHeight(),
+            scrollableHeight: scrollStateFetchers.fetchScrollableHeight(),
+        })
+        .catch(noop)
 
 window.addEventListener('scroll', throttle(500)(sendCurrentSrollState))


### PR DESCRIPTION
- reported in #325 that failed connections between content script and bg script spam the page console (content_script loaded as part of web page)
- can only reproduce on [untracked tabs](https://github.com/WorldBrain/Memex/issues/314#issuecomment-367879824)
- now any Promise rejections are caught and ignored, rather than default uncaught Promise behaviour of logging error to stderr - not optimal for content_script