### PR TITLE
WIP(Icon design system): Svg icons -> React components

### DIFF
--- a/src/Icons/DoneIcon.js
+++ b/src/Icons/DoneIcon.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const DoneIcon = props => (
+    <svg width={32} height={32} fill="none" {...props}>
+        <circle cx={16} cy={16} r={16} fill={props.circlefill} />
+        <path
+            d="M24 12.546L21.454 10l-7.272 7.273-3.636-3.637L8 16.182l6.182 6.182L24 12.545z"
+            fill={props.tickfill}
+        />
+    </svg>
+)
+
+DoneIcon.defaultProps = {
+    circlefill: '#5CD9A6',
+    tickfill: '#fff',
+}
+
+DoneIcon.propTypes = {
+    circlefill: PropTypes.string,
+    tickfill: PropTypes.tickfill,
+}
+
+export default DoneIcon

--- a/src/Icons/StepOnboardingIcon.js
+++ b/src/Icons/StepOnboardingIcon.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const StepOnboardingIcon = props => (
+    <svg width={52} height={52} fill="none" {...props}>
+        <circle opacity={0.3} cx={26} cy={26} r={26} fill={props.circleFill} />
+        <path
+            d="M30.55 25.35l-8.125-5.687a.812.812 0 0 0-1.3.65v11.375a.812.812 0 0 0 1.3.65l8.125-5.688a.846.846 0 0 0 0-1.3z"
+            fill={props.triangleFill}
+        />
+    </svg>
+)
+
+StepOnboardingIcon.defaultProps = {
+    circleFill: '#5CD9A6',
+    triangleFill: '#2AB98A',
+}
+
+StepOnboardingIcon.propTypes = {
+    circleFill: PropTypes.string,
+    triangleFill: PropTypes.string,
+}
+
+export default StepOnboardingIcon

--- a/src/overview/onboarding/components/checklist-item.css
+++ b/src/overview/onboarding/components/checklist-item.css
@@ -42,7 +42,6 @@
     background-size: 40px;
     cursor: pointer;
     opacity: 0.7;
-    background-image: url('/img/step_onboarding.svg');
 
     &:hover {
         opacity: 1;
@@ -50,7 +49,6 @@
 }
 
 .doneIcon {
-    background-image: url('/img/doneIcon.svg');
     opacity: 1;
 }
 

--- a/src/overview/onboarding/components/checklist-item.tsx
+++ b/src/overview/onboarding/components/checklist-item.tsx
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react'
 import cx from 'classnames'
+import StepOnboardingIcon from './../../../Icons/StepOnboardingIcon'
+import DoneIcon from './../../../Icons/DoneIcon'
 
 const styles = require('./checklist-item.css')
 
@@ -20,24 +22,31 @@ export default class ChecklistItem extends PureComponent<Props> {
                             [styles.doneIcon]: this.props.isChecked,
                         })}
                         onClick={this.props.handleClick}
-                    />
+                    >
+                        {this.props.isChecked ? (
+                            <DoneIcon />
+                        ) : (
+                            <StepOnboardingIcon />
+                        )}
+                    </div>
+
                     <div>
-                    <p
-                        className={cx(styles.checklistText, {
-                            [styles.striked]: this.props.isChecked,
-                        })}
-                        onClick={this.props.handleClick}
-                    >
-                        {this.props.children}{' '}
-                    </p>
-                    <p
-                        className={cx(styles.subTitle, {
-                            [styles.striked]: this.props.isChecked,
-                        })}
-                        onClick={this.props.handleClick}
-                    >
-                        {this.props.subtitle}
-                    </p>
+                        <p
+                            className={cx(styles.checklistText, {
+                                [styles.striked]: this.props.isChecked,
+                            })}
+                            onClick={this.props.handleClick}
+                        >
+                            {this.props.children}{' '}
+                        </p>
+                        <p
+                            className={cx(styles.subTitle, {
+                                [styles.striked]: this.props.isChecked,
+                            })}
+                            onClick={this.props.handleClick}
+                        >
+                            {this.props.subtitle}
+                        </p>
                     </div>
                 </div>
             </React.Fragment>


### PR DESCRIPTION
Using react components instead of plain svg provides an easy way to alter the appearance of icons using props, therby removing the hassle of redesigning vector graphics. This commit upgrades two such icons present on the onboarding screen. 