### PR TITLE
Move flawed debounced indexing to throttle-per-tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.11.8",
+    "version": "0.11.9",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/activity-logger/background/tab-change-listeners.ts
+++ b/src/activity-logger/background/tab-change-listeners.ts
@@ -1,5 +1,5 @@
 import { browser, Storage, Tabs } from 'webextension-polyfill-ts'
-import debounce from 'lodash/debounce'
+import throttle from 'lodash/throttle'
 
 import * as searchIndex from '../../search'
 import {
@@ -20,6 +20,7 @@ import {
     FavIconChecker,
     FavIconCreator,
     BookmarkChecker,
+    TabIndexer,
 } from './types'
 
 interface Props {
@@ -64,10 +65,16 @@ export default class TabChangeListeners {
     public checkBookmark: BookmarkChecker
 
     /**
-     * Handles fetching, and indexing the fav-icon once the tab updates, if needed.
+     * Handles throttled indexing of the tab contents on tab updates.
+     * Each tab gets an object of throttled indexers to handle indexing of
+     * things such as the fav-icon and visit.
+     *
+     * TODO: should this be integrated with the ext-wide tab state manager?
      */
-    handleFavIcon: TabChangeListener
-    private handleVisitIndexing: TabChangeListener
+    private tabIndexers = new Map<
+        number,
+        { favIcon: TabIndexer; page: TabIndexer }
+    >()
 
     constructor({
         tabManager,
@@ -95,20 +102,33 @@ export default class TabChangeListeners {
         this._tabActive = tabActiveCheck
         this.checkBookmark = bookmarkCheck
         this._contentScriptPaths = contentScriptPaths
-
-        // Set up debounces for different tab change listeners as some sites can
-        // really spam the fav-icon changes when they first load and to avoid some URL redirects.
-        // TODO: Better ways should exist
-        this.handleFavIcon = debounce(
-            this._handleFavIcon,
-            TabChangeListeners.FAV_ICON_CHANGE_THRESHOLD,
-        )
-
-        this.handleVisitIndexing = debounce(
-            this._handleVisitIndexing,
-            TabChangeListeners.URL_CHANGE_THRESHOLD,
-        )
     }
+
+    private getOrCreateTabIndexers(tabId: number) {
+        let indexers = this.tabIndexers.get(tabId)
+
+        if (!indexers) {
+            this.tabIndexers.set(tabId, {
+                favIcon: throttle(
+                    tab => this._handleFavIcon(tabId, {}, tab),
+                    TabChangeListeners.FAV_ICON_CHANGE_THRESHOLD,
+                ),
+                page: throttle(
+                    tab => this._handleVisitIndexing(tabId, {}, tab),
+                    TabChangeListeners.URL_CHANGE_THRESHOLD,
+                ),
+            })
+            indexers = this.tabIndexers.get(tabId)
+        }
+
+        return indexers
+    }
+
+    handleFavIcon: TabChangeListener = (tabId, _, tab) =>
+        this.getOrCreateTabIndexers(tabId).favIcon(tab)
+
+    handleVisitIndexing: TabChangeListener = (tabId, _, tab) =>
+        this.getOrCreateTabIndexers(tabId).page(tab)
 
     /**
      * Handles fetching of user indexing preferences from underyling browser storage.
@@ -147,7 +167,7 @@ export default class TabChangeListeners {
             isLoaded: status === 'complete',
         })
 
-        // Send off request for updating that prev. visit's tab state, if active long enough
+        // Update that prev. visit's tab state, if active long enough
         if (
             oldTab != null &&
             oldTab.url !== url &&

--- a/src/activity-logger/background/tab-change-listeners.ts
+++ b/src/activity-logger/background/tab-change-listeners.ts
@@ -112,10 +112,12 @@ export default class TabChangeListeners {
                 favIcon: throttle(
                     tab => this._handleFavIcon(tabId, {}, tab),
                     TabChangeListeners.FAV_ICON_CHANGE_THRESHOLD,
+                    { leading: false },
                 ),
                 page: throttle(
                     tab => this._handleVisitIndexing(tabId, {}, tab),
                     TabChangeListeners.URL_CHANGE_THRESHOLD,
+                    { leading: false },
                 ),
             })
             indexers = this.tabIndexers.get(tabId)

--- a/src/activity-logger/background/types.ts
+++ b/src/activity-logger/background/types.ts
@@ -35,6 +35,8 @@ export type TabChangeListener = (
     tab: Tabs.Tab,
 ) => Promise<void>
 
+export type TabIndexer = (tab: Tabs.Tab) => Promise<void>
+
 export type LoggableTabChecker = (tab: Tabs.Tab) => Promise<boolean>
 export type VisitInteractionUpdater = (interalTab: TabState) => Promise<void>
 export type FavIconFetcher = (url: string) => Promise<string>

--- a/src/util/ui-logic.test.ts
+++ b/src/util/ui-logic.test.ts
@@ -1,3 +1,4 @@
 describe('Tools to connect framework independent UI logic with React', () => {
     // TODO: Write these, but not urgently since relying components test these fully
+    test.skip('noop', () => undefined)
 })


### PR DESCRIPTION
Noted a flaw in the implementation of the last attempt to "throttle" page and fav-icon indexing: it was creating a single debounced fn which all tabs were competing for. This results in tabs being completely missed when opening multiple tabs within certain time thresholds.

- the throttle is still wanted due to high frequency changes with tab URL and favIconUrl props
- now it has been updated to work on a per-tab basis where there is a throttled (not debounced) fn for each tab
- fixes #640 

### Ways to reproduce issue #640 
1. easy way on Chrome via bookmarks manager:
  i. make a large number (8+) of discrete bookmarks in a single dir
  ii. open `chrome:bookmarks`
  iii. right click on that dir and press "Open all bookmarks"
  iv. wait for all tabs to load
  v. focus each tab, one-by-one (only need to keep focused a few 100ms)
  vi. go to overview and see only some of those pages
2. ...

### TODOs:
- [ ] see if/how/should this code can fit into tab state manager
- [ ] test. Find regressions. Other cases that fail.