### PR TITLE
Allow google/DDG results to fall back to URL if no title

### DIFF
--- a/src/search-injection/components/ResultItem.js
+++ b/src/search-injection/components/ResultItem.js
@@ -13,7 +13,7 @@ const ResultItem = props => (
             onClick={props.onLinkClick}
             target="_blank"
         >
-            {props.title}
+            {props.title || props.url}
         </a>
         <p className={styles.url}>{props.url}</p>
         <div className={styles.displayTime}>


### PR DESCRIPTION
- in some cases, where a page's title cannot be extracted (most websites work fine, PDFs depend on how the pdf metadata was set up) overview results will fallback to displaying URL for title
- search injection result views didn't have this fallback, leading to minor inconsistencies and not being able to click the result