### PR TITLE
WIP: Fixes for HN Launch

### DIFF
--- a/src/content-tooltip/content_script.js
+++ b/src/content-tooltip/content_script.js
@@ -31,6 +31,7 @@ export async function init() {
         },
     })
     interactions.setupTooltipTrigger(showTooltip)
+    interactions.conditionallyTriggerTooltip(showTooltip)
 }
 
 init()

--- a/src/content-tooltip/interactions.js
+++ b/src/content-tooltip/interactions.js
@@ -77,6 +77,8 @@ function isAnchorOrContentEditable(selected) {
 
 function userSelectedText() {
     const selection = document.getSelection()
+    if (selection.type === 'None') return false
+
     const selectedString = selection.toString().trim()
     const container = selection.getRangeAt(0).commonAncestorContainer
     const extras = isAnchorOrContentEditable(container)

--- a/src/content-tooltip/interactions.js
+++ b/src/content-tooltip/interactions.js
@@ -15,19 +15,35 @@ export function destroyTooltipTrigger() {
 }
 
 export const conditionallyTriggerTooltip = delayed(async (callback, event) => {
+    /*
+    Checks for certain conditions before triggering the tooltip.
+    i) Whether the selection made by the user is just text.
+    ii) Whether the user has enabled the tooltip in his preferences.
+    iii) Whether the selected target is not inside the tooltip itself.
+
+    Event is undefined in the scenario of user selecting the text before the
+    page has loaded. So we don't need to check for condition iii) since the
+    tooltip wouldn't have popped up yet.
+    */
     const isTooltipEnabled = await getTooltipState()
     if (
         !userSelectedText() ||
         !isTooltipEnabled ||
-        isTargetInsideTooltip(event)
+        (event && isTargetInsideTooltip(event))
     ) {
         return
     }
+
+    /*
+    If all the conditions passed, then this returns the position to anchor the
+    tooltip. The positioning is based on the user's preferred method. But in the
+    case of tooltip popping up before page load, it resorts to text based method
+    */
     const positioning = await getPositionState()
     let position
-    if (positioning === 'text') {
+    if (positioning === 'text' || !event) {
         position = calculateTooltipPostion()
-    } else if (positioning === 'mouse') {
+    } else if (positioning === 'mouse' && event) {
         position = { x: event.pageX, y: event.pageY }
     }
     callback(position)

--- a/src/sidebar-overlay/content_script/index.js
+++ b/src/sidebar-overlay/content_script/index.js
@@ -1,9 +1,14 @@
-import { bodyLoader } from 'src/util/loader'
+import { bodyLoader, interactiveLoader } from 'src/util/loader'
 
 import * as interactions from './interactions'
 import { getLocalStorage } from 'src/util/storage'
 
 import { TOOLTIP_STORAGE_NAME } from 'src/content-tooltip/constants'
+
+const onKeydown = e => {
+    if (e.key !== 'm') return
+    interactions.insertRibbon()
+}
 
 const init = async () => {
     interactions.setupRPC()
@@ -11,7 +16,11 @@ const init = async () => {
     const isTooltipEnabled = await getLocalStorage(TOOLTIP_STORAGE_NAME, true)
     if (!isTooltipEnabled) return
 
+    await interactiveLoader()
+    document.addEventListener('keydown', onKeydown, false)
+
     await bodyLoader()
+    document.removeEventListener('keydown', onKeydown, false)
     const passwordInputs = document.querySelectorAll('input[type=password]')
     const hasAPasswordInput = passwordInputs.length > 0
     if (hasAPasswordInput) return


### PR DESCRIPTION
- [x] Trigger tooltip if the user selected text before page load.
- [x] Remove console errors mentioned in previous [issue](https://github.com/WorldBrain/Memex/issues/554#issuecomment-422125067)
- [x] Insert Ribbon at page load using shortcut 'm'

Have used 'm' as the letter to trigger the insertion, using escape stops the page load completely so even the Ribbon doesn't load properly. 😕 Will be good, if any one checks this out...

Apart from this is there any other work I need to push along with this PR?