### PR TITLE
Port Dexie-based schema to StorageManager schemas

### DIFF
--- a/src/analytics/internal/analytics.js
+++ b/src/analytics/internal/analytics.js
@@ -47,12 +47,6 @@ class Analytics {
      * @param {EventTrackInfo} eventArgs
      */
     async storeEventLogStatistics(eventArgs) {
-        // If details is not there then add default value
-        const params = {
-            ...eventArgs,
-            details: eventArgs.details || {},
-        }
-
         // Create notificaitions params
         const notifParams = {
             latestTime: eventArgs.time,
@@ -60,10 +54,10 @@ class Analytics {
         }
 
         // Store the event in dexie
-        await this.storeEvent(params)
+        await this.storeEvent(eventArgs)
 
         if (EVENT_TYPES[eventArgs.type].notifType) {
-            await this.incrementValue(notifParams)
+            this.incrementValue(notifParams)
         }
     }
 
@@ -76,19 +70,20 @@ class Analytics {
         const latestTimeWithCount = await this.getLatestTimeWithCount({
             notifType,
         })
+
         if (!latestTimeWithCount) {
             return
         }
 
-        await this.updateValue(notifType, latestTimeWithCount)
+        this.updateValue(notifType, latestTimeWithCount)
     }
 
     // Update the value when the memeory variables is out of update or load initial data
-    async updateValue(notifType, value) {
+    updateValue(notifType, value) {
         this._eventStats[notifType] = value
     }
 
-    async incrementValue(event) {
+    incrementValue(event) {
         this._eventStats[event.notifType] = {
             count: this._eventStats[event.notifType].count + 1,
             latestTime: event.latestTime,
@@ -113,7 +108,6 @@ class Analytics {
         const params = {
             ...eventArgs,
             time,
-            details: {},
         }
 
         await this.storeEventLogStatistics(params)

--- a/src/search/search-index-new/storage/dexie-schema.ts
+++ b/src/search/search-index-new/storage/dexie-schema.ts
@@ -21,7 +21,7 @@ export function getDexieHistory(storageRegistry: StorageRegistry) {
             })
         })
 
-    return versions
+    return patchDirectLinksSchema(versions)
 }
 
 function getDexieSchema(collections: RegistryCollections) {
@@ -69,3 +69,42 @@ const convertIndexToDexieExps = ({ fields, indices }: CollectionDefinition) =>
             return `${listPrefix}${indexDef.field}`
         })
         .join(', ')
+
+/**
+ * Takes the generated schema versions, based on the registed collections, and finds the
+ * first one in which `directLinks` schema was added, then generates a "patch" schema.
+ * This "patch" schema should contain the incorrect indexes that was accidently rolled out
+ * to users at the release of our Direct Links feature. This should ensure Dexie knows about
+ * both the incorrect indexes and how to drop those to migrate to the correct indexes.
+ */
+function patchDirectLinksSchema(schemaVersions: DexieSchema[]): DexieSchema[] {
+    const firstAppears = schemaVersions.findIndex(
+        ({ schema }) => schema.directLinks != null,
+    )
+
+    // Return schemas as-is if direct links schema not found (tests)
+    if (firstAppears === -1) {
+        return schemaVersions
+    }
+
+    const preceding = schemaVersions[firstAppears - 1]
+
+    const patchedSchema = {
+        schema: {
+            ...preceding.schema,
+            directLinks: 'url, *pageTitle, *body, createdWhen',
+        },
+        migrations: [],
+        version: preceding.version + 1,
+    }
+
+    return [
+        ...schemaVersions.slice(0, firstAppears),
+        // Shim the schema with the incorrect indexes, so Dexie knows about its existence
+        patchedSchema,
+        // All subsequent schemas need to be 1 version higher to take the incorrect index schema into account
+        ...schemaVersions
+            .slice(firstAppears)
+            .map(schema => ({ ...schema, version: schema.version + 1 })),
+    ]
+}

--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -3,7 +3,17 @@ import { FilterQuery as MongoFilterQuery } from 'mongodb'
 import StorageRegistry from './registry'
 import { Field } from './fields'
 
-export type FieldType = 'text' | 'json' | 'datetime' | 'string' | 'url' | 'bool'
+export type FieldType =
+    | 'text'
+    | 'json'
+    | 'datetime'
+    | 'timestamp'
+    | 'string'
+    | 'url'
+    | 'int'
+    | 'float'
+    | 'blob'
+    | 'bool'
 
 // TODO
 export interface MigrationRunner {


### PR DESCRIPTION
This branch has been updated to use the new `IndexDefinition` shape from #422. Currently it generates the same original Dexie schema that seems to work fine with existing data now 😃 

@ShishKabab I realized just for the task of porting the schemas, we won't have to worry about things like the additional full-text search indexes created from `'text'` fields and similar things - they are currently handled as part of the `StorageManager`'s `putObject` method which the existing data model isn't using yet. Moving the current `search-index-new` interface to `FeatureStorage` classes will be another, more-involved task todo down the road (maybe when we get rid of `search-index-old` feature module?). 

I have had to add a few new `FieldType`s. See what you think:
- `int`: integer numbers
- `float`: floating point numbers
- `binary` currently used whenever `Blob`s appear in our data model... (`Blob`s are serializable though, so perhaps just using `json` is better?)

I'm also not entirely sure about some of the `FieldType` purposes. As Dexie is the only storage backend we current support, it doesn't matter greatly right now, but it would be great to clarify these so we don't have to change schemas again later and I can add JSDoc to the type def to avoid later confusion:

1. the difference between `text`, `string`, and `url`. I presume `text` and `string` are somewhat akin to `text` and `varchar`, respectively, in most popular RDBMS. Does that match your thinking? When should `url` be used?
2. In existing model: with some Dexie tables, like `bookmarks` and `visits`, we have some `time` fields which are just epoch timestamps. In IDB they are stored as `number`s. However in the new direct linking model there is the `createdWhen` field stored in IDB as a `Date` object. The `datetime` type is obviously intended for the `createdWhen` field, but should the existing data model epoch timestamp fields be set as `datetime` or it will be better to use a number-based field? 
Trying to think about this in a non-Dexie/IDB-specific way but also taking into consideration the existing typed data which resides in IDB