### PR TITLE
Misc sentry fixes

### DIFF
--- a/src/activity-logger/background/index.js
+++ b/src/activity-logger/background/index.js
@@ -67,6 +67,6 @@ browser.tabs.onUpdated.addListener(async function(tabId, changeInfo, tab) {
             await handleUrl(tabId, changeInfo, tab)
         }
     } catch (err) {
-        // Ignore errors
+        console.error(err)
     }
 })

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -144,7 +144,7 @@ class Analytics {
         }
 
         if (force) {
-            await this._sendReq(params)
+            await this._sendReq(params).catch(console.error)
         } else {
             this._poolReq(params)
         }

--- a/src/options/imports/enhancer.js
+++ b/src/options/imports/enhancer.js
@@ -7,7 +7,10 @@ const hydrateImportsFromStorage = store => {
         browser.storage.local.get(key).then(data => {
             if (!data[key]) return
 
-            const parsedData = JSON.parse(data[key])
+            const parsedData =
+                typeof data[key] === 'string'
+                    ? JSON.parse(data[key])
+                    : data[key]
             store.dispatch(action(parsedData))
         })
 
@@ -20,8 +23,7 @@ const hydrateImportsFromStorage = store => {
 
 const syncImportsToStorage = store =>
     store.subscribe(() => {
-        const dump = (key, data) =>
-            browser.storage.local.set({ [key]: JSON.stringify(data) })
+        const dump = (key, data) => browser.storage.local.set({ [key]: data })
 
         const state = store.getState()
         dump(STORAGE_KEYS.ALLOW_TYPES, selectors.allowTypes(state))

--- a/src/options/imports/reducer.js
+++ b/src/options/imports/reducer.js
@@ -108,7 +108,6 @@ const setImportState = val => genericReducer('importStatus', val)
 
 export default createReducer(
     {
-        [actions.initAllowTypes]: payloadReducer('allowTypes'),
         [actions.prepareImport]: prepareImportReducer,
         [actions.startImport]: setImportState(STATUS.RUNNING),
         [actions.stopImport]: setImportState(STATUS.STOPPED),
@@ -128,6 +127,17 @@ export default createReducer(
         [actions.initDownloadData]: payloadReducer('downloadData'),
 
         // Adv settings mode reducers
+        [actions.initAllowTypes]: (state, allowTypes) => ({
+            ...state,
+            allowTypes: {
+                [TYPE.BOOKMARK]:
+                    allowTypes[TYPE.BOOKMARK] ||
+                    defaultState.allowTypes[TYPE.BOOKMARK],
+                [TYPE.HISTORY]:
+                    allowTypes[TYPE.HISTORY] ||
+                    defaultState.allowTypes[TYPE.HISTORY],
+            },
+        }),
         [actions.setConcurrency]: (state, concurrency) => ({
             ...state,
             concurrency,

--- a/src/page-analysis/content_script/extract-fav-icon.js
+++ b/src/page-analysis/content_script/extract-fav-icon.js
@@ -25,7 +25,9 @@ async function getFavIcon(favIconUrl) {
 
         const dataUrl = await responseToDataUrl(response)
         return dataUrl
-    } catch (err) {} // carry on without fav-icon
+    } catch (err) {
+        return undefined // carry on without fav-icon
+    }
 }
 
 /**

--- a/src/search/background/index.js
+++ b/src/search/background/index.js
@@ -35,7 +35,7 @@ browser.runtime.onConnect.addListener(searchConnectionHandler)
 
 const handleBookmarkRemoval = (id, { node }) =>
     node.url
-        ? indexInterface.delBookmark(node)
+        ? indexInterface.delBookmark(node).catch(console.error)
         : console.warn('Cannot remove bookmark with no URL', node)
 
 // Store and index any new browser bookmark

--- a/src/search/search-index-new/models/fav-icon.ts
+++ b/src/search/search-index-new/models/fav-icon.ts
@@ -32,8 +32,12 @@ export default class FavIcon extends AbstractModel {
 
     set favIconURI(dataURI: string) {
         if (dataURI) {
-            this.favIcon = AbstractModel.dataURLToBlob(dataURI)
-            this[favIcon] = AbstractModel.getBlobURL(this.favIcon)
+            try {
+                this.favIcon = AbstractModel.dataURLToBlob(dataURI)
+                this[favIcon] = AbstractModel.getBlobURL(this.favIcon)
+            } catch (err) {
+                console.error(err)
+            }
         }
     }
 
@@ -44,6 +48,11 @@ export default class FavIcon extends AbstractModel {
     }
 
     public async save() {
-        return db.transaction('rw', db.favIcons, () => db.favIcons.put(this))
+        return db.transaction('rw', db.favIcons, () => {
+            // Could have been errors converting the data url to blob
+            if (this.favIcon !== null) {
+                db.favIcons.put(this)
+            }
+        })
     }
 }

--- a/src/search/search-index-old/bookmarks/add.js
+++ b/src/search/search-index-old/bookmarks/add.js
@@ -22,13 +22,13 @@ async function getAttachments(pageData) {
 }
 
 export async function handleBookmarkCreation(id, bookmarkInfo) {
-    let pageDoc = {
-        _id: generatePageDocId({ url: bookmarkInfo.url }),
-        url: bookmarkInfo.url,
-        title: bookmarkInfo.title,
-    }
-
     try {
+        let pageDoc = {
+            _id: generatePageDocId({ url: bookmarkInfo.url }),
+            url: bookmarkInfo.url,
+            title: bookmarkInfo.title,
+        }
+
         const fetch = fetchPageData({
             url: bookmarkInfo.url,
             opts: {
@@ -44,15 +44,15 @@ export async function handleBookmarkCreation(id, bookmarkInfo) {
             _attachments: await getAttachments(pageData),
             content: pageData.content,
         }
-    } catch (err) {
-        console.error(
-            'Error occurred while fetching page data: ',
-            err.toString(),
-        )
-    } finally {
+
         const bookmarkDoc = transformToBookmarkDoc(pageDoc)(bookmarkInfo)
         addPageConcurrent({ pageDoc, bookmarkDocs: [bookmarkDoc] })
         db.bulkDocs([bookmarkDoc, pageDoc])
+    } catch (err) {
+        console.error(
+            'Error occurred while creating bookmark: ',
+            err.toString(),
+        )
     }
 }
 

--- a/src/search/search-index-old/util.js
+++ b/src/search/search-index-old/util.js
@@ -30,7 +30,7 @@ export const makeIndexFnConcSafe = fn => (...args) =>
                 .then(resolve)
                 .catch(reject),
         ),
-    )
+    ).catch(console.error)
 
 export const idbBatchToPromise = batch =>
     new Promise((resolve, reject) =>


### PR DESCRIPTION
- most of these address errors relating to uncaught errors in the old index implementation (apparently we still have users on the old index)
- one issue fixed up in the options script which should address #390 #384 + #380. Options page could crash under the conditions: 
  - user has gone to imports page prior to our removal of old extension migration (I think it was in the new index release)
  - user comes back to imports page after updating (local storage contains the old data still, and imports UI attempted to rehydrate state using that)
- one non-sentry related enhancement added which is the removal of de/serialization of imports UI state:
  - prev was serializing all UI state to a string before persisting to local storage
  - this could have contributed to the imports UI performance issues (string parsing is CPU bound; as imports progressed, more and more URL data would need to be SerDe'd every time something changes)
  - now just store them as native JS types, like the rest of our codebase. No need to serialize for using web ext local storage, only HTML5 local storage is limited to string-only values

**NOTE:** needs to be merged into `develop` as well after merge