### PR TITLE
Hotfix/1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/popup/blacklist-button/components/BlacklistConfirm.css
+++ b/src/popup/blacklist-button/components/BlacklistConfirm.css
@@ -1,4 +1,4 @@
-@import url('/fonts/Inter/Inter.css');
+@import url('/fonts/Inter/inter.css');
 
 @value colors: '../../../common-ui/colors.css';
 @value color4, color6 from colors;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,4 @@
-@import url('/fonts/Inter/Inter.css');
+@import url('/fonts/Inter/inter.css');
 
 .title {
     color: #3eb995;


### PR DESCRIPTION
I set up an Ubuntu VM to play with issue #735. I can reproduce it on Chrome with the store build. My own builds work fine and the store build works on the respective version of Chromium.

I ran Chrome [with logging enabled](https://stackoverflow.com/a/12233986) and recorded what got logged from pressing the install button in the store page until the ext opens the onboarding page and crashes:
https://gist.github.com/poltak/b38ccb88b9b7d76c58a1de35ecb66ae8

The more interesting things are L22-26:
```
[6230:6394:0418/094909.853901:VERBOSE1:content_hash.cc(295)] content mismatch for img/worldbrain-logo-narrow-bw-16.png
[6230:6394:0418/094909.860392:VERBOSE1:content_hash.cc(295)] content mismatch for img/worldbrain-logo-narrow-bw-48.png
[6230:6394:0418/094909.860754:VERBOSE1:content_hash.cc(295)] content mismatch for img/worldbrain-logo-narrow-bw.png
[6230:6394:0418/094909.873816:VERBOSE1:content_hash.cc(295)] content mismatch for manifest.json
```

@oliversauter we changed those icons recently. Is there any other steps to do with that, like upload them to the store page or anything? I doubt these warnings are that important though, as the standard ext output gets logged afterwards.

and L31-32:

```
[6230:6249:0418/094910.803205:VERBOSE1:content_verify_job.cc(256)] job failed for abkfbakhjpmblaafnpgjppbmioombali fonts/Inter/Inter.css reason:3
[6230:6230:0418/094910.806602:VERBOSE1:content_verifier.cc(518)] VerifyFailed abkfbakhjpmblaafnpgjppbmioombali reason:3
```

This hotfix contains a possible fix for this. I noticed there is no `fonts/Inter/Inter.css` in the built extension output. There is only `fonts/Inter/inter.css` (lowercase). Though this should not matter on the default filesystems of Windows and macOS - they're case-insensitive. However most of the major Linux filesystems are case-sensitive. 
Maybe this explains why it's only been reported on Linux so far. But it still doesn't explain why it doesn't reproduce on dev builds :/