### PR TITLE
Fix Google/DDG search UI persisting incorrect state shape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldbrain-extension",
-  "version": "0.1.1",
+  "version": "0.1.6",
   "homepage": "https://worldbrain.io",
   "license": "MIT",
   "repository": {

--- a/src/search-injection/components/container.js
+++ b/src/search-injection/components/container.js
@@ -35,7 +35,6 @@ class Container extends React.Component {
         dropdown: false,
         removed: false,
         position: null,
-        searchEngine: '',
     }
 
     async componentDidMount() {
@@ -94,11 +93,29 @@ class Container extends React.Component {
         }))
     }
 
+    /**
+     * Handles persisting the enabled (removed) state for current search engine, without affecting other
+     * search engine preferences.
+     *
+     * @param {boolean} isEnabled
+     */
+    async _persistEnabledChange(isEnabled) {
+        const prevState = await getLocalStorage(
+            constants.SEARCH_INJECTION_KEY,
+            constants.SEARCH_INJECTION_DEFAULT,
+        )
+
+        await setLocalStorage(constants.SEARCH_INJECTION_KEY, {
+            ...prevState,
+            [this.props.searchEngine]: isEnabled,
+        })
+    }
+
     async removeResults() {
         // Sets the search injection key to false
         // And sets removed state to true
         // Triggering the Removed text UI to pop up
-        await setLocalStorage(constants.SEARCH_INJECTION_KEY, false)
+        await this._persistEnabledChange(false)
 
         this.trackEvent({
             category: 'Search integration',
@@ -113,10 +130,9 @@ class Container extends React.Component {
     }
 
     async undoRemove() {
-        await setLocalStorage(constants.SEARCH_INJECTION_KEY, true)
-        this.setState({
-            removed: false,
-        })
+        await this._persistEnabledChange(true)
+
+        this.setState({ removed: false })
     }
 
     async changePosition() {


### PR DESCRIPTION
- seems like the local storage setting functions, called when the user removes/undos results, weren't updated to the new shape introduced with DDG support (still using the "google-only" shape)
- updated it to make sure to just update the persisted state of the current search engine within the stored object (search engines => bool flags)

Looking at this now, it is super obvious, and really should have been picked up in all the reviews and manual testing we all did on #362. That's the way things go sometimes, I suppose 😄 at least only a small fix needed.

Note that effected users - those who have pressed "remove results" on google/ddg - will now have the wrong state shape stored in local storage, but @digi0ps migration code should catch this and convert it over when we push the next update (tired with a forced update to this branch build from `master`) 👍 

@oliversauter I also updated the version # in `package.json`. I saw in 8dc25548a21ceb9621e98176892f6cd953aed270 you updated the `src/manifest.json` version number directly, but I think the way @ShishKabab set it up (correct me if I'm wrong) is to use the `package.json` as the source of truth, then Gulp will automatically update the `src/manifest.json` for you. If they're out of sync, Gulp will keep changing them which can be a little bit annoying to deal with in dev (git will constantly bug you about the change)
