### PR TITLE
Fix inconsistency in Pouch doc title path

### DIFF
--- a/src/search-injection/content_script.js
+++ b/src/search-injection/content_script.js
@@ -34,7 +34,7 @@ const search = query => {
     const port = browser.runtime.connect({ name: SEARCH_CONN_NAME })
     port.onMessage.addListener(cmdHandler)
 
-    port.postMessage({ cmd: CMDS.SEARCH, searchParams: { query } })
+    port.postMessage({ cmd: CMDS.SEARCH, searchParams: { query, limit: 5 } })
 }
 
 const init = async () => {

--- a/src/search/search-index-old/map-search-to-pouch.js
+++ b/src/search/search-index-old/map-search-to-pouch.js
@@ -124,6 +124,7 @@ export default async function mapResultsToPouchDocs(results, searchParams) {
         pageDocs.map(async ({ _attachments, ...doc }) => ({
             ...doc,
             ...(await processAttachments({ _attachments, ...doc })),
+            title: doc.content.title || doc.title,
             hasBookmark: resultsMap.get(doc._id).hasBookmark,
             displayTime: resultsMap.get(doc._id).timestamp,
             tags: resultsMap.get(doc._id).tags.map(removeKeyType),

--- a/src/search/search-index-old/pipeline.js
+++ b/src/search/search-index-old/pipeline.js
@@ -150,16 +150,14 @@ export default async function pipeline({
 
     // Ensure a pouch page doc exists for current page
     let newPage = false
-    try {
-        await db.get(id)
-    } catch (err) {
-        if (err.status === 404) {
-            newPage = true
-            await db.put({ _id: id, url, title: content.title, content })
-        } else {
+    await db.get(id).catch(err => {
+        if (err.status !== 404) {
             throw err
         }
-    }
+
+        newPage = true
+        return db.put({ _id: id, url, content })
+    })
 
     if (favIconURI) {
         await handleAttachment(id, 'favIcon', favIconURI)


### PR DESCRIPTION
- bug with the old index shaping pouch docs slightly differently depending on use-case
- title meant to be stored on `content.title`, but some new docs would also get it store on `title`
- the search would only check `title`; this leads to missing titles in search results (even though the data is still there in `content.title`)
- now ensuring all pouch add/update logic saves title only to `content.title`
- search-pouch mapping now falls back to `title`
- also set an explicit limit on the search-engine injection search request; we were asking for 2x the needed results before (display only shows 4/5)