### PR TITLE
Close Search Injection dropdown when clicked outside.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-datepicker": "^0.55.0",
     "react-dom": "^16.0.0",
     "react-helmet": "^5.2.0",
+    "react-onclickoutside": "^6.7.1",
     "react-redux": "^5.0.5",
     "react-router": "^3.2.0",
     "react-slick": "^0.15.4",

--- a/src/search-injection/components/Dropdown.js
+++ b/src/search-injection/components/Dropdown.js
@@ -12,27 +12,56 @@ const openSettings = () => {
     browser.runtime.sendMessage(message)
 }
 
-const Dropdown = props => {
-    return (
-        <div className={styles.dropdownContainer}>
-            <ul className={styles.dropdown}>
-                <li className={styles.dropdownElement} onClick={openSettings}>
-                    Settings
-                </li>
-                <li className={styles.dropdownElement} onClick={props.rerender}>
-                    Change position of Memex
-                </li>
-                <li className={styles.dropdownElement} onClick={props.remove}>
-                    Remove Results Forever
-                </li>
-            </ul>
-        </div>
-    )
-}
+class Dropdown extends React.Component {
+    static propTypes = {
+        remove: PropTypes.func.isRequired,
+        rerender: PropTypes.func.isRequired,
+        closeDropdown: PropTypes.func.isRequired,
+    }
 
-Dropdown.propTypes = {
-    remove: PropTypes.func.isRequired,
-    rerender: PropTypes.func.isRequired,
+    componentDidMount() {
+        document.addEventListener('click', this.handleOutsideClick)
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('click', this.handleOutsideClick)
+    }
+
+    handleOutsideClick = e => {
+        if (this.dropdownRef && !this.dropdownRef.contains(e.target))
+            this.props.closeDropdown()
+    }
+
+    setDropdownRef = node => {
+        this.dropdownRef = node
+    }
+
+    render() {
+        return (
+            <div ref={this.setDropdownRef} className={styles.dropdownContainer}>
+                <ul className={styles.dropdown}>
+                    <li
+                        className={styles.dropdownElement}
+                        onClick={openSettings}
+                    >
+                        Settings
+                    </li>
+                    <li
+                        className={styles.dropdownElement}
+                        onClick={this.props.rerender}
+                    >
+                        Change position of Memex
+                    </li>
+                    <li
+                        className={styles.dropdownElement}
+                        onClick={this.props.remove}
+                    >
+                        Remove Results Forever
+                    </li>
+                </ul>
+            </div>
+        )
+    }
 }
 
 export default Dropdown

--- a/src/search-injection/components/Dropdown.js
+++ b/src/search-injection/components/Dropdown.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import onClickOutside from 'react-onclickoutside'
 
 import { OPEN_OPTIONS } from '../constants'
 import styles from './Dropdown.css'
@@ -19,26 +20,13 @@ class Dropdown extends React.Component {
         closeDropdown: PropTypes.func.isRequired,
     }
 
-    componentDidMount() {
-        document.addEventListener('click', this.handleOutsideClick)
-    }
-
-    componentWillUnmount() {
-        document.removeEventListener('click', this.handleOutsideClick)
-    }
-
-    handleOutsideClick = e => {
-        if (this.dropdownRef && !this.dropdownRef.contains(e.target))
-            this.props.closeDropdown()
-    }
-
-    setDropdownRef = node => {
-        this.dropdownRef = node
+    handleClickOutside = () => {
+        this.props.closeDropdown()
     }
 
     render() {
         return (
-            <div ref={this.setDropdownRef} className={styles.dropdownContainer}>
+            <div className={styles.dropdownContainer}>
                 <ul className={styles.dropdown}>
                     <li
                         className={styles.dropdownElement}
@@ -64,4 +52,4 @@ class Dropdown extends React.Component {
     }
 }
 
-export default Dropdown
+export default onClickOutside(Dropdown)

--- a/src/search-injection/components/Results.js
+++ b/src/search-injection/components/Results.js
@@ -37,12 +37,13 @@ const Results = props => {
                 </div>
                 <button
                     className={styles.settingsButton}
-                    onClick={props.toggleDropDown}
+                    onClick={props.toggleDropdown}
                 />
                 {props.dropdown ? (
                     <Dropdown
                         remove={props.removeResults}
                         rerender={props.changePosition}
+                        closeDropdown={props.closeDropdown}
                     />
                 ) : (
                     ''
@@ -63,7 +64,8 @@ Results.propTypes = {
     seeMoreResults: PropTypes.func.isRequired,
     toggleHideResults: PropTypes.func.isRequired,
     hideResults: PropTypes.bool.isRequired,
-    toggleDropDown: PropTypes.func.isRequired,
+    toggleDropdown: PropTypes.func.isRequired,
+    closeDropdown: PropTypes.func.isRequired,
     dropdown: PropTypes.bool.isRequired,
     removeResults: PropTypes.func.isRequired,
     changePosition: PropTypes.func.isRequired,

--- a/src/search-injection/components/container.js
+++ b/src/search-injection/components/container.js
@@ -21,7 +21,8 @@ class Container extends React.Component {
         this.renderResultItems = this.renderResultItems.bind(this)
         this.seeMoreResults = this.seeMoreResults.bind(this)
         this.toggleHideResults = this.toggleHideResults.bind(this)
-        this.toggleDropDown = this.toggleDropDown.bind(this)
+        this.toggleDropdown = this.toggleDropdown.bind(this)
+        this.closeDropdown = this.closeDropdown.bind(this)
         this.removeResults = this.removeResults.bind(this)
         this.undoRemove = this.undoRemove.bind(this)
         this.changePosition = this.changePosition.bind(this)
@@ -86,11 +87,17 @@ class Container extends React.Component {
         })
     }
 
-    toggleDropDown() {
+    toggleDropdown() {
         this.setState(state => ({
             ...state,
             dropdown: !state.dropdown,
         }))
+    }
+
+    closeDropdown() {
+        this.setState({
+            dropdown: false,
+        })
     }
 
     /**
@@ -164,7 +171,8 @@ class Container extends React.Component {
                 seeMoreResults={this.seeMoreResults}
                 toggleHideResults={this.toggleHideResults}
                 hideResults={this.state.hideResults}
-                toggleDropDown={this.toggleDropDown}
+                toggleDropdown={this.toggleDropdown}
+                closeDropdown={this.closeDropdown}
                 dropdown={this.state.dropdown}
                 removeResults={this.removeResults}
                 changePosition={this.changePosition}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7990,6 +7990,10 @@ react-onclickoutside@^6.1.1:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.6.0.tgz#8526d0675fad26558e9f0a400c983b813c99ef3c"
 
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-popper@^0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.3.tgz#fa2809a80fbe7ec516e9bac01d81bc47a8b5cd3b"


### PR DESCRIPTION
When *Dropdown* component is mounted, it attaches an eventListener to the document which sets the `dropdown` state to `false`, which closes the dropdown.

When the *Dropdown* component is unmounted the eventListener is removed. 

Is there any better method for this? 
@poltak @oliversauter @ShishKabab 