### PR TITLE
StorageManager fix for indexed text fields indexing the wrong field

### DIFF
--- a/src/analytics/internal/analytics.js
+++ b/src/analytics/internal/analytics.js
@@ -47,12 +47,6 @@ class Analytics {
      * @param {EventTrackInfo} eventArgs
      */
     async storeEventLogStatistics(eventArgs) {
-        // If details is not there then add default value
-        const params = {
-            ...eventArgs,
-            details: eventArgs.details || {},
-        }
-
         // Create notificaitions params
         const notifParams = {
             latestTime: eventArgs.time,
@@ -60,10 +54,10 @@ class Analytics {
         }
 
         // Store the event in dexie
-        await this.storeEvent(params)
+        await this.storeEvent(eventArgs)
 
         if (EVENT_TYPES[eventArgs.type].notifType) {
-            await this.incrementValue(notifParams)
+            this.incrementValue(notifParams)
         }
     }
 
@@ -76,19 +70,20 @@ class Analytics {
         const latestTimeWithCount = await this.getLatestTimeWithCount({
             notifType,
         })
+
         if (!latestTimeWithCount) {
             return
         }
 
-        await this.updateValue(notifType, latestTimeWithCount)
+        this.updateValue(notifType, latestTimeWithCount)
     }
 
     // Update the value when the memeory variables is out of update or load initial data
-    async updateValue(notifType, value) {
+    updateValue(notifType, value) {
         this._eventStats[notifType] = value
     }
 
-    async incrementValue(event) {
+    incrementValue(event) {
         this._eventStats[event.notifType] = {
             count: this._eventStats[event.notifType].count + 1,
             latestTime: event.latestTime,
@@ -113,7 +108,6 @@ class Analytics {
         const params = {
             ...eventArgs,
             time,
-            details: {},
         }
 
         await this.storeEventLogStatistics(params)

--- a/src/search/search-index-new/storage/dexie-schema.ts
+++ b/src/search/search-index-new/storage/dexie-schema.ts
@@ -21,7 +21,7 @@ export function getDexieHistory(storageRegistry: StorageRegistry) {
             })
         })
 
-    return versions
+    return patchDirectLinksSchema(versions)
 }
 
 function getDexieSchema(collections: RegistryCollections) {
@@ -69,3 +69,42 @@ const convertIndexToDexieExps = ({ fields, indices }: CollectionDefinition) =>
             return `${listPrefix}${indexDef.field}`
         })
         .join(', ')
+
+/**
+ * Takes the generated schema versions, based on the registed collections, and finds the
+ * first one in which `directLinks` schema was added, then generates a "patch" schema.
+ * This "patch" schema should contain the incorrect indexes that was accidently rolled out
+ * to users at the release of our Direct Links feature. This should ensure Dexie knows about
+ * both the incorrect indexes and how to drop those to migrate to the correct indexes.
+ */
+function patchDirectLinksSchema(schemaVersions: DexieSchema[]): DexieSchema[] {
+    const firstAppears = schemaVersions.findIndex(
+        ({ schema }) => schema.directLinks != null,
+    )
+
+    // Return schemas as-is if direct links schema not found (tests)
+    if (firstAppears === -1) {
+        return schemaVersions
+    }
+
+    const preceding = schemaVersions[firstAppears - 1]
+
+    const patchedSchema = {
+        schema: {
+            ...preceding.schema,
+            directLinks: 'url, *pageTitle, *body, createdWhen',
+        },
+        migrations: [],
+        version: preceding.version + 1,
+    }
+
+    return [
+        ...schemaVersions.slice(0, firstAppears),
+        // Shim the schema with the incorrect indexes, so Dexie knows about its existence
+        patchedSchema,
+        // All subsequent schemas need to be 1 version higher to take the incorrect index schema into account
+        ...schemaVersions
+            .slice(firstAppears)
+            .map(schema => ({ ...schema, version: schema.version + 1 })),
+    ]
+}

--- a/src/search/search-index-new/storage/dexie-schema.ts
+++ b/src/search/search-index-new/storage/dexie-schema.ts
@@ -53,13 +53,17 @@ const convertIndexToDexieExps = ({ fields, indices }: CollectionDefinition) =>
                 return `[${indexDef.field[0]}+${indexDef.field[1]}]`
             }
 
-            // Create Dexie MultiEntry index for text fields: http://dexie.org/docs/MultiEntry-Index
+            // Create Dexie MultiEntry index for indexed text fields: http://dexie.org/docs/MultiEntry-Index
             // TODO: throw error if text field + PK index
-            const fieldDef = fields[indexDef.field]
-            let listPrefix = fieldDef.type === 'text' ? '*' : ''
+            if (fields[indexDef.field].type === 'text') {
+                const fullTextField =
+                    indexDef.fullTextIndexName ||
+                    StorageRegistry.createTermsIndex(indexDef.field)
+                return `*${fullTextField}`
+            }
 
             // Note that order of these statements matters
-            listPrefix = indexDef.unique ? '&' : listPrefix
+            let listPrefix = indexDef.unique ? '&' : ''
             listPrefix = indexDef.pk && indexDef.autoInc ? '++' : listPrefix
 
             return `${listPrefix}${indexDef.field}`

--- a/src/search/search-index-new/storage/manager.test.ts
+++ b/src/search/search-index-new/storage/manager.test.ts
@@ -71,6 +71,18 @@ describe('StorageManager', () => {
                 ],
             })
 
+            storageManager.registerCollection('dogs', {
+                version: new Date(2018, 6, 26),
+                fields: {
+                    id: { type: 'string' },
+                    biography: { type: 'text' },
+                },
+                indices: [
+                    { field: 'biography', fullTextIndexName: 'biographyTerms' },
+                    { field: 'id', pk: true },
+                ],
+            })
+
             const dexieSchemas = getDexieHistory(storageManager.registry)
 
             expect(dexieSchemas[0]).toEqual({
@@ -85,7 +97,7 @@ describe('StorageManager', () => {
             expect(dexieSchemas[1]).toEqual({
                 version: 2,
                 schema: {
-                    eggs: 'slug, *field2',
+                    eggs: 'slug, *_field2_terms',
                     spam: 'slug',
                 },
                 migrations: [migrateEggs],
@@ -94,7 +106,7 @@ describe('StorageManager', () => {
             expect(dexieSchemas[2]).toEqual({
                 version: 3,
                 schema: {
-                    eggs: 'slug, *field2',
+                    eggs: 'slug, *_field2_terms',
                     foo: 'slug',
                     spam: 'slug',
                 },
@@ -104,7 +116,7 @@ describe('StorageManager', () => {
             expect(dexieSchemas[3]).toEqual({
                 version: 4,
                 schema: {
-                    eggs: 'slug, *field2',
+                    eggs: 'slug, *_field2_terms',
                     foo: 'slug',
                     spam: 'slug',
                     ham: '[nameLast+nameFirst], nameLast',
@@ -115,11 +127,24 @@ describe('StorageManager', () => {
             expect(dexieSchemas[4]).toEqual({
                 version: 5,
                 schema: {
-                    eggs: 'slug, *field2',
+                    eggs: 'slug, *_field2_terms',
                     foo: 'slug',
                     spam: 'slug',
                     ham: '[nameLast+nameFirst], nameLast',
                     people: '++id, &ssn',
+                },
+                migrations: [],
+            })
+
+            expect(dexieSchemas[5]).toEqual({
+                version: 6,
+                schema: {
+                    eggs: 'slug, *_field2_terms',
+                    foo: 'slug',
+                    spam: 'slug',
+                    ham: '[nameLast+nameFirst], nameLast',
+                    people: '++id, &ssn',
+                    dogs: 'id, *biographyTerms',
                 },
                 migrations: [],
             })

--- a/src/search/search-index-new/storage/manager.ts
+++ b/src/search/search-index-new/storage/manager.ts
@@ -37,7 +37,8 @@ export class StorageManager implements ManageableStorage {
         switch (fieldDef.type) {
             case 'text':
                 const fullTextField =
-                    indexDef.fullTextIndexName || `_${fieldName}_terms`
+                    indexDef.fullTextIndexName ||
+                    StorageRegistry.createTermsIndex(fieldName)
                 object[fullTextField] = [...extractTerms(object[fieldName])]
                 break
             default:

--- a/src/search/search-index-new/storage/registry.ts
+++ b/src/search/search-index-new/storage/registry.ts
@@ -15,6 +15,9 @@ export interface RegistryCollectionsVersionMap {
 }
 
 export default class StorageRegistry implements RegisterableStorage {
+    public static createTermsIndex = (fieldName: string) =>
+        `_${fieldName}_terms`
+
     public collections: RegistryCollections = {}
     public collectionsByVersion: RegistryCollectionsVersionMap = {}
 

--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -3,7 +3,17 @@ import { FilterQuery as MongoFilterQuery } from 'mongodb'
 import StorageRegistry from './registry'
 import { Field } from './fields'
 
-export type FieldType = 'text' | 'json' | 'datetime' | 'string' | 'url' | 'bool'
+export type FieldType =
+    | 'text'
+    | 'json'
+    | 'datetime'
+    | 'timestamp'
+    | 'string'
+    | 'url'
+    | 'int'
+    | 'float'
+    | 'blob'
+    | 'bool'
 
 // TODO
 export interface MigrationRunner {


### PR DESCRIPTION
This adds in a fix for a StorageManager bug I talked with @ShishKabab about on slack yesterday. The wrong field was being indexed for indexed fields of type `'text'`. 

This sadly affects all our users who upgraded to our direct linking release and will need a one-off migration before we can consider adding support to search for highlights. **Note that the migration is not included in this work.**

Seems to work well and pass the changes to the StorageManager tests I made. 

This will also affect the schema porting work in #429, which I'll need to go over some more with these changes.

One unrelated thing that I discovered while playing with this fix was that the internally used `_index` flag, added to field definitions by the registry module if they have a corresponding index, was redundant. There's more info in 4870d82d668571fba211c7e86800dfbc3b9da37e where I've removed the code relating to that. @ShishKabab let me know if you think there was some other reason for that flag that I've missed and we can easily revert that.
