### PR TITLE
Gulp commands for automated publishing

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -295,7 +295,7 @@ gulp.task(
 // Tasks for publishing the extension
 
 gulp.task('publish-extension:chrome', ['package-extension'], async () => {
-    const extensionID = 'abkfbakhjpmblaafnpgjppbmioombali'
+    const extensionID = process.env.WEBSTORE_EXTENSION_ID
     const tokenManager = new chromeStore.TokenManager(
         'worldbrain-1057',
         process.env.WEBSTORE_CLIENT_ID,

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -297,7 +297,7 @@ gulp.task(
 gulp.task('publish-extension:chrome', ['package-extension'], async () => {
     const extensionID = process.env.WEBSTORE_EXTENSION_ID
     const tokenManager = new chromeStore.TokenManager(
-        'worldbrain-1057',
+        process.env.WEBSTORE_TOKEN_CODE,
         process.env.WEBSTORE_CLIENT_ID,
         process.env.WEBSTORE_CLIENT_SECRET,
     )

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -309,7 +309,7 @@ gulp.task('publish-extension:chrome', ['package-extension'], async () => {
         )
     })
     await api.update(extensionID, zip)
-    await api.publish(extensionID)
+    await api.publish(extensionID, process.env.WEBSTORE_PUBLISH_TARGET)
 })
 
 gulp.task('publish-extension:firefox', ['package-extension'], () => {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "worldbrain-extension",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://worldbrain.io",
-  "license": "Unlicense",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/WorldBrain/WebMemex"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldbrain-extension",
-  "version": "0.1.0",
+  "version": "0.1.0.1030",
   "homepage": "https://worldbrain.io",
   "license": "Unlicense",
   "repository": {
@@ -134,6 +134,7 @@
     "redux-devtools": "^3.4.0",
     "redux-devtools-dock-monitor": "^1.1.2",
     "redux-devtools-log-monitor": "^1.3.0",
+    "sign-addon": "^0.3.0",
     "stream-to-promise": "^2.2.0",
     "stylelint": "^7.11.1",
     "stylelint-config-standard": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "babel-preset-stage-1": "^6.24.1",
     "babelify": "^7.3.0",
     "browserify": "^14.4.0",
-    "chrome-store-api": "^1.0.5",
+    "chrome-webstore-upload": "^0.2.2",
     "crx": "^3.2.1",
     "css-modulesify": "git+https://github.com/Treora/css-modulesify#95447d1",
     "eslint": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "babel-preset-stage-1": "^6.24.1",
     "babelify": "^7.3.0",
     "browserify": "^14.4.0",
+    "chrome-store-api": "^1.0.5",
     "crx": "^3.2.1",
     "css-modulesify": "git+https://github.com/Treora/css-modulesify#95447d1",
     "eslint": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldbrain-extension",
-  "version": "0.1.0.1030",
+  "version": "0.1.0",
   "homepage": "https://worldbrain.io",
   "license": "Unlicense",
   "repository": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,17 +1,24 @@
 {
     "name": "WorldBrain's Memex",
     "short_name": "Memex",
-    "version": "0.1.0.1030",
+    "version": "0.1.0",
     "offline_enabled": true,
-    "description":
-        "Find previously visited websites & PDFs in seconds. Full-text search your browsing history and bookmarks.",
+    "description": "Find previously visited websites & PDFs in seconds. Full-text search your browsing history and bookmarks.",
     "background": {
-        "scripts": ["lib/browser-polyfill.js", "background.js"]
+        "scripts": [
+            "lib/browser-polyfill.js",
+            "background.js"
+        ]
     },
     "content_scripts": [
         {
-            "matches": ["<all_urls>"],
-            "js": ["lib/browser-polyfill.js", "content_script.js"],
+            "matches": [
+                "<all_urls>"
+            ],
+            "js": [
+                "lib/browser-polyfill.js",
+                "content_script.js"
+            ],
             "run_at": "document_start"
         }
     ],
@@ -48,8 +55,12 @@
         "unlimitedStorage",
         "storage"
     ],
-    "web_accessible_resources": ["/lib/pdf.worker.min.js"],
-    "omnibox": { "keyword": "w" },
+    "web_accessible_resources": [
+        "/lib/pdf.worker.min.js"
+    ],
+    "omnibox": {
+        "keyword": "w"
+    },
     "options_ui": {
         "page": "./options/options.html",
         "open_in_tab": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,10 +1312,6 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.0.6:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.7"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
@@ -1712,16 +1708,11 @@ chokidar@^1.0.0, chokidar@^1.4.3:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chrome-store-api@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/chrome-store-api/-/chrome-store-api-1.0.5.tgz#5261f9203b805447601e4b09dab828a27c97487f"
+chrome-webstore-upload@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/chrome-webstore-upload/-/chrome-webstore-upload-0.2.2.tgz#6293463a5d0475c8826ffd799a98357b04af4fcb"
   dependencies:
-    bluebird "^3.0.6"
-    debug "^2.2.0"
-    lodash "^3.10.1"
-    mkdirp "^0.5.1"
-    q "^1.4.1"
-    q-io "^1.13.1"
+    got "^6.3.0"
 
 chrono-node@^1.3.1:
   version "1.3.4"
@@ -1840,12 +1831,6 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-
-collections@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/collections/-/collections-0.2.2.tgz#1f23026b2ef36f927eecc901e99c5f0d48fa334e"
-  dependencies:
-    weak-map "1.0.0"
 
 color-convert@^0.5.3:
   version "0.5.3"
@@ -3698,7 +3683,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-got@^6.7.1:
+got@^6.3.0, got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
   dependencies:
@@ -5515,7 +5500,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@3.10.1, lodash@^3.10.1:
+lodash@3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -5716,14 +5701,6 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
     mime-db "~1.30.0"
-
-mime@^1.2.11:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
-
-mimeparse@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/mimeparse/-/mimeparse-0.1.4.tgz#dafb02752370fd226093ae3152c271af01ac254a"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -7319,28 +7296,17 @@ pure-color@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
 
-q-io@^1.13.1:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/q-io/-/q-io-1.13.5.tgz#6ac39deb5cfe0dc68436e6f8c33d0d7c3f471bb2"
-  dependencies:
-    collections "^0.2.0"
-    mime "^1.2.11"
-    mimeparse "^0.1.4"
-    q "^1.0.1"
-    qs "^6.4.0"
-    url2 "^0.0.0"
-
-q@^1.0.1, q@^1.1.2, q@^1.4.1:
+q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-
-qs@^6.4.0, qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
+qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 query-string@^4.1.0, query-string@^4.2.2, query-string@^4.3.4:
   version "4.3.4"
@@ -9038,10 +9004,6 @@ url-regex@^4.1.1:
     ip-regex "^1.0.1"
     tlds "^1.187.0"
 
-url2@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/url2/-/url2-0.0.0.tgz#4eaabd1d5c3ac90d62ab4485c998422865a04b1a"
-
 url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -9221,10 +9183,6 @@ wcwidth@^1.0.0:
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
-
-weak-map@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.0.tgz#b66e56a9df0bd25a76bbf1b514db129080614a37"
 
 web-ext@^1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,6 +1312,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^3.0.6:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.7"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
@@ -1708,6 +1712,17 @@ chokidar@^1.0.0, chokidar@^1.4.3:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chrome-store-api@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/chrome-store-api/-/chrome-store-api-1.0.5.tgz#5261f9203b805447601e4b09dab828a27c97487f"
+  dependencies:
+    bluebird "^3.0.6"
+    debug "^2.2.0"
+    lodash "^3.10.1"
+    mkdirp "^0.5.1"
+    q "^1.4.1"
+    q-io "^1.13.1"
+
 chrono-node@^1.3.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-1.3.4.tgz#fc2a9208636e09d6fd7b12d94ae2440937de24bd"
@@ -1825,6 +1840,12 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collections@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/collections/-/collections-0.2.2.tgz#1f23026b2ef36f927eecc901e99c5f0d48fa334e"
+  dependencies:
+    weak-map "1.0.0"
 
 color-convert@^0.5.3:
   version "0.5.3"
@@ -5494,7 +5515,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@3.10.1:
+lodash@3.10.1, lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -5695,6 +5716,14 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
     mime-db "~1.30.0"
+
+mime@^1.2.11:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
+mimeparse@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/mimeparse/-/mimeparse-0.1.4.tgz#dafb02752370fd226093ae3152c271af01ac254a"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -7290,17 +7319,28 @@ pure-color@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
 
-q@^1.1.2:
+q-io@^1.13.1:
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/q-io/-/q-io-1.13.5.tgz#6ac39deb5cfe0dc68436e6f8c33d0d7c3f471bb2"
+  dependencies:
+    collections "^0.2.0"
+    mime "^1.2.11"
+    mimeparse "^0.1.4"
+    q "^1.0.1"
+    qs "^6.4.0"
+    url2 "^0.0.0"
+
+q@^1.0.1, q@^1.1.2, q@^1.4.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+
+qs@^6.4.0, qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 query-string@^4.1.0, query-string@^4.2.2, query-string@^4.3.4:
   version "4.3.4"
@@ -8983,6 +9023,10 @@ url-regex@^4.1.1:
     ip-regex "^1.0.1"
     tlds "^1.187.0"
 
+url2@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/url2/-/url2-0.0.0.tgz#4eaabd1d5c3ac90d62ab4485c998422865a04b1a"
+
 url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -9162,6 +9206,10 @@ wcwidth@^1.0.0:
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
+
+weak-map@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.0.tgz#b66e56a9df0bd25a76bbf1b514db129080614a37"
 
 web-ext@^1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8165,6 +8165,21 @@ sign-addon@0.2.1:
     stream-to-promise "2.2.0"
     when "3.7.7"
 
+sign-addon@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/sign-addon/-/sign-addon-0.3.0.tgz#b5585d8ffc978058c0a0d8c28047ecb6c8e5dab6"
+  dependencies:
+    babel-polyfill "6.16.0"
+    deepcopy "0.6.3"
+    es6-error "4.0.0"
+    es6-promisify "5.0.0"
+    jsonwebtoken "7.1.9"
+    mz "2.5.0"
+    request "2.79.0"
+    source-map-support "0.4.6"
+    stream-to-promise "2.2.0"
+    when "3.7.7"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"


### PR DESCRIPTION
Adds these Gulp commands:
- publish-extension (which calls the following two commands)
- publish-extension:chrome
- publish-extension:firefox

They need the following environment variables (so this data doesn't go into a public Git repo  ;)  ):
- AMO_API_KEY (Addons Mozilla)
- AMO_API_SECRET
- WEBSTORE_TOKEN_CODE
- WEBSTORE_EXTENSION_ID
- WEBSTORE_CLIENT_ID
- WEBSTORE_CLIENT_SECRET

The code is all untested, would be great to test with a fake app. This branch does give me a weird error when doing 'gulp lint':
```
TypeError: Error while loading rule 'react/jsx-uses-react': Cannot read property '1' of null
    at Object.getFromContext (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/eslint-plugin-react/lib/util/pragma.js:34:21)
    at Object.create (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/eslint-plugin-react/lib/rules/jsx-uses-react.js:25:29)
    at Object.keys.filter.forEach.ex (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/eslint/lib/linter.js:871:67)
    at Array.forEach (native)
    at Linter.verify (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/eslint/lib/linter.js:844:93)
    at processText (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/eslint/lib/cli-engine.js:202:31)
    at CLIEngine.executeOnText (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/eslint/lib/cli-engine.js:667:26)
    at Transform.util.transform.e [as _transform] (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/gulp-eslint/index.js:50:20)
    at Transform._read (_stream_transform.js:167:10)
    at Transform._write (_stream_transform.js:155:12)
    at doWrite (_stream_writable.js:333:12)
    at writeOrBuffer (_stream_writable.js:319:5)
    at Transform.Writable.write (_stream_writable.js:245:11)
    at write (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/vinyl-fs/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/vinyl-fs/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/home/vincent/Documents/Develop/Web/WorldBrain/Memex/node_modules/vinyl-fs/node_modules/readable-stream/lib/_stream_readable.js:664:5)
```

Next step would be a flag to publish to Trusted Testers as they're called for Chrome. After all of this is implemented, the release process looks like follows (excluding proper Git flow and automated Continuous Delivery, which this is the first step for):
- Increase the version number in package.json
- Run 'gulp publish-extension' (automatically builds and packages)