### PR TITLE
Fix rendering search results on all Google search types

### DIFF
--- a/setupJest.js
+++ b/setupJest.js
@@ -1,2 +1,3 @@
 require.requireActual('babel-polyfill')
 global.fetch = require('jest-fetch-mock')
+global.URL = require('url').URL

--- a/src/search-injection/constants.js
+++ b/src/search-injection/constants.js
@@ -17,6 +17,19 @@ export const SEARCH_ENGINES = {
     },
 }
 
+// These are values of the `tbm` query param in Google searches. It denotes
+// the type of search performed. More discussion on these:
+//   https://productforums.google.com/forum/#!msg/webmasters/8fPg1I2p34w/Xsdw0stkDwAJ
+export const UNWANTED_GOOGLE_SEARCH_TYPES = [
+    'vid', // Google video
+    'nws', // Google news
+    'bks', // Google books
+    'fin', // Google finance
+    'lcl', // Google quick maps
+    'isch', // Google images
+    'pers', // Google personal
+]
+
 // Action names
 export const OPEN_OVERVIEW = 'openOverviewURL'
 export const OPEN_OPTIONS = 'openOptionsURL'

--- a/src/search-injection/utils.js
+++ b/src/search-injection/utils.js
@@ -1,17 +1,33 @@
-import { SEARCH_ENGINES } from './constants'
+import { SEARCH_ENGINES, UNWANTED_GOOGLE_SEARCH_TYPES } from './constants'
 
 export const matchURL = url => {
     // url: (string) location.href
     // match url against search engines regexs
     // returns: the search engine it matches to or false
 
+    let matchingKey
     for (const key in SEARCH_ENGINES) {
-        // eslint-disable-line prefer-const
-        const regex = SEARCH_ENGINES[key].regex
-        if (url.match(regex) !== null) return key
+        if (SEARCH_ENGINES[key].regex.test(url)) {
+            matchingKey = key
+            break
+        }
     }
+
+    if (!matchingKey) {
+        return false
+    }
+
+    // Google specific fix: `tbm` query param is used to determine google search type (videos, images, etc.)
+    // Make sure that it is not set to one of the unwanted types of search
+    const searchType = getUrlSearchParams(url).get('tbm')
+    if (!UNWANTED_GOOGLE_SEARCH_TYPES.includes(searchType)) {
+        return matchingKey
+    }
+
     return false
 }
+
+const getUrlSearchParams = url => new URL(url).searchParams
 
 export const fetchQuery = url => {
     // url: (string) location.href
@@ -19,8 +35,8 @@ export const fetchQuery = url => {
     // and fetches the query param from the url
     // returns: query
 
-    const urlObj = new URL(url)
-    const query = urlObj.searchParams.get('q')
+    const searchParams = getUrlSearchParams(url)
+    const query = searchParams.get('q')
     return query
 }
 


### PR DESCRIPTION
- quick google-specific fix for now (only thing we support anyway)
- checks the `tbm` query param which represents different google search types (they all run on same route)
- if it's set to an unwanted type, don't return a match in the main `matchURL` function
- should now only show on the "All" type of search (standard google text search)
- @digi0ps would be good to get you to review these changes (can't assign you via GitHub for some reason)