### PR TITLE
StorageManager: add support for opt. PKs with `suggest` results

### DIFF
--- a/src/search/search-index-new/storage/types.ts
+++ b/src/search/search-index-new/storage/types.ts
@@ -26,6 +26,11 @@ export interface FindOpts {
     reverse?: boolean
     skip?: number
     limit?: number
+    /**
+     * Returns associated PKs for each found suggestion.
+     * _Only used in suggest methods._
+     */
+    suggestPks?: boolean
 }
 
 export type FilterQuery<T> = MongoFilterQuery<T>
@@ -89,6 +94,12 @@ export interface RegisterableStorage {
     registerCollection(name: string, defs: CollectionDefinitions): void
 }
 
+export interface SuggestResult {
+    suggestion: string
+    collectionName: string
+    pk?: any
+}
+
 export interface ManageableStorage extends RegisterableStorage {
     initialized: boolean
     registry: StorageRegistry
@@ -113,6 +124,11 @@ export interface ManageableStorage extends RegisterableStorage {
         filter: FilterQuery<T>,
         update,
     ): Promise<number>
+    suggest<T>(
+        collectionName: string,
+        filter: FilterQuery<T>,
+        opts?: FindOpts,
+    ): Promise<SuggestResult[]>
     _finishInitialization(storage): void
 }
 


### PR DESCRIPTION
Sometimes it's useful to get the assoc. PKs with the suggestions returned from StorageManager's `suggest` method. This adds a flag to enable that. Noted that this was needed in particular for @subrat-sahu's custom-lists work during review

Currently returns an array of 2-element key value pair arrays of PKs => suggestion, i.e., `[PKType, string][]` if `suggestPks` flag is set, else simply `string[]`. 
Maybe there's a nicer way to type this return value though. Maybe an object of shape `{ suggestions: string[], pks?: any[] }` would provide a more consistent type (callers wouldn't have to add type guards or casts) and assume array lengths and orders are the same? @ShishKabab any suggestions/ideas?

Also added missing typings for `suggest` method.