### PR TITLE
Remove <p> tag selector rule in content script styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/sidebar-overlay/components/Annotation.css
+++ b/src/sidebar-overlay/components/Annotation.css
@@ -121,7 +121,7 @@
 }
 
 .footerAside {
-    width: 100%;
+    width: 96.5%;
     display: inline-block;
     font-size: 13px;
     text-align: right;
@@ -160,7 +160,7 @@
     font-size: 15px;
     float: left;
     color: #000;
-    margin-left: 15px;
+    margin-left: 5px;
     margin-top: -1px;
 }
 

--- a/src/sidebar-overlay/components/CrowdfundingBox.css
+++ b/src/sidebar-overlay/components/CrowdfundingBox.css
@@ -27,10 +27,6 @@
     }
 }
 
-p {
-    margin-bottom: 0px;
-}
-
 .header {
     color: #3eb995;
     width: 90%;


### PR DESCRIPTION
- the rule removed the bottom margin, however it was doing it for every paragraph due to the selector used
- because it is part of the content script, it gets injected into every page and tries to override every <p> tag
- **good example of why tag selectors shouldn't be used** (classes should be safe with CSS modules)
- should fix #569 
- @oliversauter we should try to get this fix out ASAP as it would interfere with a lot of sites' styles