### PR TITLE
Add hack to allow users to still add annot comments, tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/common-ui/containers/IndexDropdown.tsx
+++ b/src/common-ui/containers/IndexDropdown.tsx
@@ -345,6 +345,16 @@ class IndexDropdownContainer extends Component<Props, State> {
     }
 
     handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (
+            !(event.ctrlKey || event.metaKey) &&
+            /[a-zA-Z0-9-_ ]/.test(String.fromCharCode(event.keyCode))
+        ) {
+            event.preventDefault()
+            event.stopPropagation()
+            this.setState(state => ({ searchVal: state.searchVal + event.key }))
+            return
+        }
+
         switch (event.key) {
             case 'Enter':
                 return this.handleSearchEnterPress(event)

--- a/src/popup/components/Popup.css
+++ b/src/popup/components/Popup.css
@@ -20,6 +20,7 @@ hr {
     background-color: rgb(255, 255, 255);
     margin: -8px;
     font-size: 1.2em;
+    overflow: hidden;
 }
 
 .searchContainer {

--- a/src/sidebar-common/annotation-box/edit-mode-content.tsx
+++ b/src/sidebar-common/annotation-box/edit-mode-content.tsx
@@ -74,6 +74,13 @@ class EditModeContent extends React.Component<Props, State> {
             this._handleEditAnnotation()
         } else if (e.key === 'Tab' && !e.shiftKey) {
             this._setTagInputActive(true)
+        } else if (
+            !(e.ctrlKey || e.metaKey) &&
+            /[a-zA-Z0-9-_ ]/.test(String.fromCharCode(e.keyCode))
+        ) {
+            e.preventDefault()
+            e.stopPropagation()
+            this.setState(state => ({ commentText: state.commentText + e.key }))
         }
     }
 

--- a/src/sidebar-common/comment-box/components/comment-box-form.tsx
+++ b/src/sidebar-common/comment-box/components/comment-box-form.tsx
@@ -70,6 +70,13 @@ class CommentBoxForm extends React.Component<Props, State> {
             setTimeout(() => {
                 this._tagInputRef.querySelector('input').focus()
             }, 0)
+        } else if (
+            !(e.ctrlKey || e.metaKey) &&
+            /[a-zA-Z0-9-_ ]/.test(String.fromCharCode(e.keyCode))
+        ) {
+            e.preventDefault()
+            e.stopPropagation()
+            this.props.handleCommentTextChange(this.props.commentText + e.key)
         }
     }
 

--- a/src/sidebar-overlay/store.ts
+++ b/src/sidebar-overlay/store.ts
@@ -1,13 +1,10 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 
-import initSentry from 'src/util/raven'
 import rootReducer from './reducer'
 
 const configureStore = () => {
     const middlewares = [thunk]
-
-    initSentry(middlewares)
 
     const enhancers = [applyMiddleware(...middlewares)]
 


### PR DESCRIPTION
- addresses #722
- overrides default `keydown` event handling in a hacky way, but it seems to make things work again from user POV which I feel is the main thing for now
- does this break anything? (@oliversauter if you have time, it would be good to get your feedback testing this)
- @ShishKabab @digi0ps @mohitsakhuja it would be great to get your thoughts on this issue, this quick hack, and ways to address it in the long-term (I had one idea in this comment, but not sure if I'm on the right track: https://github.com/WorldBrain/Memex/issues/722#issuecomment-465845828)