### PR TITLE
Hotfix/quiet sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/activity-logger/background/log-page-visit.ts
+++ b/src/activity-logger/background/log-page-visit.ts
@@ -84,10 +84,16 @@ export default class PageVisitLogger {
             }
 
             const allowFavIcon = !(await this._checkFavIcon(tab.url))
-            const analysisRes = await this._analyzePage({
-                tabId: tab.id,
-                allowFavIcon,
-            })
+            let analysisRes
+            try {
+                analysisRes = await this._analyzePage({
+                    tabId: tab.id,
+                    allowFavIcon,
+                })
+            } catch (err) {
+                console.error(err)
+                return
+            }
 
             // Don't index full-text in this stage
             delete analysisRes.content.fullText
@@ -104,11 +110,17 @@ export default class PageVisitLogger {
     }
 
     async logPageVisit(tab: Tabs.Tab, textOnly = true) {
-        const analysisRes = await this._analyzePage({
-            tabId: tab.id,
-            allowFavIcon: false,
-            allowScreenshot: !textOnly,
-        })
+        let analysisRes
+        try {
+            analysisRes = await this._analyzePage({
+                tabId: tab.id,
+                allowFavIcon: false,
+                allowScreenshot: !textOnly,
+            })
+        } catch (err) {
+            console.error(err)
+            return
+        }
 
         const pageDoc = { url: tab.url, ...analysisRes }
 

--- a/src/activity-logger/background/tab-change-listeners.ts
+++ b/src/activity-logger/background/tab-change-listeners.ts
@@ -115,7 +115,10 @@ export default class TabChangeListeners {
                     { leading: false },
                 ),
                 page: throttle(
-                    tab => this._handleVisitIndexing(tabId, {}, tab),
+                    tab =>
+                        this._handleVisitIndexing(tabId, {}, tab).catch(
+                            console.error,
+                        ),
                     TabChangeListeners.URL_CHANGE_THRESHOLD,
                     { leading: false },
                 ),

--- a/src/activity-logger/background/tab-state.ts
+++ b/src/activity-logger/background/tab-state.ts
@@ -68,6 +68,7 @@ class Tab implements TabState {
 
         return remoteFunction('toggleIFrameRender', {
             tabId: this.id,
+            throwWhenNoResponse: false,
         })(shouldRender)
     }
 
@@ -76,7 +77,10 @@ class Tab implements TabState {
             return
         }
 
-        return remoteFunction('insertOrRemoveRibbon', { tabId: this.id })()
+        return remoteFunction('insertOrRemoveRibbon', {
+            tabId: this.id,
+            throwWhenNoResponse: false,
+        })()
     }
 
     private async _toggleTooltip() {
@@ -84,7 +88,10 @@ class Tab implements TabState {
             return
         }
 
-        return remoteFunction('insertOrRemoveTooltip', { tabId: this.id })()
+        return remoteFunction('insertOrRemoveTooltip', {
+            tabId: this.id,
+            throwWhenNoResponse: false,
+        })()
     }
 
     private async _updateRibbonState() {
@@ -92,7 +99,10 @@ class Tab implements TabState {
             return
         }
 
-        return remoteFunction('updateRibbon', { tabId: this.id })()
+        return remoteFunction('updateRibbon', {
+            tabId: this.id,
+            throwWhenNoResponse: false,
+        })()
     }
 
     private _pauseLogTimer() {

--- a/src/popup/tooltip-button/actions.ts
+++ b/src/popup/tooltip-button/actions.ts
@@ -40,11 +40,17 @@ export const toggleTooltipFlag: () => Thunk = () => async (
     const tabId = popup.tabId(state)
     if (wasEnabled) {
         await remoteFunction('removeTooltip', { tabId })()
-        await remoteFunction('updateRibbon', { tabId })()
+        await remoteFunction('updateRibbon', {
+            tabId,
+            throwWhenNoResponse: false,
+        })()
     } else {
         await remoteFunction('insertTooltip', { tabId })()
         await remoteFunction('showContentTooltip', { tabId })()
-        await remoteFunction('updateRibbon', { tabId })()
+        await remoteFunction('updateRibbon', {
+            tabId,
+            throwWhenNoResponse: false,
+        })()
     }
 }
 

--- a/src/sidebar-overlay/components/CongratsMessage.css
+++ b/src/sidebar-overlay/components/CongratsMessage.css
@@ -21,6 +21,7 @@
     font-size: 17px;
     text-align: left;
     margin-left: 15px;
+    text-transform: uppercase;
 }
 
 .learnMore {

--- a/src/sidebar-overlay/components/CongratsMessage.tsx
+++ b/src/sidebar-overlay/components/CongratsMessage.tsx
@@ -28,7 +28,7 @@ class CongratsMessage extends PureComponent {
                         className={styles.partyPopper}
                     />
                     <p className={styles.title}>
-                        CONGRATS TO YOUR FIRST ANNOTATION
+                        Congrats on your first annotation
                     </p>
                 </div>
                 <div className={styles.learnMore} onClick={this.goToDashboard}>

--- a/src/toolbar-notification/content_script/react/notifications/go-to-dashboard.tsx
+++ b/src/toolbar-notification/content_script/react/notifications/go-to-dashboard.tsx
@@ -15,7 +15,7 @@ const images = {
 export default function GoToDashboard({ onCloseRequested }) {
     return (
         <div className={styles.title}>
-            {/*<img className={styles.notifIcon} src={images.notifIcon}/>*/}
+            {/* <img className={styles.notifIcon} src={images.notifIcon}/> */}
             <NotificationLayout
                 title={'Go back to the search Dashboard'}
                 icon={images.notifIcon}
@@ -24,8 +24,8 @@ export default function GoToDashboard({ onCloseRequested }) {
                 closeIcon={images.closeIcon}
             >
                 Via the little{' '}
-                <img src={images.brainIcon} className={styles.icon} />
-                icon in the menu
+                <img src={images.brainIcon} className={styles.icon} /> icon in
+                the menu
             </NotificationLayout>
         </div>
     )

--- a/src/toolbar-notification/content_script/react/notifications/onboarding-select-option.tsx
+++ b/src/toolbar-notification/content_script/react/notifications/onboarding-select-option.tsx
@@ -36,7 +36,7 @@ export default function OnboardingSelectOption({ onCloseRequested }) {
                         height={'30px'}
                     />
                     <div className={styles.notifText}>
-                        to share a link to this higlight
+                        to share a link to this highlight
                     </div>
                 </div>
             </NotificationLayout>

--- a/src/toolbar-notification/content_script/react/notifications/ribbon-first-close.tsx
+++ b/src/toolbar-notification/content_script/react/notifications/ribbon-first-close.tsx
@@ -14,7 +14,7 @@ const images = {
 export default function TooltipFirstCloseNotification({ onCloseRequested }) {
     return (
         <div className={styles.title}>
-            {/*<img className={styles.notifIcon} src={images.notifIcon}/>*/}
+            {/* <img className={styles.notifIcon} src={images.notifIcon}/> */}
             <NotificationLayout
                 title={'Turn on/off Ribbon permanently'}
                 icon={images.notifIcon}
@@ -23,8 +23,8 @@ export default function TooltipFirstCloseNotification({ onCloseRequested }) {
                 closeIcon={images.closeIcon}
             >
                 Via the little{' '}
-                <img src={images.brainIcon} className={styles.brainIcon} />
-                icon in the menu
+                <img src={images.brainIcon} className={styles.brainIcon} /> icon
+                in the menu
             </NotificationLayout>
         </div>
     )

--- a/src/toolbar-notification/content_script/react/notifications/tag-this-page.tsx
+++ b/src/toolbar-notification/content_script/react/notifications/tag-this-page.tsx
@@ -15,7 +15,7 @@ const images = {
 export default function TagThisPage({ onCloseRequested }) {
     return (
         <div className={styles.title}>
-            {/*<img className={styles.notifIcon} src={images.notifIcon}/>*/}
+            {/* <img className={styles.notifIcon} src={images.notifIcon}/> */}
             <NotificationLayout
                 title={'Tag & sort this page in collections'}
                 icon={images.notifIcon}
@@ -24,8 +24,8 @@ export default function TagThisPage({ onCloseRequested }) {
                 closeIcon={images.closeIcon}
             >
                 Via the little{' '}
-                <img src={images.brainIcon} className={styles.icon} />
-                icon in the menu
+                <img src={images.brainIcon} className={styles.icon} /> icon in
+                the menu
             </NotificationLayout>
         </div>
     )

--- a/src/toolbar-notification/content_script/react/notifications/tooltip-first-close.tsx
+++ b/src/toolbar-notification/content_script/react/notifications/tooltip-first-close.tsx
@@ -15,7 +15,7 @@ const images = {
 export default function TooltipFirstCloseNotification({ onCloseRequested }) {
     return (
         <div className={styles.title}>
-            {/*<img className={styles.notifIcon} src={images.notifIcon}/>*/}
+            {/* <img className={styles.notifIcon} src={images.notifIcon}/> */}
             <NotificationLayout
                 title={'Turn on/off Highlighter permanently'}
                 icon={images.notifIcon}
@@ -24,8 +24,8 @@ export default function TooltipFirstCloseNotification({ onCloseRequested }) {
                 closeIcon={images.closeIcon}
             >
                 Via the little{' '}
-                <img src={images.brainIcon} className={styles.icon} />
-                icon in the menu
+                <img src={images.brainIcon} className={styles.icon} /> icon in
+                the menu
             </NotificationLayout>
         </div>
     )


### PR DESCRIPTION
Talked about in this week's meeting: sentry error quota was exceeded for this month already. These are some fixes to (hopefully) stop the errors being picked up by sentry for now.

Main issue was related to bad responses from lots of the sidebar-related RPC. @mohitsakhuja or @digi0ps may want to look further into this, in-case these are bugs
sentry public link: https://sentry.io/share/issue/56cf112ce9424b19a912965597fabec9/
commit addressing it: ace45e8

Other issue was weird. I *think* it's related to the `tabs` API `executeScript` calls. It's hard for me to understand given the way these errors were logged in sentry.
sentry public link: https://sentry.io/share/issue/190ce904706c43259129f0d6bbfc94c7/
commit addressing it: 6f10958

Also some misc. fixes for typos in the new onboarding I noticed after giving it a go: 274ecbdbbc30690b4aac87cbe55b10ef170c78dd
@digi0ps I also saw typos in the new onboarding with `onboarding-higlight-text` used in a few places in the code. Not sure if this is an actual problem though, and I didn't want to alter them in case something else depended on that spelling.