### PR TITLE
Move to using `git archive` for zipping source code

### DIFF
--- a/.package-exclude.lst
+++ b/.package-exclude.lst
@@ -1,9 +1,0 @@
-.git/**
-node_modules/**
-dist/**
-extension/**
-coverage/**
-.sentryclirc
-yarn-error.log
-*.sh
-*.pem

--- a/build/plugins.js
+++ b/build/plugins.js
@@ -103,8 +103,9 @@ export default function({
                 filename: extPackageName,
                 exclude: [/\.map/],
             }),
-            // TODO: do this in node
-            new PostCompilePlugin(() => exec('sh package-source-code.sh')),
+            new PostCompilePlugin(() =>
+                exec('git archive -o dist/source-code.zip master'),
+            ),
         )
     }
 

--- a/package-source-code.sh
+++ b/package-source-code.sh
@@ -1,1 +1,0 @@
-zip -rX "dist/source-code.zip" * --exclude @.package-exclude.lst

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
- updated packaging build from using `zip` command to using `git archive`
- `zip` is less portable and realized we were excluding some important hidden config files by default, like `.babelrc`
- `git archive` should include all files that are included in git, and exclude those in `.gitignore` (hence no need for the separate excluded files list anymore)