### PR TITLE
Ensure popup search input is auto-focused

### DIFF
--- a/src/popup/components/Search.js
+++ b/src/popup/components/Search.js
@@ -6,6 +6,7 @@ import styles from './Popup.css'
 const Search = ({ onSearchEnter, onSearchChange, searchValue }) => (
     <form className={styles.searchContainer}>
         <input
+            autoFocus
             className={styles.search}
             name="query"
             placeholder="Search your memory"


### PR DESCRIPTION
- fixes it now in Chrome
- FF currently breaks this, but apparently will be fixed in FF60: https://bugzilla.mozilla.org/show_bug.cgi?id=1324255