### PR TITLE
Simplify text pre-processing

### DIFF
--- a/src/page-analysis/content_script/extract-page-content.js
+++ b/src/page-analysis/content_script/extract-page-content.js
@@ -19,15 +19,18 @@ export default async function extractPageContent(
     doc = document,
     url = location.href,
 ) {
+    const htmlTimerLabel = `TIMER - HTML proc: ${url}`
     // If it is a PDF, run code for pdf instead.
     if (url.endsWith('.pdf')) {
         return await extractPdfContent({ url })
     }
 
-    // // Apply simple transformations to clean the page's HTML
+    console.time(htmlTimerLabel)
+    // Apply simple transformations to clean the page's HTML
     const { text: processedHtml } = transformPageHTML({
         html: doc.body.innerHTML,
     })
+    console.timeEnd(htmlTimerLabel)
 
     const metadata = getMetadata(doc, url, PAGE_METADATA_RULES)
 

--- a/src/search/pipeline.test.data.js
+++ b/src/search/pipeline.test.data.js
@@ -1,0 +1,42 @@
+export const EXPECTED_TERMS = [
+    'people',
+    'forget',
+    'optimize',
+    'important',
+    'code',
+]
+
+export const PAGE_1 = {
+    url: 'https://www.test.com/test',
+    content: {
+        fullText: 'the wild fox jumped over the hairy red hen',
+        title: 'test page',
+    },
+}
+
+export const EXPECTED_OUTPUT_NEW = {
+    domain: 'test.com',
+    fullTitle: PAGE_1.content.title,
+    fullUrl: PAGE_1.url,
+    text: PAGE_1.content.fullText,
+    tags: [],
+    terms: ['wild', 'fox', 'jumped', 'hairy', 'red', 'hen'],
+    urlTerms: ['test'],
+}
+
+export const EXPECTED_OUTPUT_OLD = {
+    terms: new Set([
+        'term/wild',
+        'term/fox',
+        'term/jumped',
+        'term/hairy',
+        'term/red',
+        'term/hen',
+    ]),
+    urlTerms: new Set(['url/test']),
+    titleTerms: new Set(['title/test', 'title/page']),
+    domain: 'domain/test.com',
+    visits: new Set(['visit/12345']),
+    bookmarks: new Set(),
+    tags: new Set(),
+}

--- a/src/search/pipeline.test.js
+++ b/src/search/pipeline.test.js
@@ -64,6 +64,13 @@ const runSuite = useOld => () => {
         })
     })
 
+    test('extract terms from a document normalizing weird spaces', () => {
+        testExtractTerms({
+            input:
+                'very often\u{2007}the people\u{202F}forget to optimize important\u{A0}code',
+        })
+    })
+
     test('extract terms from a document _including_ words with numbers', () => {
         testExtractTerms({
             input:

--- a/src/search/search-index-new/pipeline.js
+++ b/src/search/search-index-new/pipeline.js
@@ -14,6 +14,7 @@ export default function pipeline({
     pageDoc: { content = {}, url, ...data },
     rejectNoContent = true,
 }) {
+    const textTimerLabel = `TIMER - text proc: ${url}`
     // First apply transformations to the URL
     const { pathname, hostname } = transformUrl(url)
 
@@ -27,7 +28,9 @@ export default function pipeline({
     }
 
     // Extract all terms out of processed content
+    console.time(textTimerLabel)
     const terms = [...extractTerms(content.fullText)]
+    console.timeEnd(textTimerLabel)
     const titleTerms = [...extractTerms(content.title)]
     const urlTerms = [...extractTerms(pathname)]
 

--- a/src/search/search-index-new/pipeline.js
+++ b/src/search/search-index-new/pipeline.js
@@ -1,65 +1,6 @@
 import normalizeUrl from 'src/util/encode-url-for-id'
-import transformPageText from 'src/util/transform-page-text'
-import { DEFAULT_TERM_SEPARATOR, extractContent } from '../util'
 
-const urlNormalizationOpts = {
-    normalizeProtocol: true, // Prepend `http://` if URL is protocol-relative
-    stripFragment: true, // Remove trailing hash fragment
-    stripWWW: true, // Remove any leading `www.`
-    removeTrailingSlash: true,
-    removeQueryParameters: [/.+/], // Remove all query params from terms indexing
-    removeDirectoryIndex: [/^(default|index)\.\w{2,4}$/], // Remove things like tralining `/index.js` or `/default.php`
-    skipProtocolTrim: true,
-    skipQueryRules: true,
-}
-
-/**
- * @param {string} url A raw URL string to attempt to extract parts from.
- * @returns {any} Object containing `hostname` and `pathname` props. Values should be the `domain.tld.cctld` part and
- *  everything after, respectively. If regex matching failed on given URL, error will be logged and simply
- *  the URL with protocol and opt. `www` parts removed will be returned for both values.
- */
-export function transformUrl(url) {
-    let parsed
-    const normalized = normalizeUrl(url, urlNormalizationOpts)
-
-    try {
-        parsed = new URL(normalized)
-    } catch (error) {
-        console.error(`cannot parse URL: ${normalized}`)
-        return { hostname: normalized, pathname: normalized }
-    }
-
-    return {
-        hostname: parsed ? parsed.hostname : normalized,
-        pathname: parsed ? parsed.pathname : normalized,
-    }
-}
-
-/**
- *
- * @param {string} text
- * @returns {Set<string>} Set of "words-of-interest" - determined by pre-proc logic in `transformPageText` - extracted from `text`.
- */
-export function extractTerms(text) {
-    if (!text || !text.length) {
-        return []
-    }
-
-    const { text: transformedText } = transformPageText({ text })
-
-    if (!transformedText || !transformedText.length) {
-        return new Set()
-    }
-
-    return [
-        ...new Set(
-            extractContent(transformedText, {
-                separator: DEFAULT_TERM_SEPARATOR,
-            }),
-        ),
-    ]
-}
+import { extractTerms, transformUrl } from '../search-index-old/pipeline'
 
 /**
  * Given some page data, applies some transformations to the text and
@@ -86,9 +27,9 @@ export default function pipeline({
     }
 
     // Extract all terms out of processed content
-    const terms = extractTerms(content.fullText)
-    const titleTerms = extractTerms(content.title)
-    const urlTerms = extractTerms(pathname)
+    const terms = [...extractTerms(content.fullText)]
+    const titleTerms = [...extractTerms(content.title)]
+    const urlTerms = [...extractTerms(pathname)]
 
     return Promise.resolve({
         url: normalizeUrl(url),

--- a/src/search/search-index-old/pipeline.test.js
+++ b/src/search/search-index-old/pipeline.test.js
@@ -2,17 +2,18 @@
 
 import pipeline, { extractTerms } from './pipeline'
 
-const TEST_EXTRACT_OUTPUT = new Set([
-    'term/people',
-    'term/forget',
-    'term/optimize',
-    'term/important',
-    'term/code',
-])
+const attachPrefix = s => 'term/' + s
+
+const TEST_TERMS = ['people', 'forget', 'optimize', 'important', 'code']
+
+const TEST_EXTRACT_OUTPUT = new Set(TEST_TERMS.map(attachPrefix))
+
 function testExtractTerms({ input, output }) {
     const result = extractTerms(input, 'term')
     expect(result).toEqual(
-        output ? new Set(output.map(s => 'term/' + s)) : TEST_EXTRACT_OUTPUT,
+        output
+            ? new Set(output.map(attachPrefix))
+            : new Set(TEST_EXTRACT_OUTPUT),
     )
 }
 
@@ -82,10 +83,11 @@ describe('Search index pipeline', () => {
         })
     })
 
-    test('extract terms from a document removing words with numbers', () => {
+    test('extract terms from a document _including_ words with numbers', () => {
         testExtractTerms({
             input:
                 'very often the-people (like Punkdude123) forget to optimize important code',
+            output: [...TEST_TERMS, 'punkdude123'],
         })
     })
 
@@ -128,10 +130,11 @@ describe('Search index pipeline', () => {
         })
     })
 
-    test('FIX for Slavic languages: extract terms from a document removing words with too many consonants', () => {
+    test('extract terms from a document _including_ words with many consonants', () => {
         testExtractTerms({
             input:
                 'very often the people from Vrchlabí forget to optimize important code',
+            output: [...TEST_TERMS, 'vrchlabi'],
         })
     })
 

--- a/src/search/util.js
+++ b/src/search/util.js
@@ -1,6 +1,6 @@
 import { keyGen } from './search-index-old/util'
 
-export const DEFAULT_TERM_SEPARATOR = /[|' .,\-|(\n)]+/
+export const DEFAULT_TERM_SEPARATOR = /[|\u{A0}' .,\-|(\n)]+/u
 export const URL_SEPARATOR = /[/?#=+& _.,\-|(\n)]+/
 
 /**

--- a/src/search/util.js
+++ b/src/search/util.js
@@ -18,4 +18,4 @@ export const extractContent = (
     content
         .split(separator)
         .map(word => keyGen[key](word.toLowerCase()))
-        .filter(term => !term.endsWith('/'))
+        .filter(term => !term.endsWith('/') && term.length)

--- a/src/util/transform-page-text.js
+++ b/src/util/transform-page-text.js
@@ -3,12 +3,9 @@ import sw from 'remove-stopwords'
 import rmDiacritics from './remove-diacritics'
 
 const allWhitespacesPattern = /\s+/g
-// const singleDigitNumbersPattern = /\b\d\b/g
 const nonWordsPattern = /[\u2000-\u206F\u2E00-\u2E7F\\!"#$%&()*+,./:;<=>?@[\]^_`{|}~«»。（）ㅇ©ºø°]/gi
 const apostrophePattern = /['’]/g
-const allWordsWithDigits = /[a-z]+\d\w*|\w*\d[a-z]+/gi // /\w*\d\w*/g
 const dashPattern = /[-]/g
-const giberishWords = /\S*([b-df-hj-np-tv-z]){5,}\S*/gi
 const longWords = /\b\w{30,}\b/gi
 const randomDigits = /\b(\d{1,3}|\d{5,})\b/gi
 const urlPattern = urlRegex()
@@ -44,15 +41,9 @@ const removeDiacritics = (text = '') => {
     return rmDiacritics(text)
 }
 
-// This also removes any numbers greater than 5 chars
-const removeAllWordsWithDigits = (text = '') =>
-    text.replace(allWordsWithDigits, ' ')
-
 const removeRandomDigits = (text = '') => text.replace(randomDigits, ' ')
 
 const removeLongWords = (text = '') => text.replace(longWords, ' ')
-
-const removeGiberishWords = (text = '') => text.replace(giberishWords, ' ')
 
 /**
  * Takes in some text content and strips it of unneeded data. Currently does
@@ -93,17 +84,11 @@ export default function transform({ text = '', lang = 'en' }) {
     // We don't care about non-single-space whitespace (' ' is cool)
     searchableText = cleanupWhitespaces(searchableText)
 
-    // Remove all words containing numbers ex. blah123
-    searchableText = removeAllWordsWithDigits(searchableText)
-
     // Removes all single digits and digits over 5+ characters
     searchableText = removeRandomDigits(searchableText)
 
     // Removes all words 20+ characters long
     searchableText = removeLongWords(searchableText)
-
-    // Removes all words containing 4+ consonants such as "hellllo"
-    searchableText = removeGiberishWords(searchableText)
 
     searchableText = removeDupeWords(searchableText)
 


### PR DESCRIPTION
Fixes #330 

So far two stages mentioned in that issue have been removed and tests updated to verify the change works and doesn't effect other stuff.

Updated the pipeline tests in general to ensure both the current and slightly changed (type sig) new pipeline are both being tested. Fixed one issue from that. 

Some others remain that would be nice to get fixed with this work:
- empty string can sometimes get through and be indexed (sometimes happens in current index too)
- stopwords can sometimes get through and be indexed

<img width="526" alt="screen shot 2018-03-14 at 13 13 55" src="https://user-images.githubusercontent.com/1130716/37386238-25c0ef98-278a-11e8-9cb0-0867618ceab8.png">

It's pretty strange that it seems like only "sometimes", and cannot reproduce in the tests (so far, could try some more test data), so need to look over all the pipeline-interacting code and see how these could get through. Also have the URLs, so could manually try and reproduce with those page contents.