### PR TITLE
Show Memex results in DuckDuckGo.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -11,7 +11,11 @@ import {
 import { index } from 'src/search'
 import analytics from 'src/analytics'
 import createNotif from 'src/util/notifications'
-import { OPEN_OVERVIEW, OPEN_OPTIONS } from 'src/search-injection/constants'
+import {
+    OPEN_OVERVIEW,
+    OPEN_OPTIONS,
+    SEARCH_INJECTION_KEY,
+} from 'src/search-injection/constants'
 import db from 'src/search/search-index-new'
 import * as models from 'src/search/search-index-new/models'
 
@@ -74,6 +78,20 @@ async function onUpdate() {
         },
         () => browser.tabs.create({ url: NEW_FEATURE_NOTIF.url }),
     )
+
+    // Check whether old Search Injection boolean exists and replace it with new object
+    const searchInjectionKey = (await browser.storage.local.get(
+        SEARCH_INJECTION_KEY,
+    ))[SEARCH_INJECTION_KEY]
+
+    if (typeof searchInjectionKey === 'boolean') {
+        browser.storage.local.set({
+            [SEARCH_INJECTION_KEY]: {
+                google: searchInjectionKey,
+                duckduckgo: true,
+            },
+        })
+    }
 }
 
 browser.commands.onCommand.addListener(command => {

--- a/src/options/settings/components/Checkbox.js
+++ b/src/options/settings/components/Checkbox.js
@@ -3,28 +3,21 @@ import PropTypes from 'prop-types'
 
 import styles from './Checkbox.css'
 
-const Checkbox = ({ children, name, id, handleChange, isChecked }) => {
-    handleChange = handleChange.bind(null, name)
-    return (
-        <div>
-            <input
-                className={styles.checkbox}
-                type="checkbox"
-                name={name}
-                id={id}
-                checked={isChecked}
-                onChange={handleChange}
-            />
-            <label className={styles.label} onClick={handleChange}>
-                <span className={styles.checkboxText}>{children}</span>
-            </label>
-        </div>
-    )
-}
+const Checkbox = ({ children, handleChange, isChecked }) => (
+    <div>
+        <input
+            className={styles.checkbox}
+            type="checkbox"
+            checked={isChecked}
+            onChange={handleChange}
+        />
+        <label className={styles.label} onClick={handleChange}>
+            <span className={styles.checkboxText}>{children}</span>
+        </label>
+    </div>
+)
 
 Checkbox.propTypes = {
-    name: PropTypes.string,
-    id: PropTypes.string,
     handleChange: PropTypes.func.isRequired,
     isChecked: PropTypes.bool.isRequired,
     children: PropTypes.string.isRequired,

--- a/src/options/settings/components/Checkbox.js
+++ b/src/options/settings/components/Checkbox.js
@@ -3,20 +3,24 @@ import PropTypes from 'prop-types'
 
 import styles from './Checkbox.css'
 
-const Checkbox = ({ children, name, id, handleChange, isChecked }) => (
-    <div>
-        <input
-            className={styles.checkbox}
-            type="checkbox"
-            name={name}
-            id={id}
-            checked={isChecked}
-        />
-        <label className={styles.label} onClick={handleChange}>
-            <span className={styles.checkboxText}>{children}</span>
-        </label>
-    </div>
-)
+const Checkbox = ({ children, name, id, handleChange, isChecked }) => {
+    handleChange = handleChange.bind(null, name)
+    return (
+        <div>
+            <input
+                className={styles.checkbox}
+                type="checkbox"
+                name={name}
+                id={id}
+                checked={isChecked}
+                onChange={handleChange}
+            />
+            <label className={styles.label} onClick={handleChange}>
+                <span className={styles.checkboxText}>{children}</span>
+            </label>
+        </div>
+    )
+}
 
 Checkbox.propTypes = {
     name: PropTypes.string,

--- a/src/options/settings/components/SearchInjection.js
+++ b/src/options/settings/components/SearchInjection.js
@@ -1,27 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import Checkbox from './Checkbox'
 import styles from './SearchInjection.css'
 
-const SearchInjection = ({ injectionPreference, toggleGoogle, toggleDDG }) => {
+const SearchInjection = ({ children }) => {
     return (
         <div>
             <p className={styles.settingsHeader}>
                 Show Memex Results in Search Engines
             </p>
-            <Checkbox
-                isChecked={injectionPreference.google}
-                handleChange={toggleGoogle}
-            >
-                Google
-            </Checkbox>
-            <Checkbox
-                isChecked={injectionPreference.duckduckgo}
-                handleChange={toggleDDG}
-            >
-                DuckDuckGo
-            </Checkbox>
+            {children}
             <p>
                 Want others?{' '}
                 <a
@@ -36,9 +24,7 @@ const SearchInjection = ({ injectionPreference, toggleGoogle, toggleDDG }) => {
 }
 
 SearchInjection.propTypes = {
-    injectionPreference: PropTypes.object.isRequired,
-    toggleGoogle: PropTypes.func.isRequired,
-    toggleDDG: PropTypes.func.isRequired,
+    children: PropTypes.arrayOf(PropTypes.element).isRequired,
 }
 
 export default SearchInjection

--- a/src/options/settings/components/SearchInjection.js
+++ b/src/options/settings/components/SearchInjection.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Checkbox from './Checkbox'
 import styles from './SearchInjection.css'
 
-const SearchInjection = ({ isInjectionEnabled, toggleInjection }) => {
+const SearchInjection = ({ injectionPreference, toggleInjection }) => {
     return (
         <div>
             <p className={styles.settingsHeader}>
@@ -13,10 +13,18 @@ const SearchInjection = ({ isInjectionEnabled, toggleInjection }) => {
             <Checkbox
                 name="google"
                 id="google-checkbox"
-                isChecked={isInjectionEnabled}
+                isChecked={injectionPreference.google}
                 handleChange={toggleInjection}
             >
                 Google
+            </Checkbox>
+            <Checkbox
+                name="duckduckgo"
+                id="ddg-checkbox"
+                isChecked={injectionPreference.duckduckgo}
+                handleChange={toggleInjection}
+            >
+                DuckDuckGo
             </Checkbox>
             <p>
                 Want others?{' '}
@@ -32,7 +40,7 @@ const SearchInjection = ({ isInjectionEnabled, toggleInjection }) => {
 }
 
 SearchInjection.propTypes = {
-    isInjectionEnabled: PropTypes.bool.isRequired,
+    injectionPreference: PropTypes.object.isRequired,
     toggleInjection: PropTypes.func.isRequired,
 }
 

--- a/src/options/settings/components/SearchInjection.js
+++ b/src/options/settings/components/SearchInjection.js
@@ -4,25 +4,21 @@ import PropTypes from 'prop-types'
 import Checkbox from './Checkbox'
 import styles from './SearchInjection.css'
 
-const SearchInjection = ({ injectionPreference, toggleInjection }) => {
+const SearchInjection = ({ injectionPreference, toggleGoogle, toggleDDG }) => {
     return (
         <div>
             <p className={styles.settingsHeader}>
                 Show Memex Results in Search Engines
             </p>
             <Checkbox
-                name="google"
-                id="google-checkbox"
                 isChecked={injectionPreference.google}
-                handleChange={toggleInjection}
+                handleChange={toggleGoogle}
             >
                 Google
             </Checkbox>
             <Checkbox
-                name="duckduckgo"
-                id="ddg-checkbox"
                 isChecked={injectionPreference.duckduckgo}
-                handleChange={toggleInjection}
+                handleChange={toggleDDG}
             >
                 DuckDuckGo
             </Checkbox>
@@ -41,7 +37,8 @@ const SearchInjection = ({ injectionPreference, toggleInjection }) => {
 
 SearchInjection.propTypes = {
     injectionPreference: PropTypes.object.isRequired,
-    toggleInjection: PropTypes.func.isRequired,
+    toggleGoogle: PropTypes.func.isRequired,
+    toggleDDG: PropTypes.func.isRequired,
 }
 
 export default SearchInjection

--- a/src/options/settings/components/SearchInjectionContainer.js
+++ b/src/options/settings/components/SearchInjectionContainer.js
@@ -2,6 +2,8 @@ import React from 'react'
 
 import analytics from 'src/analytics'
 import SearchInjection from './SearchInjection'
+import Checkbox from './Checkbox'
+
 import { getLocalStorage, setLocalStorage } from 'src/search-injection/utils'
 import {
     SEARCH_INJECTION_KEY,
@@ -44,11 +46,20 @@ class SearchInjectionContainer extends React.Component {
 
     render() {
         return (
-            <SearchInjection
-                injectionPreference={this.state.injectionPreference}
-                toggleGoogle={this.bindToggleInjection('google')}
-                toggleDDG={this.bindToggleInjection('duckduckgo')}
-            />
+            <SearchInjection>
+                <Checkbox
+                    isChecked={this.state.injectionPreference.google}
+                    handleChange={this.bindToggleInjection('google')}
+                >
+                    Google
+                </Checkbox>
+                <Checkbox
+                    isChecked={this.state.injectionPreference.duckduckgo}
+                    handleChange={this.bindToggleInjection('duckduckgo')}
+                >
+                    DuckDuckGo
+                </Checkbox>
+            </SearchInjection>
         )
     }
 }

--- a/src/options/settings/components/SearchInjectionContainer.js
+++ b/src/options/settings/components/SearchInjectionContainer.js
@@ -2,24 +2,15 @@ import React from 'react'
 
 import analytics from 'src/analytics'
 import SearchInjection from './SearchInjection'
+import { getLocalStorage, setLocalStorage } from 'src/search-injection/utils'
 import {
-    getLocalStorage,
-    setLocalStorage,
+    SEARCH_INJECTION_KEY,
     SEARCH_INJECTION_DEFAULT,
-} from 'src/search-injection/utils'
-import { SEARCH_INJECTION_KEY } from 'src/search-injection/constants'
+} from 'src/search-injection/constants'
 
 class SearchInjectionContainer extends React.Component {
-    constructor(props) {
-        super(props)
-        this.toggleInjection = this.toggleInjection.bind(this)
-    }
-
     state = {
-        injectionPreference: {
-            google: true,
-            duckduckgo: true,
-        },
+        injectionPreference: { ...SEARCH_INJECTION_DEFAULT },
     }
 
     async componentDidMount() {
@@ -32,9 +23,9 @@ class SearchInjectionContainer extends React.Component {
         })
     }
 
-    async toggleInjection(name) {
+    bindToggleInjection = name => async () => {
         const { injectionPreference } = this.state
-        // Toggle that field
+        // Toggle that particular search engine key
         injectionPreference[name] = !injectionPreference[name]
         await setLocalStorage(SEARCH_INJECTION_KEY, injectionPreference)
 
@@ -55,7 +46,8 @@ class SearchInjectionContainer extends React.Component {
         return (
             <SearchInjection
                 injectionPreference={this.state.injectionPreference}
-                toggleInjection={this.toggleInjection}
+                toggleGoogle={this.bindToggleInjection('google')}
+                toggleDDG={this.bindToggleInjection('duckduckgo')}
             />
         )
     }

--- a/src/options/settings/components/SearchInjectionContainer.js
+++ b/src/options/settings/components/SearchInjectionContainer.js
@@ -2,7 +2,11 @@ import React from 'react'
 
 import analytics from 'src/analytics'
 import SearchInjection from './SearchInjection'
-import { getLocalStorage, setLocalStorage } from 'src/search-injection/utils'
+import {
+    getLocalStorage,
+    setLocalStorage,
+    SEARCH_INJECTION_DEFAULT,
+} from 'src/search-injection/utils'
 import { SEARCH_INJECTION_KEY } from 'src/search-injection/constants'
 
 class SearchInjectionContainer extends React.Component {
@@ -12,40 +16,45 @@ class SearchInjectionContainer extends React.Component {
     }
 
     state = {
-        isInjectionEnabled: false,
+        injectionPreference: {
+            google: true,
+            duckduckgo: true,
+        },
     }
 
     async componentDidMount() {
-        const isInjectionEnabled = await getLocalStorage(
+        const injectionPreference = await getLocalStorage(
             SEARCH_INJECTION_KEY,
-            true,
+            SEARCH_INJECTION_DEFAULT,
         )
         this.setState({
-            isInjectionEnabled,
+            injectionPreference,
         })
     }
 
-    async toggleInjection() {
-        const toggled = !this.state.isInjectionEnabled
-        await setLocalStorage(SEARCH_INJECTION_KEY, toggled)
+    async toggleInjection(name) {
+        const { injectionPreference } = this.state
+        // Toggle that field
+        injectionPreference[name] = !injectionPreference[name]
+        await setLocalStorage(SEARCH_INJECTION_KEY, injectionPreference)
 
-        if (!toggled) {
+        if (!injectionPreference[name]) {
             analytics.trackEvent({
                 category: 'Search integration',
                 action: 'Disabled',
-                name: 'Options script',
+                name,
             })
         }
 
         this.setState({
-            isInjectionEnabled: toggled,
+            injectionPreference,
         })
     }
 
     render() {
         return (
             <SearchInjection
-                isInjectionEnabled={this.state.isInjectionEnabled}
+                injectionPreference={this.state.injectionPreference}
                 toggleInjection={this.toggleInjection}
             />
         )

--- a/src/search-injection/components/ResultItem.css
+++ b/src/search-injection/components/ResultItem.css
@@ -37,3 +37,16 @@ for !important */
     white-space: nowrap;
     margin-bottom: 1px;
 }
+
+.duckduckgo {
+    padding-top: 9px;
+    padding-bottom: 9px;
+
+    & .url {
+        margin-top: -16px;
+    }
+
+    & .displayTime {
+        margin-top: -8px;
+    }
+}

--- a/src/search-injection/components/ResultItem.js
+++ b/src/search-injection/components/ResultItem.js
@@ -13,7 +13,7 @@ const ResultItem = props => (
             onClick={props.onLinkClick}
             target="_blank"
         >
-            {props.content.title}
+            {props.title}
         </a>
         <p className={styles.url}>{props.url}</p>
         <div className={styles.displayTime}>
@@ -25,7 +25,7 @@ const ResultItem = props => (
 
 ResultItem.propTypes = {
     searchEngine: PropTypes.string.isRequired,
-    displayTime: PropTypes.string.isRequired,
+    displayTime: PropTypes.number.isRequired,
     url: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     onLinkClick: PropTypes.func.isRequired,

--- a/src/search-injection/components/ResultItem.js
+++ b/src/search-injection/components/ResultItem.js
@@ -1,34 +1,31 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import niceTime from 'src/util/nice-time'
-import { matchURL } from '../utils'
 import classNames from 'classnames'
 
 import styles from './ResultItem.css'
 
-const ResultItem = props => {
-    const searchEngine = matchURL(location.href)
-    return (
-        <div className={classNames(styles.result, styles[searchEngine])}>
-            <a
-                className={styles.title}
-                href={props.url}
-                onClick={props.onLinkClick}
-                target="_blank"
-            >
-                {props.title}
-            </a>
-            <p className={styles.url}>{props.url}</p>
-            <div className={styles.displayTime}>
-                {' '}
-                {niceTime(props.displayTime)}{' '}
-            </div>
+const ResultItem = props => (
+    <div className={classNames(styles.result, styles[props.searchEngine])}>
+        <a
+            className={styles.title}
+            href={props.url}
+            onClick={props.onLinkClick}
+            target="_blank"
+        >
+            {props.content.title}
+        </a>
+        <p className={styles.url}>{props.url}</p>
+        <div className={styles.displayTime}>
+            {' '}
+            {niceTime(+props.displayTime)}{' '}
         </div>
-    )
-}
+    </div>
+)
 
 ResultItem.propTypes = {
-    displayTime: PropTypes.number.isRequired,
+    searchEngine: PropTypes.string.isRequired,
+    displayTime: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     onLinkClick: PropTypes.func.isRequired,

--- a/src/search-injection/components/ResultItem.js
+++ b/src/search-injection/components/ResultItem.js
@@ -1,12 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import niceTime from 'src/util/nice-time'
+import { matchURL } from '../utils'
+import classNames from 'classnames'
 
 import styles from './ResultItem.css'
 
 const ResultItem = props => {
+    const searchEngine = matchURL(location.href)
     return (
-        <div className={styles.result}>
+        <div className={classNames(styles.result, styles[searchEngine])}>
             <a
                 className={styles.title}
                 href={props.url}

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -90,6 +90,7 @@
 
 .duckduckgo_above {
     margin-top: 7px;
+    margin-bottom: 15px;
 
     & .linksContainer {
         margin-top: 4px;
@@ -111,6 +112,7 @@
 
 .duckduckgo_side {
     margin-top: 7px;
+    margin-bottom: 15px;
 
     & .resultsText {
         font-size: 1.05em;

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -68,22 +68,66 @@
     width: 71%;
 }
 
-.above {
+.google_above {
     & .settingsButton {
         right: -10px;
     }
 
     & .resultsText {
         padding-left: 16px;
+        width: 76%;
     }
 }
 
-.side {
+.google_side {
     width: 454px;
 
     & .settingsButton {
         right: -5px;
         top: 14px;
+    }
+}
+
+.duckduckgo_above {
+    margin-top: 4px;
+
+    & .linksContainer {
+        margin-top: 4px;
+        margin-bottom: 8px;
+    }
+
+    & .resultsText {
+        width: 76%;
+    }
+
+    & .settingsButton {
+        top: 6px;
+    }
+
+    & .dropdown {
+        right: 5px;
+    }
+}
+
+.duckduckgo_side {
+    margin-top: 7px;
+
+    & .resultsText {
+        font-size: 1.05em;
+    }
+
+    & .links {
+        font-size: 0.85em;
+    }
+
+    & .settingsButton {
+        right: -4px;
+        top: 9px;
+    }
+
+    & .dropdown {
+        top: 30px;
+        right: 5px;
     }
 }
 

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -6,7 +6,7 @@
     /* Base size of the children elements */
     margin-bottom: 30px;
     position: relative;
-    animation: fadeIn 0.5s ease-in;
+    animation: fadeIn 1s ease-in;
     margin-top: -20px;
 }
 
@@ -64,7 +64,7 @@
     display: inline-block;
     margin-bottom: 3px;
     font-size: 1.1em;
-    font-weight: 100;
+    font-weight: 400;
     width: 71%;
 }
 

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -89,7 +89,7 @@
 }
 
 .duckduckgo_above {
-    margin-top: 4px;
+    margin-top: 7px;
 
     & .linksContainer {
         margin-top: 4px;

--- a/src/search-injection/components/Results.js
+++ b/src/search-injection/components/Results.js
@@ -7,11 +7,12 @@ import styles from './Results.css'
 
 const Results = props => {
     const logoURL = browser.extension.getURL('img/worldbrain-logo-wo-beta.png')
+    const searchEngineClass = `${props.searchEngine}_${props.position}`
     return (
         <div
             className={classNames(
                 styles.MEMEX_CONTAINER,
-                styles[props.position],
+                styles[searchEngineClass],
             )}
         >
             <div className={styles.header}>
@@ -57,6 +58,7 @@ const Results = props => {
 
 Results.propTypes = {
     position: PropTypes.string.isRequired,
+    searchEngine: PropTypes.string.isRequired,
     totalCount: PropTypes.number.isRequired,
     seeMoreResults: PropTypes.func.isRequired,
     toggleHideResults: PropTypes.func.isRequired,

--- a/src/search-injection/components/container.js
+++ b/src/search-injection/components/container.js
@@ -57,6 +57,7 @@ class Container extends React.Component {
             <ResultItem
                 key={i}
                 onLinkClick={this.handleResultLinkClick}
+                searchEngine={this.props.searchEngine}
                 {...result}
             />
         ))
@@ -126,20 +127,23 @@ class Container extends React.Component {
     }
 
     render() {
-        const { position } = this.state
-        const { searchEngine } = this.props
         // If the state.removed is true, show the RemovedText component
         if (this.state.removed)
-            return <RemovedText undo={this.undoRemove} position={position} />
+            return (
+                <RemovedText
+                    undo={this.undoRemove}
+                    position={this.state.position}
+                />
+            )
 
-        if (!position) {
+        if (!this.state.position) {
             return null
         }
 
         return (
             <Results
-                position={position}
-                searchEngine={searchEngine}
+                position={this.state.position}
+                searchEngine={this.props.searchEngine}
                 totalCount={this.props.len}
                 seeMoreResults={this.seeMoreResults}
                 toggleHideResults={this.toggleHideResults}

--- a/src/search-injection/components/container.js
+++ b/src/search-injection/components/container.js
@@ -13,6 +13,7 @@ class Container extends React.Component {
         results: PropTypes.arrayOf(PropTypes.object).isRequired,
         len: PropTypes.number.isRequired,
         rerender: PropTypes.func.isRequired,
+        searchEngine: PropTypes.string.isRequired,
     }
 
     constructor(props) {
@@ -34,6 +35,7 @@ class Container extends React.Component {
         dropdown: false,
         removed: false,
         position: null,
+        searchEngine: '',
     }
 
     async componentDidMount() {
@@ -125,7 +127,7 @@ class Container extends React.Component {
 
     render() {
         const { position } = this.state
-
+        const { searchEngine } = this.props
         // If the state.removed is true, show the RemovedText component
         if (this.state.removed)
             return <RemovedText undo={this.undoRemove} position={position} />
@@ -137,6 +139,7 @@ class Container extends React.Component {
         return (
             <Results
                 position={position}
+                searchEngine={searchEngine}
                 totalCount={this.props.len}
                 seeMoreResults={this.seeMoreResults}
                 toggleHideResults={this.toggleHideResults}

--- a/src/search-injection/constants.js
+++ b/src/search-injection/constants.js
@@ -24,7 +24,7 @@ export const SEARCH_ENGINES = {
             side: 'results--sidebar',
         },
         containerType: 'class',
-    }
+    },
 }
 
 // These are values of the `tbm` query param in Google searches. It denotes

--- a/src/search-injection/constants.js
+++ b/src/search-injection/constants.js
@@ -6,6 +6,7 @@ export const LIMIT = {
 
 // regex - Regular Expression to match the url
 // container - ID of the container to append elements
+// containerType - specify what element type the container is
 
 export const SEARCH_ENGINES = {
     google: {
@@ -14,7 +15,16 @@ export const SEARCH_ENGINES = {
             above: 'center_col',
             side: 'rhs_block',
         },
+        containerType: 'id',
     },
+    duckduckgo: {
+        regex: /(http[s]?:\/\/)?(www.)?duckduckgo[.\w]+\/\?q=.*/,
+        container: {
+            above: 'results--main',
+            side: 'results--sidebar',
+        },
+        containerType: 'class',
+    }
 }
 
 // These are values of the `tbm` query param in Google searches. It denotes

--- a/src/search-injection/constants.js
+++ b/src/search-injection/constants.js
@@ -45,7 +45,7 @@ export const OPEN_OVERVIEW = 'openOverviewURL'
 export const OPEN_OPTIONS = 'openOptionsURL'
 // Storage keys
 export const HIDE_RESULTS_KEY = 'HIDE_MEMEX_RESULTS'
-export const SEARCH_INJECTION_KEY = 'SEARCH_INJECTION_'
+export const SEARCH_INJECTION_KEY = 'SEARCH_INJECTION'
 export const POSITION_KEY = 'RESULTS_POSITION_'
 
 // Default Search Injection Object

--- a/src/search-injection/constants.js
+++ b/src/search-injection/constants.js
@@ -45,5 +45,11 @@ export const OPEN_OVERVIEW = 'openOverviewURL'
 export const OPEN_OPTIONS = 'openOptionsURL'
 // Storage keys
 export const HIDE_RESULTS_KEY = 'HIDE_MEMEX_RESULTS'
-export const SEARCH_INJECTION_KEY = 'SEARCH_INJECTION'
+export const SEARCH_INJECTION_KEY = 'SEARCH_INJECTION_'
 export const POSITION_KEY = 'RESULTS_POSITION_'
+
+// Default Search Injection Object
+export const SEARCH_INJECTION_DEFAULT = {
+    google: true,
+    duckduckgo: true,
+}

--- a/src/search-injection/content_script.js
+++ b/src/search-injection/content_script.js
@@ -40,14 +40,12 @@ const init = async () => {
 
     const searchInjection = await utils.getLocalStorage(
         constants.SEARCH_INJECTION_KEY,
-        true,
+        constants.SEARCH_INJECTION_DEFAULT,
     )
-
-    if (!searchInjection) return
 
     const url = window.location.href
     const matched = utils.matchURL(url)
-    if (matched) {
+    if (matched && searchInjection[matched]) {
         const query = utils.fetchQuery(url)
         search(query)
     }

--- a/src/search-injection/content_script.js
+++ b/src/search-injection/content_script.js
@@ -4,6 +4,9 @@ import { handleRender } from './dom'
 
 import { SEARCH_CONN_NAME, CMDS } from '../overview/constants'
 
+const url = window.location.href
+const matched = utils.matchURL(url)
+
 const cmdHandler = ({ cmd, ...payload }) => {
     // cmd: (string) status of the search result returned
     // payload: (object) contains doc and totalCount
@@ -13,7 +16,7 @@ const cmdHandler = ({ cmd, ...payload }) => {
         case CMDS.RESULTS:
             // Render only if there is atleast one result
             if (payload.searchResult.docs.length) {
-                handleRender(payload.searchResult)
+                handleRender(payload.searchResult, matched)
             }
             break
         case CMDS.ERROR:
@@ -43,8 +46,6 @@ const init = async () => {
         constants.SEARCH_INJECTION_DEFAULT,
     )
 
-    const url = window.location.href
-    const matched = utils.matchURL(url)
     if (matched && searchInjection[matched]) {
         const query = utils.fetchQuery(url)
         search(query)

--- a/src/search-injection/dom.js
+++ b/src/search-injection/dom.js
@@ -36,16 +36,19 @@ export const handleRender = ({ docs, totalCount }) => {
             constants.POSITION_KEY,
             'side',
         )
-        
+
         const currentURL = window.location.href
-        const searchEngine = constants.SEARCH_ENGINES[utils.matchURL(currentURL)]
-        if (!searchEngine) {
+        const searchEngine = utils.matchURL(currentURL)
+        const searchEngineObj = constants.SEARCH_ENGINES[searchEngine]
+        if (!searchEngineObj) {
             return false
         }
-        const containerType = searchEngine.containerType
-        const containerIdentifier = searchEngine.container[position]
-        const container = (containerType === 'class') ? document.getElementsByClassName(containerIdentifier)[0] : document.getElementById(containerIdentifier)
-        
+        const containerType = searchEngineObj.containerType
+        const containerIdentifier = searchEngineObj.container[position]
+        const container =
+            containerType === 'class'
+                ? document.getElementsByClassName(containerIdentifier)[0]
+                : document.getElementById(containerIdentifier)
 
         // If re-rendering remove the already present component
         const component = document.getElementById('memexResults')
@@ -65,6 +68,7 @@ export const handleRender = ({ docs, totalCount }) => {
                 results={docs.slice(0, limit)}
                 len={totalCount}
                 rerender={renderComponent}
+                searchEngine={searchEngine}
             />,
             target,
         )

--- a/src/search-injection/dom.js
+++ b/src/search-injection/dom.js
@@ -36,8 +36,18 @@ export const handleRender = ({ docs, totalCount }) => {
             constants.POSITION_KEY,
             'side',
         )
-        const containerID = constants.SEARCH_ENGINES.google.container[position]
-        const container = document.getElementById(containerID)
+        
+        const searchEngine = utils.matchURL
+        if (!searchEngine) {
+            return false
+        }
+        const containerType = searchEngine.containerType
+        const containerIdentifier = searchEngine.container[position]
+        if (containerType == 'class') {
+            const container = document.getElementsByClassName(containerIdentifier)
+        } else {
+            const container = document.getElementById(containerIdentifier)
+        }
 
         // If re-rendering remove the already present component
         const component = document.getElementById('memexResults')

--- a/src/search-injection/dom.js
+++ b/src/search-injection/dom.js
@@ -37,13 +37,14 @@ export const handleRender = ({ docs, totalCount }) => {
             'side',
         )
         
-        const searchEngine = utils.matchURL
+        const currentURL = window.location.href
+        const searchEngine = constants.SEARCH_ENGINES[utils.matchURL(currentURL)]
         if (!searchEngine) {
             return false
         }
         const containerType = searchEngine.containerType
         const containerIdentifier = searchEngine.container[position]
-        const container = (containerType === 'class') ? document.getElementsByClassName(containerIdentifier) : document.getElementById(containerIdentifier)
+        const container = (containerType === 'class') ? document.getElementsByClassName(containerIdentifier)[0] : document.getElementById(containerIdentifier)
         
 
         // If re-rendering remove the already present component

--- a/src/search-injection/dom.js
+++ b/src/search-injection/dom.js
@@ -43,11 +43,8 @@ export const handleRender = ({ docs, totalCount }) => {
         }
         const containerType = searchEngine.containerType
         const containerIdentifier = searchEngine.container[position]
-        if (containerType == 'class') {
-            const container = document.getElementsByClassName(containerIdentifier)
-        } else {
-            const container = document.getElementById(containerIdentifier)
-        }
+        const container = (containerType === 'class') ? document.getElementsByClassName(containerIdentifier) : document.getElementById(containerIdentifier)
+        
 
         // If re-rendering remove the already present component
         const component = document.getElementById('memexResults')

--- a/src/search-injection/dom.js
+++ b/src/search-injection/dom.js
@@ -21,7 +21,7 @@ export const injectCSS = file => {
     d.prepend(link)
 }
 
-export const handleRender = ({ docs, totalCount }) => {
+export const handleRender = ({ docs, totalCount }, searchEngine) => {
     // docs: (array of objects) returned by the search
     // totalCount: (int) number of results found
     // Injects CSS into the search page.
@@ -37,8 +37,6 @@ export const handleRender = ({ docs, totalCount }) => {
             'side',
         )
 
-        const currentURL = window.location.href
-        const searchEngine = utils.matchURL(currentURL)
         const searchEngineObj = constants.SEARCH_ENGINES[searchEngine]
         if (!searchEngineObj) {
             return false

--- a/src/search-injection/utils.test.js
+++ b/src/search-injection/utils.test.js
@@ -4,22 +4,46 @@ import * as utils from './utils'
 
 describe('URL', () => {
     const URLS = {
-        simple: 'https://www.google.com/search?q=test',
-        complex:
-            'https://www.google.co.in/search?q=test+with+space&rlz=1C5CHFA_enIN722IN722&oq=test&aqs=chrome..69i57j69i60l4j69i65.13361j0j1&sourceid=chrome&ie=UTF-8',
-        nomatch: 'https://www.google.com/ie=UTF-8&&sourceid=chrome',
+        google: {
+            simple: 'https://www.google.com/search?q=test',
+            spacedquery:
+                'https://www.google.co.in/search?q=test+with+space&sourceid=chrome&ie=UTF-8',
+            nomatch: 'https://www.google.com/ie=UTF-8&&sourceid=chrome',
+            image: 'https://www.google.co.in/search?q=test&tbm=isch',
+            maps:
+                'https://www.google.co.in/search?q=chennai+hotels&sa=X&ved=0ahUKEwi9rqGEtbLaAhWJpI8KHVJvAyEQri4I1wEwFw&tbm=lcl',
+        },
+        ddg: {
+            simple: 'https://duckduckgo.com/?q=test&t=canonical&ia=web',
+            spacedquery: 'https://duckduckgo.com/?q=spaced+query&t=hb&ia=qa',
+            nomatch: 'https://duckduckgo.com/?t=canonical&ia=web',
+        },
     }
 
-    test('should match url', () => {
-        const result1 = utils.matchURL(URLS.simple)
-        const result2 = utils.matchURL(URLS.complex)
-        expect(result1).toBe('google')
-        expect(result2).toBe('google')
+    test('should match google url', () => {
+        expect(utils.matchURL(URLS.google.simple)).toBe('google')
+        expect(utils.matchURL(URLS.google.spacedquery)).toBe('google')
+    })
+
+    test('should match duckduckgo url', () => {
+        expect(utils.matchURL(URLS.ddg.simple)).toBe('duckduckgo')
+        expect(utils.matchURL(URLS.ddg.spacedquery)).toBe('duckduckgo')
     })
 
     test('should not match url', () => {
-        const result = utils.matchURL(URLS.nomatch)
-        expect(result).toBeFalsy()
+        expect(utils.matchURL(URLS.google.nomatch)).toBeFalsy()
+        expect(utils.matchURL(URLS.google.image)).toBeFalsy()
+        expect(utils.matchURL(URLS.google.maps)).toBeFalsy()
+        expect(utils.matchURL(URLS.ddg.nomatch)).toBeFalsy()
+    })
+
+    test('should fetch query', () => {
+        expect(utils.fetchQuery(URLS.google.simple)).toBe('test')
+        expect(utils.fetchQuery(URLS.google.spacedquery)).toBe(
+            'test with space',
+        )
+        expect(utils.fetchQuery(URLS.ddg.simple)).toBe('test')
+        expect(utils.fetchQuery(URLS.ddg.spacedquery)).toBe('spaced query')
     })
 })
 


### PR DESCRIPTION
Thanks to @heliostatic's for his base work. :) 
Forked from #352. 

- Injected Memex results into DuckDuckGo and prettified.
_Above_
![image](https://user-images.githubusercontent.com/3889675/38452924-072becc4-3a6b-11e8-8d74-be021e269bfa.png)
_Side_
![image](https://user-images.githubusercontent.com/3889675/38452908-e917eb3e-3a6a-11e8-869b-e5ea34064c60.png)

- Added DuckDuckGo tick to the Settings
_By default they are both ticked_
![image](https://user-images.githubusercontent.com/3889675/38452930-444bf432-3a6b-11e8-9fb8-9b01b51eee27.png)


> A suggestion would be to move Memex results after the extended filter bar (class=search-filters-wrap) and before the results list

Possible, but would require the box to appended differently into google and ddg container. Is it necessary?

@oliversauter @poltak 