### PR TITLE
Misc. sentry additions + fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prop-types": "^15.5.10",
     "query-string": "^4.3.4",
     "queue": "^4.4.1",
+    "raven-for-redux": "^1.3.1",
     "raven-js": "^3.23.3",
     "react": "^16.0.0",
     "react-datepicker": "^0.55.0",

--- a/src/activity-logger/background/index.js
+++ b/src/activity-logger/background/index.js
@@ -29,11 +29,12 @@ browser.tabs.onActivated.addListener(({ tabId }) =>
 
 // Runs stage 3 of the visit indexing
 browser.tabs.onRemoved.addListener(tabId => {
-    try {
-        // Remove tab from tab tracking state and update the visit with tab-derived metadata
-        const tab = tabManager.removeTab(tabId)
+    // Remove tab from tab tracking state and update the visit with tab-derived metadata
+    const tab = tabManager.removeTab(tabId)
+
+    if (tab != null) {
         updateVisitInteractionData(tab)
-    } catch (error) {}
+    }
 })
 
 /**

--- a/src/activity-logger/background/tab-change-listeners.ts
+++ b/src/activity-logger/background/tab-change-listeners.ts
@@ -21,6 +21,7 @@ export const handleVisitEnd: TabChangeListener = async function(
 
     // Send off request for updating that prev. visit's tab state, if active long enough
     if (
+        oldTab != null &&
         oldTab.url !== url &&
         oldTab.activeTime > fauxVisitThreshold &&
         (await shouldLogTab({ url: oldTab.url, incognito } as Tabs.Tab))

--- a/src/activity-logger/background/tab-manager.js
+++ b/src/activity-logger/background/tab-manager.js
@@ -18,16 +18,10 @@ export class TabManager {
 
     /**
      * @param {number} id The ID of the tab as assigned by web ext API.
-     * @returns {Tab} The state for tab stored under given ID.
-     * @throws {Error} If input `id` does not correspond to any tab stored in state.
+     * @returns {Tab|undefined} The state for tab stored under given ID, or undefined if no matching tab.
      */
     getTabState(id) {
-        const tab = this._tabs.get(id)
-        if (tab == null) {
-            throw new Error(`No tab stored under ID: ${id}`)
-        }
-
-        return tab
+        return this._tabs.get(id)
     }
 
     /**
@@ -36,11 +30,15 @@ export class TabManager {
      */
     removeTab(id) {
         const toRemove = this.getTabState(id)
-        toRemove.cancelPendingOps()
-        this._tabs.delete(id)
 
-        // If still active when closed, toggle active state to force time recalc
-        toRemove.toggleActiveState()
+        if (toRemove != null) {
+            toRemove.cancelPendingOps()
+            this._tabs.delete(id)
+
+            // If still active when closed, toggle active state to force time recalc
+            toRemove.toggleActiveState()
+        }
+
         return toRemove
     }
 
@@ -52,14 +50,18 @@ export class TabManager {
      */
     resetTab(id, activeState, url) {
         const oldTab = this.removeTab(id)
-        this._tabs.set(
-            id,
-            new Tab({
-                isActive: activeState,
-                navState: oldTab.navState,
-                url,
-            }),
-        )
+
+        if (oldTab != null) {
+            this._tabs.set(
+                id,
+                new Tab({
+                    isActive: activeState,
+                    navState: oldTab.navState,
+                    url,
+                }),
+            )
+        }
+
         return oldTab
     }
 
@@ -82,17 +84,19 @@ export class TabManager {
      * @param {() => Promise<void>} cb The page log logic to delay.
      */
     scheduleTabLog(id, logCb) {
-        try {
-            const tab = this.getTabState(id)
+        const tab = this.getTabState(id)
+
+        if (tab != null) {
             tab.scheduleLog(logCb)
-        } catch (err) {}
+        }
     }
 
     clearScheduledLog(id) {
-        try {
-            const tab = this.getTabState(id)
+        const tab = this.getTabState(id)
+
+        if (tab != null) {
             tab.cancelPendingOps()
-        } catch (err) {}
+        }
     }
 
     /**
@@ -100,10 +104,11 @@ export class TabManager {
      * @param {any} newState The new scroll state to set.
      */
     updateTabScrollState(id, newState) {
-        try {
-            const tab = this.getTabState(id)
+        const tab = this.getTabState(id)
+
+        if (tab != null) {
             tab.scrollState.updateState(newState)
-        } catch (err) {}
+        }
     }
 
     /**
@@ -112,10 +117,11 @@ export class TabManager {
      *  and ` webNavigation.TransitionType` under `type` prop.
      */
     updateNavState(id, navState) {
-        try {
-            const tab = this.getTabState(id)
+        const tab = this.getTabState(id)
+
+        if (tab != null) {
             tab.navState = navState
-        } catch (err) {}
+        }
     }
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,4 @@
 import urlRegex from 'url-regex'
-import Raven from 'raven-js'
 
 import 'src/activity-logger/background'
 import 'src/search/background'
@@ -21,15 +20,13 @@ import {
 import db from 'src/search/search-index-new'
 import * as models from 'src/search/search-index-new/models'
 import 'src/search/migration'
+import initSentry from './util/raven'
 
 window.index = searchIndex
 window.storage = db
 window.indexModels = models
 
-// Set up the sentry runtime error config
-if (process.env.SENTRY_DSN) {
-    Raven.config(process.env.SENTRY_DSN).install()
-}
+initSentry()
 
 export const OVERVIEW_URL = '/overview/overview.html'
 export const OPTIONS_URL = '/options/options.html'

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,6 @@
 import urlRegex from 'url-regex'
+import Raven from 'raven-js'
+
 import 'src/activity-logger/background'
 import 'src/search/background'
 import 'src/analytics/background'
@@ -23,6 +25,11 @@ import 'src/search/migration'
 window.index = searchIndex
 window.storage = db
 window.indexModels = models
+
+// Set up the sentry runtime error config
+if (process.env.SENTRY_DSN) {
+    Raven.config(process.env.SENTRY_DSN).install()
+}
 
 export const OVERVIEW_URL = '/overview/overview.html'
 export const OPTIONS_URL = '/options/options.html'

--- a/src/common-ui/components/Overlay.js
+++ b/src/common-ui/components/Overlay.js
@@ -34,7 +34,9 @@ class Overlay extends Component {
     }
 
     componentWillUnmount() {
-        document.body.removeChild(this.overlayRoot)
+        if (document.body.contains(this.overlayRoot)) {
+            document.body.removeChild(this.overlayRoot)
+        }
     }
 
     handleClick = event =>

--- a/src/options/acknowledgement/components/content.jsx
+++ b/src/options/acknowledgement/components/content.jsx
@@ -56,15 +56,13 @@ const AcknowledgementContainer = () => (
         <h3 className={localStyles.title}>
             A list of people who made meaningful contributions
         </h3>
-        <p>
+        <div>
             Only because of these people, the WorldBrain/Memex project can
             exist. We are deeply thankful for the hours of work & the passion
             they contributed to this project.
             <br />
             <br />
             <img src={'/../../../../img/thanks.gif'} />
-        </p>
-        <p>
             <h4 className={localStyles.title}>Contributors</h4>
             <ul className={localStyles.ul}>
                 <li>
@@ -161,7 +159,7 @@ const AcknowledgementContainer = () => (
                     <b>Digital Science</b> | 5.500 €
                 </li>
             </ul>
-        </p>
+        </div>
     </div>
 )
 

--- a/src/options/acknowledgement/components/styles.css
+++ b/src/options/acknowledgement/components/styles.css
@@ -34,6 +34,7 @@
     list-style-type: none;
     width: 80%;
     color: #777;
+    font-size: 16px;
 }
 
 .li {

--- a/src/options/options.jsx
+++ b/src/options/options.jsx
@@ -3,7 +3,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Router, Route, IndexRedirect, hashHistory } from 'react-router'
 import { Provider } from 'react-redux'
-import Raven from 'raven-js'
 
 import { ErrorBoundary, RuntimeError } from 'src/common-ui/components'
 import { withPageTracking } from 'src/common-ui/hocs'
@@ -16,11 +15,6 @@ const ReduxDevTools =
     process.env.NODE_ENV !== 'production'
         ? require('src/dev/redux-devtools-component').default
         : undefined
-
-// Set up the sentry runtime error config
-if (process.env.SENTRY_DSN) {
-    Raven.config(process.env.SENTRY_DSN).install()
-}
 
 const store = configureStore({ ReduxDevTools })
 

--- a/src/options/store.js
+++ b/src/options/store.js
@@ -1,8 +1,7 @@
 import { createStore, combineReducers, compose, applyMiddleware } from 'redux'
-import Raven from 'raven-js'
-import createRavenMiddleware from 'raven-for-redux'
 import thunk from 'redux-thunk'
 
+import initSentry from '../util/raven'
 import * as imports from './imports'
 import * as blacklist from './blacklist'
 import * as privacy from './privacy'
@@ -16,11 +15,7 @@ const rootReducer = combineReducers({
 export default function configureStore({ ReduxDevTools = undefined } = {}) {
     const middlewares = [thunk]
 
-    // Set up the sentry runtime error config + redux middleware
-    if (process.env.SENTRY_DSN) {
-        Raven.config(process.env.SENTRY_DSN).install()
-        middlewares.push(createRavenMiddleware(Raven))
-    }
+    initSentry(middlewares)
 
     const enhancers = [
         imports.enhancer,

--- a/src/options/store.js
+++ b/src/options/store.js
@@ -1,4 +1,6 @@
 import { createStore, combineReducers, compose, applyMiddleware } from 'redux'
+import Raven from 'raven-js'
+import createRavenMiddleware from 'raven-for-redux'
 import thunk from 'redux-thunk'
 
 import * as imports from './imports'
@@ -12,10 +14,18 @@ const rootReducer = combineReducers({
 })
 
 export default function configureStore({ ReduxDevTools = undefined } = {}) {
+    const middlewares = [thunk]
+
+    // Set up the sentry runtime error config + redux middleware
+    if (process.env.SENTRY_DSN) {
+        Raven.config(process.env.SENTRY_DSN).install()
+        middlewares.push(createRavenMiddleware(Raven))
+    }
+
     const enhancers = [
         imports.enhancer,
         privacy.enhancer,
-        applyMiddleware(thunk),
+        applyMiddleware(...middlewares),
     ]
 
     if (ReduxDevTools) {

--- a/src/overview/container.js
+++ b/src/overview/container.js
@@ -34,7 +34,7 @@ class OverviewContainer extends Component {
         showInitSearchMsg: PropTypes.bool.isRequired,
         resetActiveTagIndex: PropTypes.func.isRequired,
         searchResults: PropTypes.arrayOf(PropTypes.object).isRequired,
-        totalResultCount: PropTypes.number.isRequired,
+        totalResultCount: PropTypes.number,
         shouldShowCount: PropTypes.bool.isRequired,
         needsWaypoint: PropTypes.bool.isRequired,
         handleTrashBtnClick: PropTypes.func.isRequired,

--- a/src/overview/enhancer.js
+++ b/src/overview/enhancer.js
@@ -10,7 +10,6 @@ import {
     constants as onboardingConsts,
 } from './onboarding'
 import { selectors as filters, actions as filterActs } from './filters'
-import { SHOULD_TRACK_STORAGE_KEY } from 'src/options/privacy/constants'
 
 const parseBool = str => str === 'true'
 
@@ -73,7 +72,6 @@ const hydrateStateFromStorage = store => {
         onboardingActs.setImportsDone,
     )
     hydrate(onboardingConsts.STORAGE_KEYS.progress, onboardingActs.setProgress)
-    hydrate(SHOULD_TRACK_STORAGE_KEY, onboardingActs.setShouldTrack)
     hydrate(constants.SHOW_TOOL_TIP, actions.setShowTooltip)
     hydrate(constants.TOOL_TIP, actions.setTooltip)
 }
@@ -90,7 +88,6 @@ const syncStateToStorage = store =>
             onboarding.isImportsDone(state),
         )
         dump(onboardingConsts.STORAGE_KEYS.progress, onboarding.progress(state))
-        dump(SHOULD_TRACK_STORAGE_KEY, onboarding.shouldTrack(state))
         dump(constants.SHOW_TOOL_TIP, selectors.showTooltip(state))
         dump(constants.TOOL_TIP, selectors.tooltip(state))
     })

--- a/src/overview/onboarding/reducer.js
+++ b/src/overview/onboarding/reducer.js
@@ -18,10 +18,6 @@ export default createReducer(
             ...state,
             shouldTrack,
         }),
-        [actions.toggleShouldTrack]: state => ({
-            ...state,
-            shouldTrack: !state.shouldTrack,
-        }),
         [actions.setVisible]: (state, isVisible) => ({ ...state, isVisible }),
         [actions.setProgress]: (state, progress) => ({ ...state, progress }),
         [actions.incProgress]: (state, inc = 1) => ({

--- a/src/overview/overview.jsx
+++ b/src/overview/overview.jsx
@@ -2,7 +2,6 @@ import 'babel-polyfill'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import Raven from 'raven-js'
 
 import overview from 'src/overview'
 import { ErrorBoundary, RuntimeError } from 'src/common-ui/components'
@@ -14,11 +13,6 @@ import './base.css'
 let ReduxDevTools
 if (process.env.NODE_ENV !== 'production') {
     ReduxDevTools = require('src/dev/redux-devtools-component').default
-}
-
-// Set up the sentry runtime error config
-if (process.env.SENTRY_DSN) {
-    Raven.config(process.env.SENTRY_DSN).install()
 }
 
 // Set up the Redux store

--- a/src/overview/store.js
+++ b/src/overview/store.js
@@ -1,10 +1,9 @@
 import 'core-js/fn/object/values' // shim Object.values for Chromium<54
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
 import { createEpicMiddleware, combineEpics } from 'redux-observable'
-import Raven from 'raven-js'
-import createRavenMiddleware from 'raven-for-redux'
 import thunk from 'redux-thunk'
 
+import initSentry from '../util/raven'
 import overview from 'src/overview'
 import { reducer as onboarding } from 'src/overview/onboarding'
 import { reducer as filters } from 'src/overview/filters'
@@ -38,11 +37,7 @@ const stateTransformer = ({ overview, ...state }) => ({
 export default function configureStore({ ReduxDevTools = undefined } = {}) {
     const middlewares = [createEpicMiddleware(rootEpic), thunk]
 
-    // Set up the sentry runtime error config + redux middleware
-    if (process.env.SENTRY_DSN) {
-        Raven.config(process.env.SENTRY_DSN).install()
-        middlewares.push(createRavenMiddleware(Raven, { stateTransformer }))
-    }
+    initSentry(middlewares, stateTransformer)
 
     const enhancers = [overview.enhancer, applyMiddleware(...middlewares)]
     if (ReduxDevTools) {

--- a/src/overview/store.js
+++ b/src/overview/store.js
@@ -1,6 +1,8 @@
 import 'core-js/fn/object/values' // shim Object.values for Chromium<54
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
 import { createEpicMiddleware, combineEpics } from 'redux-observable'
+import Raven from 'raven-js'
+import createRavenMiddleware from 'raven-for-redux'
 import thunk from 'redux-thunk'
 
 import overview from 'src/overview'
@@ -16,10 +18,15 @@ const rootReducer = combineReducers({
 const rootEpic = combineEpics(...Object.values(overview.epics))
 
 export default function configureStore({ ReduxDevTools = undefined } = {}) {
-    const enhancers = [
-        overview.enhancer,
-        applyMiddleware(createEpicMiddleware(rootEpic), thunk),
-    ]
+    const middlewares = [createEpicMiddleware(rootEpic), thunk]
+
+    // Set up the sentry runtime error config + redux middleware
+    if (process.env.SENTRY_DSN) {
+        Raven.config(process.env.SENTRY_DSN).install()
+        middlewares.push(createRavenMiddleware(Raven))
+    }
+
+    const enhancers = [overview.enhancer, applyMiddleware(...middlewares)]
     if (ReduxDevTools) {
         enhancers.push(ReduxDevTools.instrument())
     }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,14 +1,12 @@
 import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
-import Raven from 'raven-js'
 
+import initSentry from '../util/raven'
 import { ErrorBoundary, RuntimeError } from 'src/common-ui/components'
 import Popup from './container'
 
-if (process.env.SENTRY_DSN) {
-    Raven.config(process.env.SENTRY_DSN).install()
-}
+initSentry()
 
 render(
     <ErrorBoundary component={RuntimeError}>

--- a/src/util/raven.ts
+++ b/src/util/raven.ts
@@ -1,0 +1,44 @@
+import { browser, Storage } from 'webextension-polyfill-ts'
+import * as AllRaven from 'raven-js'
+import createRavenMiddleware from 'raven-for-redux'
+
+import { storageChangesManager } from './storage-changes'
+import { SHOULD_TRACK_STORAGE_KEY as SHOULD_TRACK } from '../options/privacy/constants'
+
+// Issue with the export being a default but something with our tsconfig; TODO
+const Raven = AllRaven['default'] as AllRaven.RavenStatic
+let sentryEnabled = false
+
+// Init the enabled state based on stored flag
+browser.storage.local
+    .get(SHOULD_TRACK)
+    .then(storage => (sentryEnabled = !!storage[SHOULD_TRACK]))
+
+// Update global tracking flag every time stored flag changes
+storageChangesManager.addListener(
+    'local',
+    SHOULD_TRACK,
+    ({ newValue }) => (sentryEnabled = newValue),
+)
+
+/**
+ * Inits Sentry's JS client Raven. Optionally supports adding redux middleware,
+ * if middleware array passed in. Note this array will be updated.
+ */
+export default function initSentry(
+    reduxMiddlewares?: Function[],
+    stateTransformer = f => f,
+) {
+    if (process.env.SENTRY_DSN) {
+        Raven.config(process.env.SENTRY_DSN, {
+            shouldSendCallback: () => sentryEnabled,
+        }).install()
+
+        // If defined, add raven middleware to passed-in middlewares
+        if (reduxMiddlewares) {
+            reduxMiddlewares.push(
+                createRavenMiddleware(Raven, { stateTransformer }),
+            )
+        }
+    }
+}

--- a/src/util/storage-changes.test.ts
+++ b/src/util/storage-changes.test.ts
@@ -1,0 +1,91 @@
+import { browser, Storage } from 'webextension-polyfill-ts'
+
+import { storageChangesManager, StorageAreaName } from './storage-changes'
+
+const storageAreas: StorageAreaName[] = ['sync', 'local', 'managed']
+const testKeyA = 'testA'
+const testKeyB = 'testB'
+
+describe('Storage changes listeners manager', () =>
+    storageAreas.forEach(areaName =>
+        describe(`${areaName} storage`, () => {
+            beforeEach(() => storageChangesManager.resetListeners())
+
+            test('Can schedule new listeners', () => {
+                const mockListenerA = jest.fn()
+                const mockListenerB = jest.fn()
+
+                storageChangesManager.addListener(
+                    areaName,
+                    testKeyA,
+                    mockListenerA,
+                )
+
+                const storedListenerA = storageChangesManager['listeners']
+                    .get(areaName)
+                    .get(testKeyA)
+                expect(storedListenerA).toEqual(mockListenerA)
+
+                storageChangesManager.addListener(
+                    areaName,
+                    testKeyB,
+                    mockListenerB,
+                )
+                const storedListenerB = storageChangesManager['listeners']
+                    .get(areaName)
+                    .get(testKeyB)
+                expect(storedListenerB).toEqual(mockListenerB)
+            })
+
+            test('Can invoke scheduled listeners', async () => {
+                const newData = 'test'
+                const mockListenerA = jest.fn()
+                const mockListenerB = jest.fn()
+
+                storageChangesManager.addListener(
+                    areaName,
+                    testKeyA,
+                    mockListenerA,
+                )
+                storageChangesManager.addListener(
+                    areaName,
+                    testKeyB,
+                    mockListenerB,
+                )
+
+                // Simulate change that affects A
+                expect(mockListenerA.mock.calls.length).toBe(0)
+                const change = { oldValue: undefined, newValue: newData }
+                storageChangesManager['handleChanges'](
+                    { [testKeyA]: { ...change } },
+                    areaName,
+                )
+                expect(mockListenerA.mock.calls.length).toBe(1)
+                expect(mockListenerA.mock.calls[0][0]).toEqual(change)
+
+                // Simulate change that affects B
+                expect(mockListenerB.mock.calls.length).toBe(0)
+                storageChangesManager['handleChanges'](
+                    { [testKeyB]: { ...change } },
+                    areaName,
+                )
+                expect(mockListenerB.mock.calls.length).toBe(1)
+                expect(mockListenerB.mock.calls[0][0]).toEqual(change)
+
+                // Simulate change that affects both
+                expect(mockListenerA.mock.calls.length).toBe(1)
+                expect(mockListenerB.mock.calls.length).toBe(1)
+                storageChangesManager['handleChanges'](
+                    {
+                        [testKeyB]: { ...change },
+                        [testKeyA]: { ...change },
+                    },
+                    areaName,
+                )
+                expect(mockListenerA.mock.calls.length).toBe(2)
+                expect(mockListenerB.mock.calls.length).toBe(2)
+                expect(mockListenerA.mock.calls[0][0]).toEqual(change)
+                expect(mockListenerB.mock.calls[0][0]).toEqual(change)
+            })
+        }),
+    ))

--- a/src/util/storage-changes.ts
+++ b/src/util/storage-changes.ts
@@ -1,0 +1,66 @@
+import { browser, Storage } from 'webextension-polyfill-ts'
+
+export interface StorageChanges {
+    [key: string]: Storage.StorageChange
+}
+
+export type StorageAreaName = 'sync' | 'local' | 'managed'
+export type StorageKeyListener = (vals: Storage.StorageChange) => void
+
+export class StorageChangesManager {
+    private listeners: Map<StorageAreaName, Map<string, StorageKeyListener>>
+
+    constructor() {
+        this.resetListeners()
+
+        browser.storage.onChanged.addListener(this.handleChanges)
+    }
+
+    /**
+     * Set up state for individual storage change listeners.
+     */
+    public resetListeners() {
+        this.listeners = new Map<
+            StorageAreaName,
+            Map<string, StorageKeyListener>
+        >([['sync', new Map()], ['local', new Map()], ['managed', new Map()]])
+    }
+
+    /**
+     * Master event listener; delegates control to appropriate internal storage key listeners
+     * based on the changes made.
+     */
+    private handleChanges = (
+        changes: StorageChanges,
+        areaName: StorageAreaName,
+    ) => {
+        const storageAreaHandlers = this.listeners.get(areaName)
+
+        // Exit early when no listeners
+        if (!storageAreaHandlers.size) {
+            return
+        }
+
+        // For each of the changes, run any listeners for those particular storage keys
+        for (const [storageKey, values] of Object.entries(changes)) {
+            const handler = storageAreaHandlers.get(storageKey)
+
+            if (handler != null) {
+                handler(values)
+            }
+        }
+    }
+
+    /**
+     * Affords scheduling of new storage key listeners for specific storage areas.
+     */
+    public addListener = (
+        areaName: StorageAreaName,
+        storageKey: string,
+        listener: StorageKeyListener,
+    ) => this.listeners.get(areaName).set(storageKey, listener)
+}
+
+const storageChangesManager = new StorageChangesManager()
+
+export { storageChangesManager }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7933,6 +7933,10 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
+raven-for-redux@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/raven-for-redux/-/raven-for-redux-1.3.1.tgz#865f0056ec1706073c1b3a33164640453ed4fed2"
+
 raven-js@^3.23.3:
   version "3.23.3"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.23.3.tgz#6174f506c7362eb8bb72b291af5f22edb44ef165"


### PR DESCRIPTION
- fixes #378 by adding redux middleware to our redux apps (overview + options) which snapshot UI state for error reports 
- also adds sentry support to the background script (missing)
- some quick fixes for some minor UI-related errors showing up in sentry (932c1ea)

TODO: 
- [x] double check all UI state in both apps; may want to filter out some data before sending to sentry (search results are part of UI state, and perhaps private info and not super useful for reproducing errors) 

@oliversauter distantly related: where does sentry fall under our privacy policy? From what I can see, as of current production version, any error will get sent to sentry with user information regardless of the opt-out preference on the privacy page