### PR TITLE
Allow updating Ribbon's state on tab change

### DIFF
--- a/src/activity-logger/background/tab-state.ts
+++ b/src/activity-logger/background/tab-state.ts
@@ -87,6 +87,14 @@ class Tab implements TabState {
         return remoteFunction('insertOrRemoveTooltip', { tabId: this.id })()
     }
 
+    private async _updateRibbonState() {
+        if (!this.isLoaded || !isLoggable({ url: this.url })) {
+            return
+        }
+
+        return remoteFunction('updateRibbon', { tabId: this.id })()
+    }
+
     private _pauseLogTimer() {
         if (this._timer != null) {
             this._timer.pause()
@@ -139,6 +147,7 @@ class Tab implements TabState {
         if (!skipRemoteCall) {
             this._toggleTooltip()
             this._toggleRibbon()
+            this._updateRibbonState()
             this._toggleRenderSidebarIFrame(!this.isActive)
         }
 

--- a/src/popup/tooltip-button/actions.ts
+++ b/src/popup/tooltip-button/actions.ts
@@ -37,9 +37,11 @@ export const toggleTooltipFlag: () => Thunk = () => async (
     const tabId = popup.tabId(state)
     if (wasEnabled) {
         await remoteFunction('removeTooltip', { tabId })()
+        await remoteFunction('updateRibbon', { tabId })()
     } else {
         await remoteFunction('insertTooltip', { tabId })()
         await remoteFunction('showContentTooltip', { tabId })()
+        await remoteFunction('updateRibbon', { tabId })()
     }
 }
 

--- a/src/sidebar-overlay/components/Ribbon.js
+++ b/src/sidebar-overlay/components/Ribbon.js
@@ -210,6 +210,10 @@ class Ribbon extends React.Component {
         this.ribbonRef.removeEventListener('mouseleave', this.handleMouseLeave)
     }
 
+    updateState = ({ isRibbonEnabled, isTooltipEnabled }) => {
+        this.setState({ isRibbonEnabled, isTooltipEnabled })
+    }
+
     highlightAndScroll = async annotation => {
         const top = await this.props.highlightAndScroll(annotation)
         this.setState({

--- a/src/sidebar-overlay/components/index.js
+++ b/src/sidebar-overlay/components/index.js
@@ -16,6 +16,7 @@ export const setupRibbonUI = (
         getInitialState,
         handleRibbonToggle,
         handleTooltipToggle,
+        setRibbonRef,
     },
 ) => {
     const sidebarURL = browser.extension.getURL('sidebar.html')
@@ -23,9 +24,11 @@ export const setupRibbonUI = (
     ReactDOM.render(
         <Ribbon
             onInit={onInit}
-            destroy={() => {
+            destroy={e => {
+                e.stopPropagation()
                 onClose()
             }}
+            ref={setRibbonRef}
             getInitialState={getInitialState}
             handleRibbonToggle={handleRibbonToggle}
             handleTooltipToggle={handleTooltipToggle}

--- a/src/sidebar-overlay/content_script/index.ts
+++ b/src/sidebar-overlay/content_script/index.ts
@@ -3,7 +3,10 @@ import ToolbarNotifications from '../../toolbar-notification/content_script'
 import * as interactions from './interactions'
 import { getSidebarState } from '../utils'
 
-const onKeydown = (e, toolbarNotifications) => {
+const onKeydown = (
+    e: KeyboardEvent,
+    toolbarNotifications: ToolbarNotifications,
+) => {
     if (e.key !== 'm') {
         return
     }

--- a/src/sidebar-overlay/content_script/interactions.js
+++ b/src/sidebar-overlay/content_script/interactions.js
@@ -15,6 +15,204 @@ import {
 
 const openOptionsRPC = remoteFunction('openOptionsTab')
 
+let target = null /* Target container for the Ribbon. */
+let shadowRoot = null /* Root of the shadow DOM in which ribbon is inserted. */
+let toggleSidebar = null /* Promise that resolves to toggling the sidebar. */
+
+/**
+ * Reference to the actual Ribbon component. Useful for updating the state of
+ * the ribbon from outside the component.
+ */
+let ribbonRef = null
+
+/* Denotes whether the user inserted/removed ribbon by his/her own self. */
+let manualOverride = false
+
+/**
+ * Creates target container for Ribbon and Sidebar shadow DOM.
+ * Injects content_script.css.
+ * Mounts Ribbon React component.
+ * Sets up shadow DOM <--> webpage Remote functions.
+ *
+ * If ribbon is already inserted, then updates the ribbon.
+ */
+export const insertRibbon = async ({ toolbarNotifications }) => {
+    // If target is set, Ribbon has already been injected.
+    if (target) {
+        await updateRibbon()
+        return
+    }
+
+    let resolveToggleSidebar
+    toggleSidebar = new Promise(resolve => {
+        resolveToggleSidebar = resolve
+    })
+
+    const { shadow, rootElement } = createRootElement({
+        containerId: 'memex-annotations-ribbon-container',
+        rootId: 'memex-annotations-ribbon',
+        classNames: ['memex-annotations-ribbon'],
+    })
+    target = rootElement
+    shadowRoot = shadow
+
+    // React messes up event propagation with shadow dom, hence fix.
+    retargetEvents(shadowRoot)
+
+    setupRibbonUI(target, {
+        onInit: ({ toggleSidebar }) => {
+            resolveToggleSidebar(toggleSidebar)
+        },
+        onClose: async () => {
+            manualOverride = true
+            removeRibbon()
+
+            const closeMessageShown = await _getCloseMessageShown()
+            if (!closeMessageShown) {
+                toolbarNotifications.showToolbarNotification(
+                    'ribbon-first-close',
+                )
+                _setCloseMessageShown()
+            }
+        },
+        getInitialState: async () => {
+            const isTooltipEnabled = await getTooltipState()
+            const isRibbonEnabled = await getSidebarState()
+            return { isTooltipEnabled, isRibbonEnabled }
+        },
+        handleRibbonToggle: async prevState => {
+            await setSidebarState(!prevState)
+        },
+        handleTooltipToggle: async isTooltipEnabled => {
+            if (isTooltipEnabled) {
+                removeTooltip()
+            } else {
+                await insertTooltip({ toolbarNotifications })
+            }
+            await setTooltipState(!isTooltipEnabled)
+        },
+        setRibbonRef: ribbon => {
+            ribbonRef = ribbon
+        },
+    })
+}
+
+/**
+ * Removes the ribbon and sidebar from the DOM (if it is present) after
+ * removing the highlights from the page. Also destroys the container.
+ */
+const removeRibbon = () => {
+    if (!target) {
+        return
+    }
+    removeHighlights()
+    destroyAll(target, shadowRoot)()
+    destroyRootElement()
+    shadowRoot = null
+    target = null
+    toggleSidebar = null
+    ribbonRef = null
+}
+
+/**
+ * Inserts or removes ribbon from the page (if not overridden manually).
+ * Should either be called through the RPC, or pass the `toolbarNotifications`
+ * wrapped in an object.
+ */
+const insertOrRemoveRibbon = async ({ toolbarNotifications }) => {
+    if (manualOverride) {
+        return
+    }
+
+    const isRibbonEnabled = await getSidebarState()
+    const isRibbonPresent = !!target
+
+    if (isRibbonEnabled && !isRibbonPresent) {
+        insertRibbon({ toolbarNotifications })
+    } else if (!isRibbonEnabled && isRibbonPresent) {
+        removeRibbon()
+    }
+}
+
+/**
+ * Updates the ribbon state if it is present.
+ * Fetches whether the sidebar and tooltip are enabled.
+ * Tells the ribbon to update its state with those values.
+ */
+const updateRibbon = async () => {
+    if (!target) {
+        return
+    }
+
+    // Get ribbon and tooltip state.
+    const isRibbonEnabled = await getSidebarState()
+    const isTooltipEnabled = await getTooltipState()
+
+    ribbonRef.getInstance().updateState({ isRibbonEnabled, isTooltipEnabled })
+}
+
+/**
+ * Setups up RPC functions for the ribbon.
+ */
+export const setupRPC = ({ toolbarNotifications }) => {
+    makeRemotelyCallable({
+        /**
+         * Used for opening the sidebar. If the ribbon is not present in the
+         * DOM, the ribbon is first inserted and then the sidebar is opened.
+         */
+        toggleSidebarOverlay: async () => {
+            if (!toggleSidebar) {
+                manualOverride = true
+                insertRibbon({ toolbarNotifications })
+            }
+            return toggleSidebar.then(f => f())
+        },
+        /**
+         * Used for inserting the ribbon.
+         * @param {{override: boolean}} options Takes in an object with property `override`.
+         */
+        insertRibbon: ({ override } = {}) => {
+            manualOverride = !!override
+            insertRibbon({ toolbarNotifications })
+        },
+        /**
+         * Used for removing the ribbon.
+         * @param {{override: boolean}} options Takes in an object with property `override`.
+         */
+        removeRibbon: ({ override } = {}) => {
+            manualOverride = !!override
+            removeRibbon()
+        },
+        /**
+         * Inserts or removes the ribbon from the page depending on whether it
+         * is enabled or not.
+         */
+        insertOrRemoveRibbon: async () => {
+            await insertOrRemoveRibbon({ toolbarNotifications })
+        },
+        /**
+         * RPC for updating the ribbon's state.
+         */
+        updateRibbon,
+    })
+}
+
+const CLOSE_MESSAGESHOWN_KEY = 'ribbon.close-message-shown'
+
+const _setCloseMessageShown = async () => {
+    await browser.storage.local.set({
+        [CLOSE_MESSAGESHOWN_KEY]: true,
+    })
+}
+
+const _getCloseMessageShown = async () => {
+    const {
+        [CLOSE_MESSAGESHOWN_KEY]: closeMessageShown,
+    } = await browser.storage.local.get({ [CLOSE_MESSAGESHOWN_KEY]: false })
+
+    return closeMessageShown
+}
+
 /**
  * Scrolls to the highlight of the passed annotation.
  * @param {*} annotation The annotation object to scroll to.
@@ -71,151 +269,6 @@ export const highlightAnnotations = async (
             hoverAnnotationContainer,
         ),
     )
-}
-
-const CLOSE_MESSAGESHOWN_KEY = 'ribbon.close-message-shown'
-
-const _setCloseMessageShown = async () => {
-    await browser.storage.local.set({
-        [CLOSE_MESSAGESHOWN_KEY]: true,
-    })
-}
-
-const _getCloseMessageShown = async () => {
-    const {
-        [CLOSE_MESSAGESHOWN_KEY]: closeMessageShown,
-    } = await browser.storage.local.get({ [CLOSE_MESSAGESHOWN_KEY]: false })
-
-    return closeMessageShown
-}
-
-// Target container for the Ribbon/Sidebar shadow DOM.
-let target = null
-let shadowRoot = null
-let toggleSidebar = null
-
-/* Denotes whether the user inserted/removed ribbon by his/her own self. */
-let manualOverride = false
-
-/**
- * Creates target container for Ribbon and Sidebar shadow DOM.
- * Injects content_script.css.
- * Mounts Ribbon React component.
- * Sets up shadow DOM <--> webpage Remote functions.
- */
-export const insertRibbon = ({ toolbarNotifications }) => {
-    // If target is set, Ribbon has already been injected.
-    if (target) {
-        return
-    }
-
-    let resolveToggleSidebar
-    toggleSidebar = new Promise(resolve => {
-        resolveToggleSidebar = resolve
-    })
-
-    const { shadow, rootElement } = createRootElement({
-        containerId: 'memex-annotations-ribbon-container',
-        rootId: 'memex-annotations-ribbon',
-        classNames: ['memex-annotations-ribbon'],
-    })
-    target = rootElement
-    shadowRoot = shadow
-
-    // React messes up event propagation with shadow dom, hence fix.
-    retargetEvents(shadowRoot)
-
-    setupRibbonUI(target, {
-        onInit: ({ toggleSidebar }) => {
-            resolveToggleSidebar(toggleSidebar)
-        },
-        onClose: async () => {
-            manualOverride = true
-            removeRibbon()
-
-            const closeMessageShown = await _getCloseMessageShown()
-            if (!closeMessageShown) {
-                toolbarNotifications.showToolbarNotification(
-                    'ribbon-first-close',
-                )
-                _setCloseMessageShown()
-            }
-        },
-        getInitialState: async () => {
-            const isTooltipEnabled = await getTooltipState()
-            const isRibbonEnabled = await getSidebarState()
-            return { isTooltipEnabled, isRibbonEnabled }
-        },
-        handleRibbonToggle: async prevState => {
-            await setSidebarState(!prevState)
-        },
-        handleTooltipToggle: async isTooltipEnabled => {
-            if (isTooltipEnabled) {
-                removeTooltip()
-            } else {
-                await insertTooltip({ toolbarNotifications })
-            }
-            await setTooltipState(!isTooltipEnabled)
-        },
-    })
-}
-
-const removeRibbon = () => {
-    if (!target) {
-        return
-    }
-    removeHighlights()
-    destroyAll(target, shadowRoot)()
-    destroyRootElement()
-    shadowRoot = null
-    target = null
-    toggleSidebar = null
-}
-
-/**
- * Inserts or removes ribbon from the page (if not overridden manually).
- * Should either be called through the RPC, or pass the `toolbarNotifications`
- * wrapped in an object.
- */
-const insertOrRemoveRibbon = async ({ toolbarNotifications }) => {
-    if (manualOverride) {
-        return
-    }
-
-    const isRibbonEnabled = await getSidebarState()
-    const isRibbonPresent = !!target
-
-    if (isRibbonEnabled && !isRibbonPresent) {
-        insertRibbon({ toolbarNotifications })
-    } else if (!isRibbonEnabled && isRibbonPresent) {
-        removeRibbon()
-    }
-}
-
-/**
- * Setups up RPC functions to insert and remove Ribbon from Popup.
- */
-export const setupRPC = ({ toolbarNotifications }) => {
-    makeRemotelyCallable({
-        toggleSidebarOverlay: async () => {
-            if (!toggleSidebar) {
-                manualOverride = true
-                insertRibbon({ toolbarNotifications })
-            }
-            return toggleSidebar.then(f => f())
-        },
-        insertRibbon: ({ override } = {}) => {
-            manualOverride = !!override
-            insertRibbon({ toolbarNotifications })
-        },
-        removeRibbon: ({ override } = {}) => {
-            manualOverride = !!override
-            removeRibbon()
-        },
-        insertOrRemoveRibbon: async () => {
-            await insertOrRemoveRibbon({ toolbarNotifications })
-        },
-    })
 }
 
 /**


### PR DESCRIPTION
### Issues

- When the user toggles the tooltip/ribbon on/off from the popup, the ribbon (if it has already been inserted), does not update itself to show the same change. It shows the previous values that it got when the ribbon was loaded into the DOM.
- When the same is done through the ribbon, other ribbons present on other tabs do not show the change either.

### Fix

Created an RPC to update the state of the ribbon on tab change as well as through popup. 

#### Other changes in this PR

- Reorganized methods and declarations in the file `interactions.js` in order to keep the most important ones first.
- Added/updated comments.
- Fix a bug that caused an error to be thrown whenever ribbon was closed via the little 'x' due to not handling the event propagation properly.