### PR TITLE
Hotfix/0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/activity-logger/background/tab-bridge.ts
+++ b/src/activity-logger/background/tab-bridge.ts
@@ -11,8 +11,9 @@ const tabChangeListener = new TabChangeListeners({
     pageVisitLogger,
 })
 
-let resolveTabQuery
-const tabQueryP = new Promise(resolve => (resolveTabQuery = resolve))
+// Used to stop of tab updated event listeners while the
+//  tracking of existing tabs is happening.
+let tabQueryP = new Promise(resolve => resolve())
 
 const isTabLoaded = (tab: Tabs.Tab) => tab.status === 'complete'
 
@@ -37,6 +38,8 @@ export const tabUpdatedListener: TabChangeListener = async (
 }
 
 export async function trackExistingTabs({ isNewInstall = false }) {
+    let resolveTabQueryP
+    tabQueryP = new Promise(resolve => (resolveTabQueryP = resolve))
     const tabs = await browser.tabs.query({})
 
     for (const browserTab of tabs) {
@@ -60,7 +63,7 @@ export async function trackExistingTabs({ isNewInstall = false }) {
         }
     }
 
-    resolveTabQuery()
+    resolveTabQueryP()
 }
 
 export async function trackNewTab(id: number) {


### PR DESCRIPTION
Should fix a major bug discovered last night that stops all page visits being indexed once the browser is closed and reopened after the ext updates. This bug was introduced in `0.10.0`.

Check out bcb6e15's commit comments for more detail.