### PR TITLE
Catch tab state -> content script request error

### DIFF
--- a/src/activity-logger/background/tab-state.ts
+++ b/src/activity-logger/background/tab-state.ts
@@ -89,7 +89,9 @@ class Tab implements TabState {
         }
 
         if (!skipRemoteCall && isLoggable({ url: this.url })) {
-            this._toggleRenderSidebarIFrame(!this.isActive)
+            this._toggleRenderSidebarIFrame(!this.isActive).catch(err => {
+                // Do nothing
+            })
         }
 
         this.isActive = !this.isActive


### PR DESCRIPTION
- sometimes the tab is not available for the remote fn call although it seems very hard to detect when
- noop seems fine; we just don't want it spamming the script console + sentry