### PR TITLE
Wait for sidebar to setup before attempting annot scroll

### DIFF
--- a/src/sidebar-overlay/components/Ribbon.js
+++ b/src/sidebar-overlay/components/Ribbon.js
@@ -236,37 +236,41 @@ class Ribbon extends React.Component {
         })
     }
 
-    openSidebar = () => {
-        return this.setState(
-            {
-                isSidebarActive: true,
-                shouldRenderIFrame: true,
-            },
-            async () => {
-                if (!this.frameFC) {
-                    this.setupFrameFunctions()
-                }
-                await this.frameFC.remoteExecute('setLoaderActive')()
-                await this.fetchAnnotations()
-                const highlightables = this.state.annotations.filter(
-                    annotation => annotation.selector,
-                )
-                await this.props.highlightAll(
-                    highlightables,
-                    this.focusAnnotationContainer,
-                    this.hoverAnnotationContainer,
-                )
-                this.frameFC.remoteExecute('focusCommentBox')(true)
-
-                setTimeout(() => {
-                    const sorted = this.props.sortAnnotationByPosition(
-                        this.state.annotations,
+    openSidebar = () =>
+        new Promise(resolve => {
+            return this.setState(
+                {
+                    isSidebarActive: true,
+                    shouldRenderIFrame: true,
+                },
+                async () => {
+                    if (!this.frameFC) {
+                        this.setupFrameFunctions()
+                    }
+                    await this.frameFC.remoteExecute('setLoaderActive')()
+                    await this.fetchAnnotations()
+                    const highlightables = this.state.annotations.filter(
+                        annotation => annotation.selector,
                     )
-                    this.frameFC.remoteExecute('setAnnotations')(sorted)
-                }, 400)
-            },
-        )
-    }
+                    await this.props.highlightAll(
+                        highlightables,
+                        this.focusAnnotationContainer,
+                        this.hoverAnnotationContainer,
+                    )
+                    this.frameFC.remoteExecute('focusCommentBox')(true)
+
+                    setTimeout(async () => {
+                        const sorted = this.props.sortAnnotationByPosition(
+                            this.state.annotations,
+                        )
+                        await this.frameFC.remoteExecute('setAnnotations')(
+                            sorted,
+                        )
+                        resolve()
+                    }, 400)
+                },
+            )
+        })
 
     openSidebarAndSendAnchor = async anchor => {
         await this.openSidebar()


### PR DESCRIPTION
- the `openSidebar` method wasn't actually returning a `Promise`, although all invoking code treated it as if it did
- should fix #618
- regressed in e6693cfdc86309b7bd1c1e5249eee1f656cec861