### PR TITLE
Tests and Readme for custom-lists module

### DIFF
--- a/src/custom-lists/Readme.md
+++ b/src/custom-lists/Readme.md
@@ -1,0 +1,42 @@
+# Custom Lists(Collections)
+
+This code provides the interface for collections. The main container i.e `Index.jsx` gets mounted in the sidebar on the left in the overview. This direcory holds all the storage and state management for the custom-lists feature.
+
+## Directory structure
+
+```
+src/custom-lists
+│   Readme.md
+│   index.js
+|   actions.js
+|   reducer.js
+|   selectors.js
+│
+└───components
+│   │   index.js
+│   │
+│   │
+│   └───overview/sidebar
+│       │ CreateListForm.jsx
+│       │ CreateListForm.css
+│       │ Index.css
+│       │ Index.js
+│       │ ListItem.js
+│       └─ListItem.css
+│
+│
+└───background
+    │   index.js
+    │   storage.ts
+    │   storage.test.ts
+    │   types.ts
+    └───storage.test.data.ts
+
+```
+
+-   `components`: contains all the components that re renders in the overview sidebar, with the filters.
+    -   `overview/sidebar/Index.jsx`: The main container that contains all the other components.
+-   `background`: contains all the backgroud stuff(storage calls) related to this feature.
+    -   `storage.ts`: Contains calls to the storage manager for CRUD operations.
+    -   `index.js`: Abstract away the storage manager calls from the user interface.
+-   All the redux state management is in `actions.js`, `reducer.js` and `selectors.js`.

--- a/src/custom-lists/background/storage.test.js
+++ b/src/custom-lists/background/storage.test.js
@@ -133,7 +133,7 @@ const runSuite = () => () => {
             })
             runChecks(updatedList)
             runChecks(newName)
-            //No of pages and list updated
+            // No of pages and list updated
             expect(updatedList).toBe(1)
             // Test the name is updated correctly
             expect(newName.name).toBe('new name')
@@ -156,7 +156,7 @@ const runSuite = () => () => {
             // Nothing updated
             expect(updatedList).toBe(0)
             // cannot found anything with the new name
-            expect(newName).toBeUndefined
+            expect(newName).toBeUndefined()
         })
     })
 
@@ -165,7 +165,7 @@ const runSuite = () => () => {
             const lists = await fakeIndex.removeList({ id: 3 })
             expect(lists).toBeDefined()
             expect(lists).not.toBeNull()
-            //No of pages and list deleted by
+            // No of pages and list deleted by
             expect(lists).toEqual({ list: 1, pages: 1 })
         })
 
@@ -176,7 +176,7 @@ const runSuite = () => () => {
             })
             expect(pages).toBeDefined()
             expect(pages).not.toBeNull()
-            //No of pages deleted
+            // No of pages deleted
             expect(pages).toBe(1)
         })
     })

--- a/src/custom-lists/background/storage.test.ts
+++ b/src/custom-lists/background/storage.test.ts
@@ -86,16 +86,6 @@ const runSuite = () => () => {
         })
 
         test('fetch Pages associated with list by url', async () => {
-            const runChecks = async currPage => {
-                expect(currPage).toBeDefined()
-                expect(currPage).not.toBeNull()
-            }
-
-            runChecks(
-                await fakeIndex.fetchListPagesByUrl({
-                    url: 'https://www.ipsum.com/test',
-                }),
-            )
             const lists = await fakeIndex.fetchListPagesByUrl({
                 url: 'https://www.ipsum.com/test',
             })
@@ -103,6 +93,91 @@ const runSuite = () => () => {
             expect(lists).toBeDefined()
             expect(lists).not.toBeNull()
             expect(lists.length).toBe(2)
+        })
+
+        test('fetch lists with some urls excluded', async () => {
+            const lists = await fakeIndex.fetchAllLists({
+                excludeIds: [1, 2],
+            })
+
+            expect(lists).toBeDefined()
+            expect(lists).not.toBeNull()
+            expect(lists.length).toBe(1)
+            expect(lists[0].id).not.toBe(1)
+            expect(lists[0].id).not.toBe(2)
+        })
+
+        test('fetch lists with limits', async () => {
+            const lists = await fakeIndex.fetchAllLists({
+                limit: 1,
+            })
+
+            expect(lists).toBeDefined()
+            expect(lists).not.toBeNull()
+            expect(lists.length).toBe(1)
+        })
+    })
+
+    describe('update ops', () => {
+        test('update list name', async () => {
+            const runChecks = async currPage => {
+                expect(currPage).toBeDefined()
+                expect(currPage).not.toBeNull()
+            }
+            const updatedList = await fakeIndex.updateList({
+                id: 3,
+                name: 'new name',
+            })
+            const newName = await fakeIndex.fetchListIgnoreCase({
+                name: 'new name',
+            })
+            runChecks(updatedList)
+            runChecks(newName)
+            //No of pages and list updated
+            expect(updatedList).toBe(1)
+            // Test the name is updated correctly
+            expect(newName.name).toBe('new name')
+        })
+
+        test('fail to update list name', async () => {
+            const runChecks = async currPage => {
+                expect(currPage).toBeDefined()
+                expect(currPage).not.toBeNull()
+            }
+            const updatedList = await fakeIndex.updateList({
+                id: 4,
+                name: 'another new name',
+            })
+            const newName = await fakeIndex.fetchListIgnoreCase({
+                name: 'another new name',
+            })
+            runChecks(updatedList)
+
+            // Nothing updated
+            expect(updatedList).toBe(0)
+            // cannot found anything with the new name
+            expect(newName).toBeUndefined
+        })
+    })
+
+    describe('delete ops', () => {
+        test('delete list along with associated pages', async () => {
+            const lists = await fakeIndex.removeList({ id: 3 })
+            expect(lists).toBeDefined()
+            expect(lists).not.toBeNull()
+            //No of pages and list deleted by
+            expect(lists).toEqual({ list: 1, pages: 1 })
+        })
+
+        test('Remove page from list', async () => {
+            const pages = await fakeIndex.removePageFromList({
+                id: 1,
+                url: 'https://www.ipsum.com/test',
+            })
+            expect(pages).toBeDefined()
+            expect(pages).not.toBeNull()
+            //No of pages deleted
+            expect(pages).toBe(1)
         })
     })
 }

--- a/src/custom-lists/background/storage.test.ts
+++ b/src/custom-lists/background/storage.test.ts
@@ -97,7 +97,7 @@ const runSuite = () => () => {
 
         test('fetch lists with some urls excluded', async () => {
             const lists = await fakeIndex.fetchAllLists({
-                excludeIds: [1, 2],
+                excludeIds: [1, 2] as any[],
             })
 
             expect(lists).toBeDefined()

--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -7,8 +7,6 @@ export default class CustomListStorage extends FeatureStorage {
 
     constructor({ storageManager }) {
         super(storageManager)
-        // console.log('running const');
-
         this.storageManager.registerCollection(
             CustomListStorage.CUSTOM_LISTS_COLL,
             {

--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -226,19 +226,20 @@ export default class CustomListStorage extends FeatureStorage {
      * @memberof CustomListStorage
      */
     async removeList({ id }: { id: number }) {
-        await this.storageManager.deleteObject(
+        const list = await this.storageManager.deleteObject(
             CustomListStorage.CUSTOM_LISTS_COLL,
             {
                 id,
             },
         )
         // Delete All pages associated with that list also
-        await this.storageManager.deleteObject(
+        const pages = await this.storageManager.deleteObject(
             CustomListStorage.LIST_ENTRIES_COLL,
             {
                 listId: id,
             },
         )
+        return { list, pages }
     }
 
     /**

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -116,6 +116,7 @@ export const search = ({ overwrite } = { overwrite: false }) => async (
     }
 
     // Grab needed derived state for search
+
     const state = getState()
     const searchParams = {
         ...currentQueryParams,
@@ -125,7 +126,8 @@ export const search = ({ overwrite } = { overwrite: false }) => async (
         domainsExclude: filters.domainsExc(state),
         limit: constants.PAGE_SIZE,
         skip: selectors.resultsSkip(state),
-        lists: filters.listFilter(state),
+        // lists for now is just id of one list
+        lists: [filters.listFilter(state)],
     }
 
     try {

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -7,6 +7,7 @@ import { actions as filterActs, selectors as filters } from '../search-filters'
 import * as constants from './constants'
 import * as selectors from './selectors'
 import { fetchTooltip } from './components/tooltips'
+import { actions as sidebarActs } from './sidebar-left'
 
 export const setLoading = createAction('overview/setLoading')
 export const nextPage = createAction('overview/nextPage')
@@ -95,6 +96,8 @@ export const search = ({ overwrite } = { overwrite: false }) => async (
     const firstState = getState()
     const currentQueryParams = selectors.currentQueryParams(firstState)
     const showTooltip = selectors.showTooltip(firstState)
+    if (filters.showClearFiltersBtn(getState()))
+        dispatch(sidebarActs.openSidebarFilterMode())
 
     if (currentQueryParams.query.includes('#')) {
         return

--- a/src/search-filters/Readme.md
+++ b/src/search-filters/Readme.md
@@ -1,0 +1,31 @@
+# Search Filters
+
+This directory contains all the visual interface and redux state for the search filters.
+
+## Directory structure
+
+```
+src/search-filters
+│  Readme.md
+│  index.js
+|  actions.js
+|  reducer.js
+|  selectors.js
+|  container.js
+│
+└──components
+   │   index.js
+   │   BookmarkFilter.css
+   │   BookmarkFilter.js
+   │   FilterBar.jsx
+   │   FilterBar.css
+   │   FilteredRow.css
+   │   FilteredRow.jsx
+   │   IndexDropdownSB.jsx
+   │   IndexDropdownSB.css
+   │   SearchFilters.css
+   └───SearchFilters.js
+```
+
+-   `components`: contains all the components that renders in the overview sidebar, with the custom lists(collections.
+-   `container.js`: The main container for search filters components.

--- a/src/search-filters/container.js
+++ b/src/search-filters/container.js
@@ -34,7 +34,7 @@ class SearchFiltersContainer extends PureComponent {
         fetchSuggestedTags: PropTypes.func.isRequired,
         suggestedTags: PropTypes.arrayOf(PropTypes.string).isRequired,
         fetchSuggestedDomains: PropTypes.func.isRequired,
-        suggestedDomains: PropTypes.arrayOf(PropTypes.string).isRequired,
+        suggestedDomains: PropTypes.arrayOf(PropTypes.object).isRequired,
         toggleFilterTypes: PropTypes.func.isRequired,
         showfilteredTypes: PropTypes.bool.isRequired,
     }

--- a/src/search/search-index-new/search/index.ts
+++ b/src/search/search-index-new/search/index.ts
@@ -25,7 +25,7 @@ export async function search({
         .filterDomains(domains)
         .filterExcDomains(domainsExclude)
         .filterTags(tags)
-        .filterLists([lists])
+        .filterLists(lists)
         .get()
 
     // Short-circuit search if bad term


### PR DESCRIPTION
## Tests and Readme for custom-lists and new search filters. 
### Done
- Add Readme for custom-list module.
- wrote tests for nearly all the background functions.
- Add Readme for new search filter module.
- Open sideber in filter mode if filter is initiated from any search bar.
- Remove tag from filters if no page is associated with it.

### Todo
- Add Readme for `src/overview/sidebar-left` module.
- More tests.