### PR TITLE
Chore(dev-tools): Enable Devtools on Dev mode

### DIFF
--- a/src/options/options.jsx
+++ b/src/options/options.jsx
@@ -9,10 +9,10 @@ import Router from './router'
 import routes from './routes'
 
 // Include development tools if we are not building for production
-const ReduxDevTools = undefined
-    // process.env.NODE_ENV !== 'production'
-    //     ? require('src/dev/redux-devtools-component').default
-    //     : undefined
+const ReduxDevTools =
+    process.env.NODE_ENV !== 'production'
+        ? require('src/dev/redux-devtools-component').default
+        : undefined
 
 const store = configureStore({ ReduxDevTools })
 


### PR DESCRIPTION
Uncomment validation of NODE_ENV on `options.jsx`
Now DevTools is required on dev mode is running
