### PR TITLE
Fix current boosted terms search behaviour

### DIFF
--- a/src/overview/onboarding/actions.js
+++ b/src/overview/onboarding/actions.js
@@ -13,8 +13,11 @@ export const setProgress = createAction('onboarding/setProgress')
 export const setImportsDone = createAction('onboarding/setImportsDone')
 export const setImportsStarted = createAction('onboarding/setImportsStarted')
 
-export const init = () => (dispatch, getState) =>
-    new ImportsConnHandler(IMPORT_CONN_NAME, dispatch, getState)
+export const init = () => (dispatch, getState) => {
+    if (selectors.isVisible(getState())) {
+        return new ImportsConnHandler(IMPORT_CONN_NAME, dispatch, getState)
+    }
+}
 
 /**
  * Background script connection state handler, which sets up the connection and dispatches

--- a/src/search/search-index/util.js
+++ b/src/search/search-index/util.js
@@ -74,35 +74,21 @@ export const extractContent = (
  * @param {number} [boost=0.2] Boost to apply on base score.
  * @returns {Map<string, IndexTermValue>} Map of page IDs to boosted scores.
  */
-export const boostScores = (termValuesMap, boost = 0.2) =>
-    [...termValuesMap.values()].reduce((pageScoresMap, termValue) => {
-        // Skip empty values
-        if (termValue == null) {
-            return pageScoresMap
-        }
-
-        // For each assoc. page to the term...
-        for (const [pageId, score] of termValue) {
-            const currScore = +score.latest
-
-            if (!Number.isNaN(currScore)) {
-                let newScore
-
-                // ... boost score (extra boost, if found multiple times)
-                if (pageScoresMap.has(pageId)) {
-                    newScore = currScore + currScore * (boost + 0.1)
-                } else {
-                    newScore = currScore + currScore * boost
-                }
-
-                pageScoresMap.set(pageId, {
-                    latest: newScore.toFixed(),
-                })
-            }
-        }
-
+export function boostScores(pageScoresMap, boost = 0) {
+    if (boost === 0) {
         return pageScoresMap
-    }, new Map())
+    }
+
+    for (const [pageId, score] of pageScoresMap) {
+        const currScore = +score.latest
+
+        if (!Number.isNaN(currScore)) {
+            const newScore = currScore * (1 + boost)
+            pageScoresMap.set(pageId, { latest: newScore.toFixed() })
+        }
+    }
+    return pageScoresMap
+}
 
 /**
  * Transforms an indexed document into a search result.


### PR DESCRIPTION
Realized our URL and title terms index searches have been broken after looking into issue noted by @oliversauter on slack (great find!):

>When I go on this page: 
> https://worldbrain.helprace.com/i43-indexation-is-stopped-can-t-restart#comment-33385
> It finds it for “design community”, whereas ‘design’ is not in the text, and only ‘community’ is in the title. Searching for ‘design’ alone does not bring up the page.

Main commit:
- it was not ANDing properly on title and URL terms search
- it should do exactly the same thing for all 3 terms indexes, apart from score boosting, so now made sure it does