### PR TITLE
open sidebar tooltip

### DIFF
--- a/src/options/settings/keyboard-shortcuts.ts
+++ b/src/options/settings/keyboard-shortcuts.ts
@@ -5,8 +5,8 @@ export interface ShortcutElData {
     name: string
     children: string
     tooltip?: string
-    turnOn?: string
-    turnOff?: string
+    toggleOn?: string
+    toggleOff?: string
 }
 
 export const shortcuts: ShortcutElData[] = [
@@ -25,7 +25,9 @@ export const shortcuts: ShortcutElData[] = [
     {
         id: 'sidebar-shortcut',
         name: 'toggleSidebar',
-        children: 'Toggle sidebar',
+        children: 'Open Sidebar',
+        toggleOn: 'Open Sidebar',
+        toggleOff: 'Close Sidebar',
     },
     {
         id: 'annotation-shortcut',
@@ -42,8 +44,8 @@ export const shortcuts: ShortcutElData[] = [
         id: 'create-bm-shortcut',
         name: 'createBookmark',
         children: 'Star current page',
-        turnOn: 'Star page',
-        turnOff: 'Unstar page',
+        toggleOn: 'Star page',
+        toggleOff: 'Unstar page',
     },
     {
         id: 'add-tag-shortcut',

--- a/src/sidebar-overlay/ribbon/components/ribbon.tsx
+++ b/src/sidebar-overlay/ribbon/components/ribbon.tsx
@@ -22,6 +22,7 @@ import {
 import * as utils from 'src/content-tooltip/utils'
 import { TooltipButton } from 'src/popup/tooltip-button'
 import { KeyboardShortcuts, Shortcut } from 'src/content-tooltip/types'
+import tooltip from 'src/overview/tooltips/components/tooltip'
 const styles = require('./ribbon.css')
 
 interface Props {
@@ -157,11 +158,17 @@ class Ribbon extends Component<Props> {
         this.props.setSearchValue(searchValue)
     }
     private getTooltipText(name: string): string {
-        const toTooltipText = (tooltip: string) => {
+        const getShortcutKey: () => string = () => {
             const short: Shortcut = this.keyboardShortcuts[name]
-            return short.shortcut && short.enabled
-                ? tooltip + ' ' + '(' + short.shortcut + ')'
-                : tooltip
+            return short.shortcut && short.enabled ? short.shortcut : null
+        }
+        const toTooltipText = (tt: string, shortcutKey?: string) => {
+            const key = shortcutKey ? shortcutKey : getShortcutKey()
+            if (key) {
+                return tt + ' ' + '(' + key + ')'
+            } else {
+                return tt
+            }
         }
         const elData: ShortcutElData = this.shortcutsData.get(name)
         if (!elData) {
@@ -170,8 +177,12 @@ class Ribbon extends Component<Props> {
         switch (name) {
             case 'createBookmark':
                 return this.props.isBookmarked
-                    ? toTooltipText(elData.turnOff)
-                    : toTooltipText(elData.turnOn)
+                    ? toTooltipText(elData.toggleOff)
+                    : toTooltipText(elData.toggleOn)
+            case 'toggleSidebar':
+                return this.props.isSidebarOpen
+                    ? toTooltipText(elData.toggleOff, 'Esc')
+                    : toTooltipText(elData.toggleOn)
             default:
                 return toTooltipText(elData.tooltip)
         }
@@ -200,11 +211,9 @@ class Ribbon extends Component<Props> {
                             </ButtonTooltip>
 
                             <ButtonTooltip
-                                tooltipText={
-                                    !this.props.isSidebarOpen
-                                        ? 'Open Sidebar (R)'
-                                        : 'Close Sidebar (ESC)'
-                                }
+                                tooltipText={this.getTooltipText(
+                                    'toggleSidebar',
+                                )}
                                 position="left"
                             >
                                 <button


### PR DESCRIPTION
Tooltip for  **Open Sidebar**  now displays the correct shortcut.
Open/close Sidebar seems to be more complex than just a toggle. The shortcut in the settings only opens the Sidebar so changed the text from **Toggle** to **Open**. 