### PR TITLE
Hotfix 0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/overview/results/components/search-type-switch.css
+++ b/src/overview/results/components/search-type-switch.css
@@ -34,6 +34,7 @@
     outline: none;
     display: flex;
     align-items: center;
+    background-color: transparent;
 
     &:disabled {
         background-color: color7;

--- a/src/search-injection/components/ResultItem.css
+++ b/src/search-injection/components/ResultItem.css
@@ -18,7 +18,7 @@
     text-decoration: none !important; /* stylelint-disable-line declaration-no-important */
     display: flex;
     flex-direction: column;
-    height: 100%;
+    height: 65px;
 }
 
 .infoContainer {

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -142,7 +142,7 @@
 
     & .settingsButton {
         right: -5px;
-        top: 17px;
+        top: 8px;
     }
 
     & .mainContainer {

--- a/src/search/background/annots-list.ts
+++ b/src/search/background/annots-list.ts
@@ -411,7 +411,9 @@ export class AnnotationsListPlugin extends StorageBackendPlugin<
 
         // Cut off any excess
         if (results.size > params.limit) {
-            results = new Map([...results].slice(0, params.limit))
+            results = new Map(
+                [...results].slice(params.skip, params.skip + params.limit),
+            )
         }
 
         return results

--- a/src/search/background/storage.ts
+++ b/src/search/background/storage.ts
@@ -184,11 +184,23 @@ export default class SearchStorage extends FeatureStorage {
             { base64Img: params.base64Img, upperTimeBound: params.endDate },
         )
 
+        const annotUrls = [].concat(...results.values()).map(annot => annot.url)
+
+        // Get display data for all annots then map them back to their clusters
+        const { annotsToTags, bmUrls } = await this.findAnnotsDisplayData(
+            annotUrls,
+        )
+
         return {
-            docs: pages.map(page => ({
-                ...page,
-                annotations: results.get(page.url),
-            })),
+            docs: pages.map(page => {
+                const annotations = results.get(page.url).map(annot => ({
+                    ...annot,
+                    tags: annotsToTags.get(annot.url) || [],
+                    hasBookmark: bmUrls.has(annot.url),
+                }))
+
+                return { ...page, annotations }
+            }),
         }
     }
 

--- a/src/search/background/utils.ts
+++ b/src/search/background/utils.ts
@@ -54,5 +54,6 @@ export const reshapePageForDisplay = page => ({
     favIcon: page.favIcon,
     annotations: [],
     tags: page.tags,
+    displayTime: page.displayTime,
     annotsCount: page.annotsCount,
 })


### PR DESCRIPTION
@oliversauter So I tracked down the bottlenecks in the search where it was spending most of the time. As said on slack, this was the post-search stages where display data is mapped to the results. 

To get a better idea, here's roughly how those stages are set up:

page search: 
1. UI script remote call **(super fast)**
2. search stage **(fast)**
3. page display data mapping stage **(slow)**
4. return result to UI script **(super fast)**

annots search:
1. UI script remote call **(super fast)**
2. search stage **(fast)**
3. page display data mapping stage **(slow)**
4. annots display data mapping stage **(super slow)**
5. return result to UI script **(super fast)**

They're pretty similar pipelines, apart from extra stage in annots search.

stage 3 and annots search stage 4 have been optimized a lot in the past few commits. Reduced the number of needed DB queries by merging a lot of them and doing more processing in memory. 

Though it's super important to note that they're still slow relative to the search stage 2. This is only really noticeable with lots of data in your DB. I also went back and realized our previous, page-only search's display data mapping stage was also a huge bottleneck when you have lots of data in your DB.

### Idea

Given how the search pipelines are laid out like this, and knowing where the slow parts are, I have an idea for a way we could really improve the perceived search speed from UX POV. We could do the display data mapping stages async after the UI has a chance to load the main search stage results. i.e, a possible implementation might look like:

1. UI script remote call **(super fast)**
2. search stage **(fast)**
3. return result to UI script **(super fast)**
4. UI script remote call "get all display data" **(super fast)**
5. page display data mapping stage **(slower)**
6. annots display data mapping stage **(slower)**
7. return result to UI script **(super fast)**

From the user POV it might work where the main page result layouts load first, then things like screenshots, favicons, annots count, bookmark status, etc, load async.

@oliversauter let me know what you think about this idea, and if it makes sense. I think it wouldn't be a huge amount of effort for a much better search UX, but we may need to weigh up it's importance relative to other plans.

### Take aways from tracking down this problem:

- We really should be playing with bigger data sets when developing and testing features like search. It will become much more obvious whether or not things scale. Before we were testing with less than 1% of my personal-use extension's data.
- Doing Dexie `WhereClause.anyOf()` queries are a lot faster than doing N concurrent `WhereClause.equals()` queries, but seemingly only when there's a lot of data in the table