### PR TITLE
Hotfix/paused bookmarking

### DIFF
--- a/src/imports/background/data-sources.js
+++ b/src/imports/background/data-sources.js
@@ -76,8 +76,8 @@ export default class ImportDataSources {
         yield childGroups.bms
 
         // Recursively process next levels (not expected to get deep)
-        for (const dirNode of childGroups.dirs) {
-            yield* this.bookmarks(dirNode)
+        for (const dir of childGroups.dirs) {
+            yield* this.bookmarks(dir)
         }
     }
 }

--- a/src/overview/filters/reducer.js
+++ b/src/overview/filters/reducer.js
@@ -53,17 +53,25 @@ const toggleFilter = filterKey => (state, value) => {
 
 const parseStringFilters = str => (str === '' ? [] : str.split(','))
 
-const setFilters = filterKey => (state, filters) => ({
-    ...state,
-    [filterKey]:
-        typeof filters === 'string' ? parseStringFilters(filters) : filters,
-    showFilters: true,
-})
+const setFilters = filterKey => (state, filters) => {
+    const newState = {
+        ...state,
+        [filterKey]:
+            typeof filters === 'string' ? parseStringFilters(filters) : filters,
+    }
+
+    newState.showFilters =
+        newState.tags.length > 0 ||
+        newState.domainsExc.length > 0 ||
+        newState.domainsInc.length > 0 ||
+        newState.onlyBookmarks
+
+    return newState
+}
 
 const toggleBookmarkFilter = state => ({
     ...state,
     onlyBookmarks: !state.onlyBookmarks,
-    showFilters: true,
 })
 
 const resetFilters = state => ({

--- a/src/page-analysis/background/index.js
+++ b/src/page-analysis/background/index.js
@@ -7,7 +7,7 @@ import makeScreenshot from './make-screenshot'
 
 /**
  * @typedef {Object} PageAnalysisResult
- * @property {string} content Object containing `fullText`, and other meta data extracted from the DOM.
+ * @property {any} content Object containing `fullText`, and other meta data extracted from the DOM.
  * @property {string} [favIcon] Data URL representing the favicon.
  * @property {string} [screenshot] Data URL representing the screenshot.
  */
@@ -38,12 +38,11 @@ export default async function analysePage({
     ]
 
     // When every task has either completed or failed, return what we got
-    const [
-        content,
-        screenshotURI,
-        favIconURI,
-    ] = await whenAllSettled(dataFetchingPromises, {
-        onRejection: err => undefined,
-    })
+    const [content, screenshotURI, favIconURI] = await whenAllSettled(
+        dataFetchingPromises,
+        {
+            onRejection: err => undefined,
+        },
+    )
     return { favIconURI, screenshotURI, content }
 }

--- a/src/search/background/index.js
+++ b/src/search/background/index.js
@@ -1,5 +1,3 @@
-import noop from 'lodash/fp/noop'
-
 import { makeRemotelyCallable } from 'src/util/webextensionRPC'
 import searchConnectionHandler from './search-connection-handler'
 import indexInterface from '../'
@@ -8,7 +6,7 @@ makeRemotelyCallable({
     addTag: indexInterface.addTag,
     delTag: indexInterface.delTag,
     suggest: indexInterface.suggest,
-    addBookmark: (...args) => indexInterface.addBookmark(...args).catch(noop),
+    addBookmark: indexInterface.addBookmark,
     delBookmark: indexInterface.delBookmark,
     delPages: indexInterface.delPages,
     delPagesByDomain: indexInterface.delPagesByDomain,

--- a/src/search/search-index-new/bookmarks.ts
+++ b/src/search/search-index-new/bookmarks.ts
@@ -1,27 +1,34 @@
+import { Bookmarks } from 'webextension-polyfill-ts'
+
 import db from '.'
-import normalizeUrl from 'src/util/encode-url-for-id'
-import analysePage from 'src/page-analysis/background'
-import fetchPageData from 'src/page-analysis/background/fetch-page-data'
+import normalizeUrl from '../../util/encode-url-for-id'
+import analysePage from '../../page-analysis/background'
+import fetchPageData from '../../page-analysis/background/fetch-page-data'
 import pipeline from './pipeline'
 import { Page } from './models'
 
-export async function addBookmark({ url, timestamp = Date.now(), tabId }) {
+export async function addBookmark({
+    url,
+    timestamp = Date.now(),
+    tabId,
+}: {
+    url: string
+    timestamp: number
+    tabId: number
+}) {
     const normalized = normalizeUrl(url)
-
     let page = await db.pages.get(normalized)
 
     // No existing page for BM; need to make new via content-script if `tabId` provided
     if (page == null) {
         if (tabId == null) {
             throw new Error(
-                'Page does not exist for URL and no tabID provided to extract content:',
-                normalized,
+                `Page does not exist for URL and no tabID provided to extract content: ${normalized}`,
             )
         }
 
-        // TODO: handle screenshot, favicon
-        const { content } = await analysePage({ tabId })
-        const [pageDoc] = await pipeline({ pageDoc: { content, url } })
+        const analysisRes = await analysePage({ tabId, allowFavIcon: false })
+        const pageDoc = await pipeline({ pageDoc: { ...analysisRes, url } })
         page = new Page(pageDoc)
     }
 
@@ -32,7 +39,7 @@ export async function addBookmark({ url, timestamp = Date.now(), tabId }) {
     })
 }
 
-export function delBookmark({ url }) {
+export function delBookmark({ url }: Bookmarks.BookmarkTreeNode) {
     const normalized = normalizeUrl(url)
 
     return db.transaction('rw', db.tables, async () => {
@@ -56,7 +63,10 @@ export function delBookmark({ url }) {
  * Handles the browser `bookmarks.onCreated` event:
  * https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks/onCreated
  */
-export async function handleBookmarkCreation(browserId, { url }) {
+export async function handleBookmarkCreation(
+    browserId: string,
+    { url }: Bookmarks.BookmarkTreeNode,
+) {
     try {
         const normalized = normalizeUrl(url)
 


### PR DESCRIPTION
Don't merge this PR; I will do via git as hotfix requires merging into both `master` and `develop`, which github makes painful. Opening here for visibility and ease of testing/review.

- fixes #413 
    - bug with bookmarking on pages that have not been indexed
    - issue originally discovered when indexing is paused, but also reproducible with other methods that block indexing (eg. blacklisting)
    - also migrated bookmarking index module to TypeScript
- fixes other bug I noticed with overview filter bar always being shown when overview loads (no corresponding issue)
  - regression in latest release
 