### PR TITLE
Compound index support for StorageManager

### DIFF
--- a/src/direct-linking/background/storage.ts
+++ b/src/direct-linking/background/storage.ts
@@ -14,7 +14,12 @@ export default class DirectLinkingStorage extends FeatureStorage {
                 createdWhen: { type: 'datetime' },
                 url: { type: 'string' },
             },
-            indices: ['url', 'pageTitle', 'body', 'createdWhen'],
+            indices: [
+                { field: 'url', pk: true },
+                { field: 'pageTitle' },
+                { field: 'body' },
+                { field: 'createdWhen' },
+            ],
         })
     }
 

--- a/src/direct-linking/background/storage.ts
+++ b/src/direct-linking/background/storage.ts
@@ -12,9 +12,9 @@ export default class DirectLinkingStorage extends FeatureStorage {
                 body: { type: 'text' },
                 selector: { type: 'json' },
                 createdWhen: { type: 'datetime' },
-                url: { type: 'string', pk: true },
+                url: { type: 'string' },
             },
-            indices: ['pageTitle', 'body', 'createdWhen', 'url'],
+            indices: ['url', 'pageTitle', 'body', 'createdWhen'],
         })
     }
 

--- a/src/search/search-index-new/storage/dexie-schema.ts
+++ b/src/search/search-index-new/storage/dexie-schema.ts
@@ -25,11 +25,8 @@ export function _getDexieSchema(collections: RegistryCollections) {
 
     Object.entries(collections).forEach(([collectionName, collectionDef]) => {
         const dexieTable: string[] = []
-        const sortedIndexedFields = collectionDef.indices.sort(
-            indexName => (collectionDef.fields[indexName].pk ? -1 : 1),
-        )
 
-        sortedIndexedFields.forEach(indexName => {
+        collectionDef.indices.forEach(indexName => {
             const fieldDef = collectionDef.fields[indexName]
             const listPrefix = fieldDef.type === 'text' ? '*' : ''
             const dexieField = `${listPrefix}${indexName}`

--- a/src/search/search-index-new/storage/manager.test.ts
+++ b/src/search/search-index-new/storage/manager.test.ts
@@ -9,7 +9,7 @@ describe('StorageManager', () => {
             storageManager.registerCollection('spam', {
                 version: new Date(2018, 5, 20),
                 fields: {
-                    slug: { type: 'string', pk: true },
+                    slug: { type: 'string' },
                     field1: { type: 'string' },
                 },
                 indices: ['slug'],
@@ -20,7 +20,7 @@ describe('StorageManager', () => {
                 {
                     version: new Date(2018, 5, 20),
                     fields: {
-                        slug: { type: 'string', pk: true },
+                        slug: { type: 'string' },
                         field1: { type: 'string' },
                     },
                     indices: ['slug'],
@@ -28,7 +28,7 @@ describe('StorageManager', () => {
                 {
                     version: new Date(2018, 5, 25),
                     fields: {
-                        slug: { type: 'string', pk: true },
+                        slug: { type: 'string' },
                         field1: { type: 'string' },
                         field2: { type: 'text' },
                     },
@@ -36,41 +36,65 @@ describe('StorageManager', () => {
                     migrate: migrateEggs,
                 },
             ])
+
             storageManager.registerCollection('foo', {
                 version: new Date(2018, 5, 28),
                 fields: {
-                    slug: { type: 'string', pk: true },
+                    slug: { type: 'string' },
                     field1: { type: 'string' },
                 },
                 indices: ['slug'],
             })
-            expect(getDexieHistory(storageManager.registry)).toEqual([
-                {
-                    version: 1,
-                    schema: {
-                        eggs: 'slug',
-                        spam: 'slug',
-                    },
-                    migrations: [],
+
+            storageManager.registerCollection('ham', {
+                version: new Date(2018, 6, 20),
+                fields: {
+                    nameFirst: { type: 'string' },
+                    nameLast: { type: 'string' },
                 },
-                {
-                    version: 2,
-                    schema: {
-                        eggs: 'slug, *field2',
-                        spam: 'slug',
-                    },
-                    migrations: [migrateEggs],
+                indices: [['nameLast', 'nameFirst'], 'nameLast'],
+            })
+
+            const dexieSchemas = getDexieHistory(storageManager.registry)
+
+            expect(dexieSchemas[0]).toEqual({
+                version: 1,
+                schema: {
+                    eggs: 'slug',
+                    spam: 'slug',
                 },
-                {
-                    version: 3,
-                    schema: {
-                        eggs: 'slug, *field2',
-                        foo: 'slug',
-                        spam: 'slug',
-                    },
-                    migrations: [],
+                migrations: [],
+            })
+
+            expect(dexieSchemas[1]).toEqual({
+                version: 2,
+                schema: {
+                    eggs: 'slug, *field2',
+                    spam: 'slug',
                 },
-            ])
+                migrations: [migrateEggs],
+            })
+
+            expect(dexieSchemas[2]).toEqual({
+                version: 3,
+                schema: {
+                    eggs: 'slug, *field2',
+                    foo: 'slug',
+                    spam: 'slug',
+                },
+                migrations: [],
+            })
+
+            expect(dexieSchemas[3]).toEqual({
+                version: 4,
+                schema: {
+                    eggs: 'slug, *field2',
+                    foo: 'slug',
+                    spam: 'slug',
+                    ham: '[nameLast+nameFirst], nameLast',
+                },
+                migrations: [],
+            })
         })
     })
 })

--- a/src/search/search-index-new/storage/manager.test.ts
+++ b/src/search/search-index-new/storage/manager.test.ts
@@ -12,7 +12,7 @@ describe('StorageManager', () => {
                     slug: { type: 'string' },
                     field1: { type: 'string' },
                 },
-                indices: ['slug'],
+                indices: [{ field: 'slug', pk: true }],
             })
 
             const migrateEggs = () => Promise.resolve()
@@ -23,7 +23,7 @@ describe('StorageManager', () => {
                         slug: { type: 'string' },
                         field1: { type: 'string' },
                     },
-                    indices: ['slug'],
+                    indices: [{ field: 'slug', pk: true }],
                 },
                 {
                     version: new Date(2018, 5, 25),
@@ -32,7 +32,7 @@ describe('StorageManager', () => {
                         field1: { type: 'string' },
                         field2: { type: 'text' },
                     },
-                    indices: ['slug', 'field2'],
+                    indices: [{ field: 'slug', pk: true }, { field: 'field2' }],
                     migrate: migrateEggs,
                 },
             ])
@@ -43,7 +43,7 @@ describe('StorageManager', () => {
                     slug: { type: 'string' },
                     field1: { type: 'string' },
                 },
-                indices: ['slug'],
+                indices: [{ field: 'slug', pk: true }],
             })
 
             storageManager.registerCollection('ham', {
@@ -52,7 +52,10 @@ describe('StorageManager', () => {
                     nameFirst: { type: 'string' },
                     nameLast: { type: 'string' },
                 },
-                indices: [['nameLast', 'nameFirst'], 'nameLast'],
+                indices: [
+                    { field: ['nameLast', 'nameFirst'], pk: true },
+                    { field: 'nameLast' },
+                ],
             })
 
             const dexieSchemas = getDexieHistory(storageManager.registry)

--- a/src/search/search-index-new/storage/registry.ts
+++ b/src/search/search-index-new/storage/registry.ts
@@ -2,6 +2,7 @@ import {
     RegisterableStorage,
     CollectionDefinitions,
     CollectionDefinition,
+    IndexType,
 } from './types'
 import FIELD_TYPES from './fields'
 
@@ -16,6 +17,24 @@ export interface RegistryCollectionsVersionMap {
 export default class StorageRegistry implements RegisterableStorage {
     public collections: RegistryCollections = {}
     public collectionsByVersion: RegistryCollectionsVersionMap = {}
+
+    /**
+     * Handles mutating a collection's definition to flag all fields that are declared to be
+     * indexable as indexed fields.
+     */
+    private static _registerIndexedFields = (def: CollectionDefinition) => {
+        const flagField = (fieldName: string) =>
+            (def.fields[fieldName]._index = true)
+
+        return function(index: IndexType) {
+            // Compound indexes need to flag all specified fields
+            if (index instanceof Array) {
+                index.forEach(flagField)
+            } else {
+                flagField(index)
+            }
+        }
+    }
 
     registerCollection(name: string, defs: CollectionDefinitions) {
         if (!(defs instanceof Array)) {
@@ -35,9 +54,7 @@ export default class StorageRegistry implements RegisterableStorage {
             })
 
             const indices = def.indices || []
-            indices.forEach(fieldName => {
-                def.fields[fieldName]._index = true
-            })
+            indices.forEach(StorageRegistry._registerIndexedFields(def))
 
             const version = def.version.getTime()
             this.collectionsByVersion[version] =

--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -5,6 +5,8 @@ import { Field } from './fields'
 
 export type FieldType = 'text' | 'json' | 'datetime' | 'string' | 'url'
 
+export type IndexType = string | [string, string]
+
 // TODO
 export interface MigrationRunner {
     (): Promise<void>
@@ -36,7 +38,7 @@ export interface CollectionField {
 export interface CollectionDefinition {
     version: Date
     /** Sorted array of fields that will be indexed. Primary key index should be the first element. */
-    indices: Array<string | [string, string]>
+    indices: IndexType[]
     fields: CollectionFields
     migrate?: MigrationRunner
     name?: string

--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -5,8 +5,6 @@ import { Field } from './fields'
 
 export type FieldType = 'text' | 'json' | 'datetime' | 'string' | 'url'
 
-export type IndexType = string | [string, string]
-
 // TODO
 export interface MigrationRunner {
     (): Promise<void>
@@ -35,10 +33,38 @@ export interface CollectionField {
     _index?: boolean
 }
 
+export type IndexSourceFields = string | [string, string]
+
+export interface IndexDefinition {
+    /**
+     * Points to a corresponding field name defined in the `fields` part of the collection definition.
+     * In the case of a compound index, this should be a pair of fields expressed as an `Array`.
+     */
+    field: IndexSourceFields
+    /**
+     * Denotes whether or not this index should be a primary key. There should only be one index
+     * with this flag set.
+     */
+    pk?: boolean
+    /**
+     * Denotes the index being enforced as unique.
+     */
+    unique?: boolean
+    /**
+     * Denotes the primary key index will be auto-incremented.
+     * Only used if `pk` flag also set. Implies `unique` flag set.
+     */
+    autoInc?: boolean
+    /**
+     * Sets a custom name for the corresponding index created to afford full-text search.
+     * Note that this will only be used if the corresponding field definition in `fields` is
+     * of `type` `'text'`.
+     */
+    fullTextIndexName?: string
+}
 export interface CollectionDefinition {
     version: Date
-    /** Sorted array of fields that will be indexed. Primary key index should be the first element. */
-    indices: IndexType[]
+    indices: IndexDefinition[]
     fields: CollectionFields
     migrate?: MigrationRunner
     name?: string

--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -36,7 +36,8 @@ export interface CollectionField {
 
 export interface CollectionDefinition {
     version: Date
-    indices: string[]
+    /** Sorted array of fields that will be indexed. Primary key index should be the first element. */
+    indices: Array<string | [string, string]>
     fields: CollectionFields
     migrate?: MigrationRunner
     name?: string

--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -30,7 +30,6 @@ export interface CollectionFields {
 export interface CollectionField {
     type: FieldType
     fieldObject?: Field
-    pk?: boolean
     _index?: boolean
 }
 


### PR DESCRIPTION
@ShishKabab would be good to get your review + opinions on these changes before going ahead and bringing them in.

Notable changes (more info in commit messages):

1. ~~removed `pk` bool field from collection `fields` definitions~~ (moved to `IndexDefinition`)
    - currently only ever used for ordering the indexable fields in Dexie schemas, however indexable fields in StorageManager are already declared in an ordered data structure
    - only relates to indexable fields, but was declared as part of general data `fields` schema; need to handle case of user declaring field as PK but never declaring it in `indices`
    - instead have taken inspiration from Dexie schemas by saying the first `indices` element is the primary key index (JSDoc added to typings to guide users when writing schemas)
    - updated direct-linking schema to reflect this

2. whenever accessing a `CollectionField` definition - usually via something like `collection.fields[indexName]` - we now check if the `indexName` is a compound index or not, and act slightly differently if so
    - ~~again taking inspiration from Dexie's compound index shape: expressed as "[fieldA+fieldB]". See new test case for example~~
    - new shape: compound indexes are now expressed as type `[string, string]` where each element corresponds to the name of a field - now no need to mess around with string processing. It also means the `indices` array in StorageManager collection defs is now of type `Array<string|[string, string]>` (thanks to suggestion from @ShishKabab )

TODOs (either in here or later):

- [ ] move current Dexie schema to StorageManager schema
- [ ] detection and proper errors thrown when user declares invalid schemas (I don't think these can be done at compile time): 
    - [ ] fields that appear in compound indexes should not be type `text`
    - [ ] indexes should not be made for fields of type `text`
    - [ ] `indices` array needs to contain __exactly one__ `IndexDefinition` with `pk` set