### PR TITLE
Fix update notifs in Firefox

### DIFF
--- a/src/util/update-notification.js
+++ b/src/util/update-notification.js
@@ -11,16 +11,9 @@ const updateNotification = () => {
         title: 'NEW FEATURE: Tagging',
         iconUrl: '/img/worldbrain-logo-narrow.png',
         message: 'Click for more Information',
-        buttons: [{ title: 'Click for more Information' }],
     })
 
-    browser.notifications.onButtonClicked.addListener((id, index) => {
-        createTab(id)
-    })
-
-    browser.notifications.onClicked.addListener(id => {
-        createTab(id)
-    })
+    browser.notifications.onClicked.addListener(createTab)
 }
 
 export default updateNotification


### PR DESCRIPTION
- buttons aren't supported in FF notifs; error gets thrown
- this is documented: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
- this button also just did the same thing as notif click