### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 publish.sh
 stats.json
 .sentryclirc
+.DS_Store


### PR DESCRIPTION
Gets pretty annoying in macOS, so I have added `.DS_Store` to `.gitignore`.
@poltak 