### PR TITLE
Webpack production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 coverage/
 publish.sh
 stats.json
+.sentryclirc

--- a/build/env.js
+++ b/build/env.js
@@ -1,10 +1,18 @@
-export default (dev = false) => ({
-    PIWIK_SITE_ID: '1',
-    NODE_ENV: dev ? 'development' : 'production',
-    PIWIK_HOST: dev
-        ? 'http://localhost:1234'
-        : 'https://analytics.worldbrain.io',
-    SENTRY_DSN: dev
-        ? ''
-        : 'https://205014a0f65e4160a29db2935250b47c@sentry.io/305612',
-})
+export default ({ mode }) => {
+    const env = {
+        VERSION: process.env.npm_package_version,
+        PIWIK_SITE_ID: '1',
+        NODE_ENV: mode,
+    }
+
+    if (mode === 'development') {
+        env.PIWIK_HOST = 'http://localhost:1234'
+        env.SENTRY_DSN = ''
+    } else if (mode === 'production') {
+        env.PIWIK_HOST = 'https://analytics.worldbrain.io'
+        env.SENTRY_DSN =
+            'https://205014a0f65e4160a29db2935250b47c@sentry.io/305612'
+    }
+
+    return env
+}

--- a/build/minimizers.js
+++ b/build/minimizers.js
@@ -1,0 +1,11 @@
+import UglifyJsPlugin from 'uglifyjs-webpack-plugin'
+import CssAssetsPlugin from 'optimize-css-assets-webpack-plugin'
+
+export default () => [
+    new UglifyJsPlugin({
+        cache: true,
+        parallel: true,
+        sourceMap: true,
+    }),
+    new CssAssetsPlugin({}),
+]

--- a/build/static-files.js
+++ b/build/static-files.js
@@ -19,11 +19,24 @@ export const htmlAssets = [
 ]
 
 /**
+ * Set the manifest version to be equal to `package.json` version.
+ */
+function transformManifestVersion(content) {
+    const manifest = JSON.parse(content.toString())
+    manifest.version = process.env.npm_package_version
+    return Buffer.from(JSON.stringify(manifest))
+}
+
+/**
  * Everything in here gets copied as-is to the output dir.
  * See: https://github.com/webpack-contrib/copy-webpack-plugin#usage
  */
 export const copyPatterns = [
-    { from: 'src/manifest.json', to: '.' },
+    {
+        from: 'src/manifest.json',
+        to: '.',
+        transform: transformManifestVersion,
+    },
     { from: 'img', to: 'img' },
 
     {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "npm run build:clean && webpack",
     "build:ci": "npm run build:clean && webpack --env.ci",
     "build:prod": "npm run build:clean && webpack --env.prod",
+    "build:package": "npm run build:clean && webpack --env.prod --env.package",
     "build:clean": "rm -rf ./extension",
     "build:old-prod": "npm run build:clean && gulp build-prod",
     "build:old": "npm run build:clean && gulp build",
@@ -93,6 +94,7 @@
     "when-all-settled": "^0.1.1"
   },
   "devDependencies": {
+    "@sentry/webpack-plugin": "^1.5.2",
     "@types/jest": "^22.1.4",
     "autoprefixer": "^7.1.1",
     "babel-eslint": "^7.2.3",
@@ -147,7 +149,9 @@
     "loose-envify": "^1.3.1",
     "material-design-icons": "^3.0.1",
     "memdown": "^2.0.0",
+    "mini-css-extract-plugin": "^0.4.0",
     "npm-run-all": "^4.1.3",
+    "optimize-css-assets-webpack-plugin": "^4.0.2",
     "pify": "^3.0.0",
     "postcss-cssnext": "^3.1.0",
     "postcss-loader": "^2.1.5",
@@ -180,16 +184,18 @@
     "typescript": "^2.7.2",
     "uglify-es": "^3.1.7",
     "uglifyify": "^4.0.1",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^1.0.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.9.0",
     "web-ext": "^1.10.0",
     "webextension-polyfill-ts": "^0.8.3",
-    "webpack": "^4.10.0",
+    "webpack": "^4.10.1",
     "webpack-build-notifier": "^0.1.25",
     "webpack-chrome-extension-reloader": "^0.6.9",
-    "webpack-cli": "^2.1.3"
+    "webpack-cli": "^2.1.3",
+    "zip-webpack-plugin": "^3.0.0"
   },
   "resolutions": {
     "abstract-leveldown": "4.0.3"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,22 +3,16 @@
     "short_name": "Memex",
     "version": "0.3.3",
     "offline_enabled": true,
-    "description": "Find previously visited websites & PDFs in seconds. Full-text search your browsing history and bookmarks.",
+    "description":
+        "Find previously visited websites & PDFs in seconds. Full-text search your browsing history and bookmarks.",
     "background": {
-        "scripts": [
-            "lib/browser-polyfill.js",
-            "background.js"
-        ]
+        "scripts": ["lib/browser-polyfill.js", "background.js"]
     },
     "content_scripts": [
         {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": [
-                "lib/browser-polyfill.js",
-                "content_script.js"
-            ],
+            "matches": ["<all_urls>"],
+            "js": ["lib/browser-polyfill.js", "content_script.js"],
+            "css": ["/content_script.css"],
             "run_at": "document_start"
         }
     ],
@@ -56,11 +50,7 @@
         "unlimitedStorage",
         "storage"
     ],
-    "web_accessible_resources": [
-        "/lib/pdf.worker.min.js",
-        "/img/*",
-        "/content_script.css"
-    ],
+    "web_accessible_resources": ["/lib/pdf.worker.min.js", "/img/*"],
     "omnibox": {
         "keyword": "w"
     },

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -6,12 +6,8 @@ export default (env = {}) => {
         mode: env.prod ? 'production' : 'development',
         notifsEnabled: !!env.notifs,
         isCI: !!env.ci,
+        shouldPackage: !!env.package,
     })
-
-    // CI doesn't need source-maps
-    if (env.ci) {
-        delete conf.devtool
-    }
 
     return conf
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,21 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/cli@^1.30.2":
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.32.0.tgz#24fc0639529e5b033ac475b603d73a8dcf032e03"
+  dependencies:
+    https-proxy-agent "^2.1.1"
+    node-fetch "^1.7.3"
+    progress "2.0.0"
+    proxy-from-env "^1.0.0"
+
+"@sentry/webpack-plugin@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.5.2.tgz#c1f66afb919b8881b1b1ab7363939978ee662ce2"
+  dependencies:
+    "@sentry/cli" "^1.30.2"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -280,6 +295,12 @@ addons-linter@0.22.3:
 adm-zip@~0.4.x:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
+
+agent-base@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -3607,7 +3628,7 @@ es6-promise@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
-es6-promisify@5.0.0:
+es6-promisify@5.0.0, es6-promisify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
   dependencies:
@@ -5295,6 +5316,13 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+https-proxy-agent@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
@@ -6837,6 +6865,13 @@ labeled-stream-splicer@^2.0.0:
     isarray "^2.0.4"
     stream-splicer "^2.0.0"
 
+last-call-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
+  dependencies:
+    lodash "^4.17.5"
+    webpack-sources "^1.1.0"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -7742,6 +7777,13 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
+mini-css-extract-plugin@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.0.tgz#ff3bf08bee96e618e177c16ca6131bfecef707f9"
+  dependencies:
+    loader-utils "^1.1.0"
+    webpack-sources "^1.1.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -8048,7 +8090,7 @@ node-ensure@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
 
-node-fetch@^1.0.1:
+node-fetch@^1.0.1, node-fetch@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -8409,6 +8451,13 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optimize-css-assets-webpack-plugin@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-4.0.2.tgz#813d511d20fe5d9a605458441ed97074d79c1122"
+  dependencies:
+    cssnano "^3.10.0"
+    last-call-webpack-plugin "^3.0.0"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
@@ -9848,13 +9897,13 @@ process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+progress@2.0.0, progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-
-progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -9902,6 +9951,10 @@ property-is-enumerable-x@^1.1.0:
   dependencies:
     to-object-x "^1.4.1"
     to-property-key-x "^2.0.1"
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -12442,7 +12495,7 @@ uglifyify@^4.0.1:
     through "~2.3.4"
     uglify-es "^3.0.15"
 
-uglifyjs-webpack-plugin@^1.2.4:
+uglifyjs-webpack-plugin@^1.2.4, uglifyjs-webpack-plugin@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz#2ef8387c8f1a903ec5e44fa36f9f3cbdcea67641"
   dependencies:
@@ -13055,9 +13108,9 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.10.0.tgz#bc7a274afdb5556f9cbe836778abbca283c52938"
+webpack@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.10.1.tgz#74909fb9c32941b5c34d22c1f8782c9a033a52e7"
   dependencies:
     "@webassemblyjs/ast" "1.5.8"
     "@webassemblyjs/wasm-edit" "1.5.8"
@@ -13466,7 +13519,7 @@ yauzl@2.8.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
 
-yazl@^2.1.0:
+yazl@^2.1.0, yazl@^2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
   dependencies:
@@ -13537,3 +13590,10 @@ zip-stream@^1.1.0:
     compress-commons "^1.2.0"
     lodash "^4.8.0"
     readable-stream "^2.0.0"
+
+zip-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/zip-webpack-plugin/-/zip-webpack-plugin-3.0.0.tgz#63b3c173f1a87a006915cd7328a3c40b44dc8e32"
+  dependencies:
+    webpack-sources "^1.1.0"
+    yazl "^2.4.3"


### PR DESCRIPTION
I thought I could keep adding things to the branch and they would automatically show up in #403. Seems like I have to open a new PR. Copy and pasted TODO list from last PR:

## Dev TODOs

- [ ] update README
- [x] dev build
  - [x] watch mode works
    - [x] watch mode is fast (doesn't rebuild every chunk for changes in one)
  - [ ] ~~hot-reload for background and content script~~ **perf issues**
    - [ ] doesn't reload extension if only UI scripts had changes
  - [ ] hot-reload for UI scripts (popup not so important)*
    - [ ] react views + styles changes*
    - [ ] redux state persistence*
  - [x] source-maps supported and work in the browser
    - [x] TS
    - [x] JS
  - [x] [optional build notifications](https://www.npmjs.com/package/webpack-build-notifier) (sounds annoying, but I find audio indicator when build is ready very useful to know when to refresh the page - when HMR is not available)
  - [x] integrates with linters
    - [x] tslint
    - [x] eslint
    - [x] stylelint
  - [x] works with CI setup
    - [ ] find out why hard source plugin caching doesn't work in Travis
  - [ ] react dev tools works*
  - [x] redux dev tools works*
  - [x] optimize to be faster (~~look into [happypack](https://github.com/amireh/happypack)~~ ended up going with [thread-loader](https://github.com/webpack-contrib/thread-loader))*
  - [x] get styles working with content_script

## Prod TODOs

- [ ] production build
  - [x] things get uglified etc
    - [ ] fix bug with content script uglification somehow breaking the code...
  - [x] proper "env vars" get set
  - [x] set up automated sentry releases and sourcemaps (they have a [webpack plugin](https://docs.sentry.io/clients/javascript/sourcemaps/#using-sentry-webpack-plugin))
  - [x] extension packaging
    - [x] extension zip
    - [ ] source code zip (not sure how to do this just yet - upstream issue [here](https://github.com/erikdesjardins/zip-webpack-plugin/issues/26))
  - [ ] ensure PDF processing logic works (webpack pushes to separate chunk due to large size and re-use in diff scripts)
  - [x] implement `package.json` => `manifest.json` version propagation


__\* _are "nice-to-have"s but lower prio and may not be possible___


Feel free to request or suggest more build features!