### PR TITLE
Critical fix for no ribbon on FF

### DIFF
--- a/src/content-tooltip/content_script.ts
+++ b/src/content-tooltip/content_script.ts
@@ -61,15 +61,15 @@ export default async function init({
 const CLOSE_MESSAGESHOWN_KEY = 'tooltip.close-message-shown'
 
 export async function _setCloseMessageShown() {
-    await window['browser'].storage.local.set({
+    await browser.storage.local.set({
         [CLOSE_MESSAGESHOWN_KEY]: true,
     })
 }
 
 export async function _getCloseMessageShown() {
-    const { [CLOSE_MESSAGESHOWN_KEY]: closeMessageShown } = await window[
-        'browser'
-    ].storage.local.get({ [CLOSE_MESSAGESHOWN_KEY]: false })
+    const {
+        [CLOSE_MESSAGESHOWN_KEY]: closeMessageShown,
+    } = await browser.storage.local.get({ [CLOSE_MESSAGESHOWN_KEY]: false })
 
     return closeMessageShown
 }

--- a/src/sidebar-overlay/content_script/interactions.js
+++ b/src/sidebar-overlay/content_script/interactions.js
@@ -1,4 +1,5 @@
 import retargetEvents from 'react-shadow-dom-retarget-events'
+import { browser } from 'webextension-polyfill-ts'
 
 import { highlightAnnotation } from 'src/direct-linking/content_script/rendering'
 import { makeRemotelyCallable, remoteFunction } from 'src/util/webextensionRPC'
@@ -71,15 +72,15 @@ export const highlightAnnotations = async (
 const CLOSE_MESSAGESHOWN_KEY = 'ribbon.close-message-shown'
 
 const _setCloseMessageShown = async () => {
-    await window['browser'].storage.local.set({
+    await browser.storage.local.set({
         [CLOSE_MESSAGESHOWN_KEY]: true,
     })
 }
 
 const _getCloseMessageShown = async () => {
-    const { [CLOSE_MESSAGESHOWN_KEY]: closeMessageShown } = await window[
-        'browser'
-    ].storage.local.get({ [CLOSE_MESSAGESHOWN_KEY]: false })
+    const {
+        [CLOSE_MESSAGESHOWN_KEY]: closeMessageShown,
+    } = await browser.storage.local.get({ [CLOSE_MESSAGESHOWN_KEY]: false })
 
     return closeMessageShown
 }

--- a/src/sidebar-overlay/content_script/rendering.ts
+++ b/src/sidebar-overlay/content_script/rendering.ts
@@ -1,3 +1,5 @@
+import { browser } from 'webextension-polyfill-ts'
+
 import { injectCSS } from '../../search-injection/dom'
 
 const CONTAINER_CLASS = 'memex-annotations-ribbon-container'
@@ -15,7 +17,7 @@ export function createRootElement({
     container.classList.add(CONTAINER_CLASS)
     container.setAttribute('id', containerId)
 
-    const cssFile = window['browser'].extension.getURL('/content_script.css')
+    const cssFile = browser.runtime.getURL('/content_script.css')
     const { rootElement, shadow } = createShadowRootIfSupported(
         container,
         rootId,

--- a/src/toolbar-notification/content_script/rendering.ts
+++ b/src/toolbar-notification/content_script/rendering.ts
@@ -1,4 +1,6 @@
-import { injectCSS } from 'src/search-injection/dom'
+import { browser } from 'webextension-polyfill-ts'
+
+import { injectCSS } from '../../search-injection/dom'
 
 const CONTAINER_CLASS = 'memex-tooltip-notification'
 
@@ -6,7 +8,7 @@ export function createRootElement() {
     const container = document.createElement('div')
     container.classList.add(CONTAINER_CLASS)
 
-    const cssFile = window['browser'].extension.getURL('/content_script.css')
+    const cssFile = browser.runtime.getURL('/content_script.css')
     const { rootElement, shadow } = createShadowRootIfSupported(
         container,
         cssFile,


### PR DESCRIPTION
Fixes #645

Sidenote: Changed `browser.extension.getURL` to `browser.runtime.getURL` as it is stated as "deprecated" on MDN.