### PR TITLE
Add a 'Back button' for Tag and Collection popup

### DIFF
--- a/src/common-ui/components/IndexDropdown.css
+++ b/src/common-ui/components/IndexDropdown.css
@@ -52,21 +52,26 @@
 .backButton {
     border: none;
     outline: none;
-    margin-top: 6px;
+    grid-area: backButton;
+    justify-self: center;
+    align-self: center;
+    font-size: 1em;
+    padding: 0;
 }
 
 .numberTags {
-    align-items: flex-start;
-    margin-top: 6px;
+    grid-area: numberTags;
+    justify-self: center;
+    align-self: center;
     color: #777;
 }
 
 .summaryTagContainer {
     width: 100%;
-    display: flex;
-    padding-top: 10px;
-    justify-content: space-around;
-    padding-bottom: 10px;
+    display: grid;
+    grid-template-columns: 1fr 1.5fr 1fr;
+    grid-template-areas: 'backButton numberTags .';
+    padding: 10px 0;
     background: white;
 }
 

--- a/src/common-ui/components/IndexDropdown.css
+++ b/src/common-ui/components/IndexDropdown.css
@@ -49,6 +49,12 @@
     }
 }
 
+.backButton {
+    border: none;
+    outline: none;
+    margin-top: 6px;
+}
+
 .numberTags {
     align-items: flex-start;
     margin-top: 6px;

--- a/src/common-ui/components/IndexDropdown.css
+++ b/src/common-ui/components/IndexDropdown.css
@@ -56,7 +56,12 @@
     justify-self: center;
     align-self: center;
     font-size: 1em;
-    padding: 0;
+    background-color: #3eb995;
+    border-radius: 4px;
+    padding: 3px 7px 4px 7px;
+    color: white;
+    margin-top: 3px;
+    cursor: pointer;
 }
 
 .numberTags {
@@ -64,6 +69,7 @@
     justify-self: center;
     align-self: center;
     color: #777;
+    padding-top: 2px;
 }
 
 .summaryTagContainer {

--- a/src/common-ui/components/IndexDropdown.js
+++ b/src/common-ui/components/IndexDropdown.js
@@ -116,10 +116,7 @@ class IndexDropdown extends PureComponent {
                     <div className={this.styles.summaryTagContainer}>
                         {!this.props.isForAnnotation && (
                             <button
-                                className={cx(
-                                    this.styles.backButton,
-                                    this.styles.bold,
-                                )}
+                                className={this.styles.backButton}
                                 onClick={this.props.onBackBtnClick}
                             >
                                 &lt;Back

--- a/src/common-ui/components/IndexDropdown.js
+++ b/src/common-ui/components/IndexDropdown.js
@@ -26,6 +26,7 @@ class IndexDropdown extends PureComponent {
         isForSidebar: PropTypes.bool,
         clearSearchField: PropTypes.func,
         showClearfieldBtn: PropTypes.bool,
+        onBackBtnClick: PropTypes.func,
     }
 
     get styles() {
@@ -113,6 +114,17 @@ class IndexDropdown extends PureComponent {
                 </div>
                 {!this.props.isForSidebar && (
                     <div className={this.styles.summaryTagContainer}>
+                        {!this.props.isForAnnotation && (
+                            <button
+                                className={cx(
+                                    this.styles.backButton,
+                                    this.styles.bold,
+                                )}
+                                onClick={this.props.onBackBtnClick}
+                            >
+                                &lt;Back
+                            </button>
+                        )}
                         <div className={this.styles.numberTags}>
                             <span className={this.styles.bold}>
                                 {this.props.numberOfTags}

--- a/src/common-ui/components/IndexDropdown.js
+++ b/src/common-ui/components/IndexDropdown.js
@@ -119,7 +119,7 @@ class IndexDropdown extends PureComponent {
                                 className={this.styles.backButton}
                                 onClick={this.props.onBackBtnClick}
                             >
-                                &lt;Back
+                                Back
                             </button>
                         )}
                         <div className={this.styles.numberTags}>

--- a/src/common-ui/containers/IndexDropdown.tsx
+++ b/src/common-ui/containers/IndexDropdown.tsx
@@ -87,7 +87,7 @@ class IndexDropdownContainer extends Component<Props, State> {
         }
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps: Props) {
         // Checking for initFilters' length is better as component updates only
         // when a filter is added or deleted, which implies that the length of
         // props.initFilters will differ across two updates.
@@ -218,10 +218,9 @@ class IndexDropdownContainer extends Component<Props, State> {
      */
     private handleTagSelection = (index: number) => async event => {
         const tag = this.state.displayFilters[index]
-        const pageHasTag = this.state.filters.includes(tag)
 
         // Either add or remove the tag, let Redux handle the store changes.
-        if (!pageHasTag) {
+        if (!this.pageHasTag(tag)) {
             if (this.allowIndexUpdate) {
                 this.addTagRPC({
                     url: this.props.url,
@@ -324,7 +323,7 @@ class IndexDropdownContainer extends Component<Props, State> {
     ) => {
         const searchVal = event.currentTarget.value
 
-        // If user backspaces to clear input, show the current assoc tags again
+        // If user backspaces to clear input, show the list of suggested tags again.
         let displayFilters
         let clearFieldBtn
         if (!searchVal.length) {

--- a/src/custom-lists/background/index.js
+++ b/src/custom-lists/background/index.js
@@ -29,7 +29,9 @@ export default class CustomListBackground {
             fetchAllLists: (...params) => {
                 return this.fetchAllLists(...params)
             },
-
+            fetchListById: (...params) => {
+                return this.fetchListById(...params)
+            },
             fetchListPagesByUrl: (...params) => {
                 return this.fetchListPagesByUrl(...params)
             },
@@ -56,6 +58,16 @@ export default class CustomListBackground {
         }
 
         return this.storage.fetchAllLists({ query, opts })
+    }
+
+    /**
+     * Takes an id and returns the list object associated with it.
+     * @param {Object} obj
+     * @param {number} id
+     * @returns {Object}
+     */
+    async fetchListById({ id }) {
+        return this.storage.fetchListById(id)
     }
 
     /**

--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -95,12 +95,11 @@ export default class CustomListStorage extends FeatureStorage {
     /**
      *  Fetch list By Id.
      *
-     * @private
      * @param {number} id
-     * @returns {PageList}
+     * @returns
      * @memberof CustomListStorage
      */
-    private async fetchListById(id: number) {
+    async fetchListById(id: number) {
         const list = await this.storageManager.findObject<PageList>(
             CustomListStorage.CUSTOM_LISTS_COLL,
             { id },

--- a/src/popup/collections-button/actions.ts
+++ b/src/popup/collections-button/actions.ts
@@ -1,18 +1,24 @@
 import { createAction } from 'redux-act'
 
 import { Thunk } from '../types'
+import { PageList } from '../../custom-lists/background/types'
 import * as selectors from './selectors'
 
 export const setShowCollectionsPicker = createAction<boolean>(
     'collections/showCollectionsPicker',
 )
 
-export const setCollections = createAction<string[]>(
+export const setCollections = createAction<PageList[]>(
     'collections/setCollections',
 )
-export const setInitColls = createAction<string[]>('collections/setInitColls')
+export const setInitColls = createAction<PageList[]>('collections/setInitColls')
 
 export const toggleShowTagsPicker: () => Thunk = () => (dispatch, getState) =>
     dispatch(
         setShowCollectionsPicker(!selectors.showCollectionsPicker(getState())),
     )
+
+export const addCollection = createAction<PageList>('collections/addCollection')
+export const deleteCollection = createAction<PageList>(
+    'collections/deleteCollection',
+)

--- a/src/popup/collections-button/reducer.ts
+++ b/src/popup/collections-button/reducer.ts
@@ -1,14 +1,15 @@
 import { createReducer } from 'redux-act'
 
 import * as acts from './actions'
+import { PageList } from '../../custom-lists/background/types'
 
 export interface State {
     /** Denotes whether or not the popup should show the collections picker. */
     showCollectionsPicker: boolean
     /** Holds the collections associated with the page. */
-    collections: string[]
+    collections: PageList[]
     /** Holds the initial list suggestions to display for user list search. */
-    initCollSuggestions: string[]
+    initCollSuggestions: PageList[]
 }
 
 export const defState: State = {
@@ -33,5 +34,54 @@ reducer.on(acts.setInitColls, (state, payload) => ({
     ...state,
     initCollSuggestions: payload,
 }))
+
+reducer.on(acts.addCollection, (state, payload) => {
+    // Create a new suggested collection if it doesn't already exist, otherwise
+    // just move it the front.
+    const index = state.initCollSuggestions.findIndex(
+        collection => collection.id === payload.id,
+    )
+    const initCollSuggestions =
+        index === -1
+            ? [{ ...payload, active: true }, ...state.initCollSuggestions]
+            : [
+                  { ...payload, active: true },
+                  ...state.initCollSuggestions.slice(0, index),
+                  ...state.initCollSuggestions.slice(index + 1),
+              ]
+    return {
+        ...state,
+        collections: [{ ...payload, active: true }, ...state.collections],
+        initCollSuggestions,
+    }
+})
+
+reducer.on(acts.deleteCollection, (state, payload) => {
+    const collectionIndex = state.collections.findIndex(
+        collection => collection.id === payload.id,
+    )
+    const suggestionIndex = state.initCollSuggestions.findIndex(
+        collection => collection.id === payload.id,
+    )
+
+    // Remote the collection from the list of collections.
+    const collections = [
+        ...state.collections.slice(0, collectionIndex),
+        ...state.collections.slice(collectionIndex + 1),
+    ]
+
+    // Move the suggested collection to the back of the list of suggested collections.
+    const initCollSuggestions = [
+        ...state.initCollSuggestions.slice(0, suggestionIndex),
+        ...state.initCollSuggestions.slice(suggestionIndex + 1),
+        { ...state.initCollSuggestions[suggestionIndex], active: false },
+    ]
+
+    return {
+        ...state,
+        collections,
+        initCollSuggestions,
+    }
+})
 
 export default reducer

--- a/src/popup/container.tsx
+++ b/src/popup/container.tsx
@@ -18,9 +18,10 @@ import ButtonIcon from './components/ButtonIcon'
 import { TooltipButton } from './tooltip-button'
 import { NotifButton } from './notif-button'
 import { HistoryPauser } from './pause-button'
-import { selectors as tags, TagsButton } from './tags-button'
+import { selectors as tags, acts as tagActs, TagsButton } from './tags-button'
 import {
     selectors as collections,
+    acts as collectionActs,
     CollectionsButton,
 } from './collections-button'
 import {
@@ -32,6 +33,7 @@ import { BookmarkButton } from './bookmark-button'
 import * as selectors from './selectors'
 import * as acts from './actions'
 import { ClickHandler, RootState } from './types'
+import { PageList } from '../custom-lists/background/types'
 
 const btnStyles = require('./components/Button.css')
 const styles = require('./components/Popup.css')
@@ -45,15 +47,21 @@ interface StateProps {
     tabId: number
     url: string
     tags: string[]
-    collections: any[]
+    collections: PageList[]
     searchValue: string
     initTagSuggs: string[]
-    initCollSuggs: any[]
+    initCollSuggs: PageList[]
 }
 
 interface DispatchProps {
     initState: () => Promise<void>
     handleSearchChange: ClickHandler<HTMLInputElement>
+    toggleShowTagsPicker: () => void
+    toggleShowCollectionsPicker: () => void
+    onTagAdd: (tag: string) => void
+    onTagDel: (tag: string) => void
+    onCollectionAdd: (collection: PageList) => void
+    onCollectionDel: (collection: PageList) => void
 }
 
 export type Props = OwnProps & StateProps & DispatchProps
@@ -103,6 +111,9 @@ class PopupContainer extends PureComponent<Props> {
                     initFilters={this.props.tags}
                     initSuggestions={this.props.initTagSuggs}
                     source="tag"
+                    onBackBtnClick={this.props.toggleShowTagsPicker}
+                    onFilterAdd={this.props.onTagAdd}
+                    onFilterDel={this.props.onTagDel}
                 />
             )
         }
@@ -114,6 +125,9 @@ class PopupContainer extends PureComponent<Props> {
                     results={this.props.collections}
                     initSuggestions={this.props.initCollSuggs}
                     url={this.props.url}
+                    onBackBtnClick={this.props.toggleShowCollectionsPicker}
+                    onFilterAdd={this.props.onCollectionAdd}
+                    onFilterDel={this.props.onCollectionDel}
                 />
             )
         }
@@ -189,6 +203,15 @@ const mapDispatch = (dispatch): DispatchProps => ({
         const input = e.target as HTMLInputElement
         dispatch(acts.setSearchVal(input.value))
     },
+    toggleShowTagsPicker: () => dispatch(tagActs.toggleShowTagsPicker()),
+    toggleShowCollectionsPicker: () =>
+        dispatch(collectionActs.toggleShowTagsPicker()),
+    onTagAdd: (tag: string) => dispatch(tagActs.addTag(tag)),
+    onTagDel: (tag: string) => dispatch(tagActs.deleteTag(tag)),
+    onCollectionAdd: (collection: PageList) =>
+        dispatch(collectionActs.addCollection(collection)),
+    onCollectionDel: (collection: PageList) =>
+        dispatch(collectionActs.deleteCollection(collection)),
 })
 
 export default connect<StateProps, DispatchProps, OwnProps>(

--- a/src/popup/container.tsx
+++ b/src/popup/container.tsx
@@ -122,7 +122,7 @@ class PopupContainer extends PureComponent<Props> {
             return (
                 <AddListDropdownContainer
                     mode="popup"
-                    results={this.props.collections}
+                    initLists={this.props.collections}
                     initSuggestions={this.props.initCollSuggs}
                     url={this.props.url}
                     onBackBtnClick={this.props.toggleShowCollectionsPicker}

--- a/src/popup/tags-button/actions.ts
+++ b/src/popup/tags-button/actions.ts
@@ -11,3 +11,6 @@ export const setInitTagSuggests = createAction<string[]>(
 
 export const toggleShowTagsPicker: () => Thunk = () => (dispatch, getState) =>
     dispatch(setShowTagsPicker(!selectors.showTagsPicker(getState())))
+
+export const addTag = createAction<string>('tags/addTag')
+export const deleteTag = createAction<string>('tags/deleteTag')

--- a/src/popup/tags-button/reducer.ts
+++ b/src/popup/tags-button/reducer.ts
@@ -34,4 +34,47 @@ reducer.on(acts.setInitTagSuggests, (state, payload) => ({
     initTagSuggestions: payload,
 }))
 
+reducer.on(acts.addTag, (state, payload) => {
+    // Create a new suggested tag if it doesn't already exist, otherwise just
+    // move it the front.
+    const index = state.initTagSuggestions.indexOf(payload)
+    const initTagSuggestions =
+        index === -1
+            ? [payload, ...state.initTagSuggestions]
+            : [
+                  payload,
+                  ...state.initTagSuggestions.slice(0, index),
+                  ...state.initTagSuggestions.slice(index + 1),
+              ]
+    return {
+        ...state,
+        tags: [payload, ...state.tags],
+        initTagSuggestions,
+    }
+})
+
+reducer.on(acts.deleteTag, (state, payload) => {
+    const tagIndex = state.tags.indexOf(payload)
+    const suggestionIndex = state.initTagSuggestions.indexOf(payload)
+
+    // Remote the tag from the list of tags.
+    const tags = [
+        ...state.tags.slice(0, tagIndex),
+        ...state.tags.slice(tagIndex + 1),
+    ]
+
+    // Move the suggested tag to the back of the list of suggested tags.
+    const initTagSuggestions = [
+        ...state.initTagSuggestions.slice(0, suggestionIndex),
+        ...state.initTagSuggestions.slice(suggestionIndex + 1),
+        state.initTagSuggestions[suggestionIndex],
+    ]
+
+    return {
+        ...state,
+        tags,
+        initTagSuggestions,
+    }
+})
+
 export default reducer


### PR DESCRIPTION
## Changes involved

- [x] Add a back button for tag and collection popup menus
- [x] Fix a bug in tag and collection popup menus that caused the suggestions to disappear if the user had entered something in the searchbar and cleared it
- [x] Unify the behavior of Tag and Collection popup menus by letting Redux handle adding and deleting tags/collections instead of adding and deleting them in the components themselves.
- [x] Change the types of actions and reducers for collection popup menus to the ones that are actually being used (instead of 'string')
- [x] Convert the file `AddListDropdownContainer` to TypeScript
- [x] Style the back button properly. Currently it has been styled like it's done [here](https://www.notion.so/quintessentials/Back-button-on-tag-and-collection-popup-menu-4fa135147f3b4be2822bccd5a797a7d3) on Notion. (The gifs are outdated in terms of style. Refer Notion link for the style)

## Demo

### Back button

**Old behavior:** When a user had to add a tag to a page, and add the page to a collection, they had to reopen the popup to do so.
**New behavior:** Wait for it...
![demo-1](https://user-images.githubusercontent.com/30660843/49332847-8e11b180-f5da-11e8-9969-3bab7a8b26ac.gif)

### Tag/collection popup menu

**Old behavior:** Typing into the searchbar and clearing it means losing suggestions.
![demo-2a](https://user-images.githubusercontent.com/30660843/49333069-3e34e980-f5de-11e8-8d0a-4ac9a7e458ac.gif)

**New behavior:** Predictable and intuitive like many other applications.
![demo-2b](https://user-images.githubusercontent.com/30660843/49333071-47be5180-f5de-11e8-8d8d-000ce98a43aa.gif)

Demo shows the working of Tag popup menu. Collection popup menu works similarly.
