### PR TITLE
Hotfix for scroll into view function in FF.

### DIFF
--- a/src/common-ui/containers/AddListDropdownContainer.js
+++ b/src/common-ui/containers/AddListDropdownContainer.js
@@ -73,8 +73,9 @@ class DropdownContainer extends Component {
     scrollElementIntoViewIfNeeded(domNode) {
         // const parentNode = domNode.parentNode
         // parentNode.scrollTop = domNode.offsetTop - parentNode.offsetTop
-        // domNode.scrollIntoView({ behaviour: 'smooth', block: 'nearest' })
-        domNode.scrollIntoViewIfNeeded()
+        domNode.scrollIntoView({ behaviour: 'smooth', block: 'nearest' })
+        // Gives error in FF.
+        // domNode.scrollIntoViewIfNeeded()
     }
 
     setInputRef = el => (this.inputEl = el)

--- a/src/common-ui/containers/IndexDropdown.tsx
+++ b/src/common-ui/containers/IndexDropdown.tsx
@@ -375,8 +375,6 @@ class IndexDropdownContainer extends Component<Props, State> {
     private renderTags() {
         const tags = this.getDisplayTags()
 
-        // const Row = this.props.isForSidebar ? FilteredRow : IndexDropdownRow
-
         const tagOptions = tags.map((tag, i) => (
             <IndexDropdownRow
                 {...tag}

--- a/src/overview/sidebar-left/components/SidebarIcons.css
+++ b/src/overview/sidebar-left/components/SidebarIcons.css
@@ -42,6 +42,10 @@
     left: -8px;
     width: 105px;
     justify-content: space-evenly;
+
+    @media (max-width: 835px) {
+        display: none !important; /* stylelint-disable-line declaration-no-important */
+    }
 }
 
 .buttonContainer {


### PR DESCRIPTION
- Replace `scrollIntoViewIfNeeded()` by  a better alternative which works for chrome and FF.
- Remove the sidebar icons if screen size is halved.