### PR TITLE
Ensure stylelint does not fail watch build on error

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -249,7 +249,12 @@ gulp.task('lint-watch', ['lint'], callback => {
     })
 
     gulp.watch(['src/**/*.css']).on('change', event => {
-        return gulp.src(event.path).pipe(stylelint(stylelintOptions))
+        return gulp.src(event.path).pipe(
+            stylelint({
+                ...stylelintOptions,
+                failAfterError: false,
+            }),
+        )
     })
 
     // Don't call callback, to wait forever.


### PR DESCRIPTION
- missing `failAfterError` option in CSS watch task's `gulp-stylelint` setup; it defaults to `true`