### PR TITLE
hotfix(css-module): Use localIdentName to identify className on development

### DIFF
--- a/build/loaders.js
+++ b/build/loaders.js
@@ -49,6 +49,10 @@ export const cssModulesLoader = {
     },
 }
 
+export const localIdentName = {
+    localIdentName: '[path]__[local]--[hash:base64:5]',
+}
+
 export const cssVanillaLoader = {
     loader: 'css-loader',
 }
@@ -123,6 +127,10 @@ export default ({ mode, context, isCI = false, injectStyles = false }) => {
 
     if (mode !== 'production') {
         main.use = [threadLoader, ...main.use]
+        cssModulesLoader.options = Object.assign(
+            cssModulesLoader.options,
+            localIdentName,
+        )
     }
 
     return [main, coffee, imgLoader, lint, cssModules, cssVanilla]


### PR DESCRIPTION
If `mode` is equal `development` we add a hash using path + local + base64:5
eg. `src-overview-results-components-__main--dzcJi`

Solving the #418 issue.