### PR TITLE
Remove hidden HTML element filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/sidebar-overlay/content_script/interactions.js
+++ b/src/sidebar-overlay/content_script/interactions.js
@@ -1,5 +1,3 @@
-import scrollToElement from 'scroll-to-element'
-
 import { highlightAnnotation } from 'src/direct-linking/content_script/rendering'
 import { injectCSS } from 'src/search-injection/dom'
 import { makeRemotelyCallable, remoteFunction } from 'src/util/webextensionRPC'
@@ -20,14 +18,18 @@ export function scrollToHighlight(annotation) {
     )
 
     if ($highlight) {
-        scrollToElement($highlight, {
-            offset: -200,
-            duration: 400,
-        })
+        Element.prototype.documentOffsetTop = function() {
+            return (
+                this.offsetTop +
+                (this.offsetParent ? this.offsetParent.documentOffsetTop() : 0)
+            )
+        }
+
+        const top = $highlight.documentOffsetTop() - window.innerHeight / 2
+        window.scrollTo({ top, behavior: 'smooth' })
         // The pixels scrolled need to be returned in
         // order to restrict scrolling when mouse is
         // over the iFrame
-        const top = getOffsetTop($highlight) - 200
         return top
     } else {
         console.error('MEMEX: Oops, no highlight found to scroll to')

--- a/src/util/transform-page-html.js
+++ b/src/util/transform-page-html.js
@@ -28,14 +28,6 @@ export default function transformHTML({ html = '' }) {
     $('code').remove()
     $('select').remove()
 
-    // This should remove all hidden items on pages
-    $('*').each(function() {
-        const display = $(this).css('display')
-        const visibility = $(this).css('visibility')
-        if (display === 'none' || visibility === 'hidden') {
-            $(this).remove()
-        }
-    })
     // Remove style only after removing hidden elements
     $('style').remove()
 


### PR DESCRIPTION
- because it's super slow going through every single element on the page and checking their styles in linear time
- addresses #612
- set this up as a hotfix branch, as I thought it would be nice to get it in ASAP but simple to convert into a feature branch if desired (@oliversauter)