### PR TITLE
Feature/misc fixes

### DIFF
--- a/src/activity-logger/background/index.ts
+++ b/src/activity-logger/background/index.ts
@@ -10,7 +10,6 @@ import { TabChangeListener } from './types'
 import TabChangeListeners from './tab-change-listeners'
 import PageVisitLogger from './log-page-visit'
 import { CONCURR_TAB_LOAD } from '../constants'
-import NotificationBackground from 'src/notifications/background'
 
 export default class ActivityLoggerBackground {
     static SCROLL_UPDATE_FN = 'updateScrollState'
@@ -31,13 +30,11 @@ export default class ActivityLoggerBackground {
 
     constructor({
         storageManager,
-        notifsBackground,
         tabsAPI = browser.tabs,
         runtimeAPI = browser.runtime,
         webNavAPI = browser.webNavigation,
     }: {
         storageManager: Storex
-        notifsBackground: NotificationBackground
         tabsAPI?: Tabs.Static
         runtimeAPI?: Runtime.Static
         webNavAPI?: WebNavigation.Static
@@ -53,7 +50,6 @@ export default class ActivityLoggerBackground {
         this.tabChangeListener = new TabChangeListeners({
             tabManager: this.tabManager,
             pageVisitLogger: this.pageVisitLogger,
-            notifsBackground,
         })
     }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -44,7 +44,6 @@ directLinking.setupRequestInterceptor()
 
 const activityLogger = new ActivityLoggerBackground({
     storageManager,
-    notifsBackground: notifications,
 })
 activityLogger.setupRemoteFunctions()
 activityLogger.setupWebExtAPIHandlers()
@@ -125,3 +124,4 @@ window['notifications'] = notifications
 window['analytics'] = analytics
 window['logger'] = activityLogger
 window['tabMan'] = activityLogger.tabManager
+window['socialInt'] = social

--- a/src/direct-linking/background/index.ts
+++ b/src/direct-linking/background/index.ts
@@ -241,6 +241,9 @@ export default class DirectLinkingBackground {
             selector,
         })
 
+        // Attempt to (re-)index, if user preference set, but don't wait for it
+        this.annotationStorage.indexPageFromTab(tab)
+
         if (bookmarked) {
             await this.toggleAnnotBookmark({ tab }, { url: uniqueUrl })
         }

--- a/src/options/components/navigation/Nav.jsx
+++ b/src/options/components/navigation/Nav.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'react-router'
 
 import styles from './styles.css'
 
@@ -8,14 +7,6 @@ const Nav = ({ children }) => {
     return (
         <nav className={styles.root}>
             <ul className={styles.nav}>{children}</ul>
-            <div className={styles.icon_div}>
-                <Link to="/overview">
-                    <img
-                        src="/img/memex-logo.png"
-                        className={styles.icon}
-                    />
-                </Link>
-            </div>
         </nav>
     )
 }


### PR DESCRIPTION
Addresses points from slack thread https://worldbrain.slack.com/archives/CABJX9GRK/p1558788308005000

> 1) @ Saoud Rizwan found an important bug we have not considered yet, but should be easy to fix.
We dont have a setting that says "only index pages I added notes and annotations". It results in those pages never being logged and annotations not being retrievable when on the dashboard. (when settings for "index all" or "only title" are disabled) Can you prioritise this one?
>
> 2) Turn off the notifications for page visits again. Only show the ones that appear when people do an action, like tagging, adding to collection, bookmarking, adding annotation. Many people are annoyed and I see them popping up too often too even if there is no problem.

Plus a misc issue noted with rendering the memex logo twice in the options page's nav.