### PR TITLE
Hotfix/1.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": {

--- a/src/custom-lists/background/storage.history.ts
+++ b/src/custom-lists/background/storage.history.ts
@@ -20,6 +20,24 @@ export default {
                     { field: 'createdAt' },
                 ],
             },
+            {
+                version: new Date('2019-08-21'),
+                fields: {
+                    id: { type: 'string' },
+                    name: { type: 'string' },
+                    isDeletable: { type: 'boolean' },
+                    isNestable: { type: 'boolean' },
+                    createdAt: { type: 'datetime' },
+                    updatedAt: { type: 'datetime', optional: true },
+                },
+                indices: [
+                    { field: 'id', pk: true },
+                    { field: 'name', unique: true },
+                    { field: 'isDeletable' },
+                    { field: 'isNestable' },
+                    { field: 'createdAt' },
+                ],
+            },
         ],
     },
 } as StorageModuleHistory

--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -17,14 +17,13 @@ export default class CustomListStorage extends StorageModule {
             history,
             collections: {
                 [CustomListStorage.CUSTOM_LISTS_COLL]: {
-                    version: new Date('2019-08-21'),
+                    version: new Date('2019-08-29'),
                     fields: {
                         id: { type: 'string' },
                         name: { type: 'string' },
                         isDeletable: { type: 'boolean' },
                         isNestable: { type: 'boolean' },
                         createdAt: { type: 'datetime' },
-                        updatedAt: { type: 'datetime', optional: true },
                     },
                     indices: [
                         { field: 'id', pk: true },
@@ -123,7 +122,7 @@ export default class CustomListStorage extends StorageModule {
                         },
                         {
                             name: '$name:string',
-                            updatedAt: '$updatedAt:any',
+                            // updatedAt: '$updatedAt:any',
                         },
                     ],
                 },
@@ -265,7 +264,11 @@ export default class CustomListStorage extends StorageModule {
         name: string
         updatedAt?: Date
     }) {
-        return this.operation('updateListName', { id, name, updatedAt })
+        return this.operation('updateListName', {
+            id,
+            name,
+            // updatedAt,
+        })
     }
 
     async removeList({ id }: { id: number }) {

--- a/src/search/index.test.ts
+++ b/src/search/index.test.ts
@@ -616,7 +616,19 @@ describe('Search index integration', () => {
             expect(after.length).toBe(1)
         })
 
-        test('page re-add appends new terms', async () => {
+        test('page does not duplicate text fields on updates', async () => {
+            const pageBefore = await idx.getPage(getDb)(DATA.PAGE_3.url)
+
+            await idx.addPage(getDb)({ pageDoc: DATA.PAGE_3 })
+
+            const pageAfter = await idx.getPage(getDb)(DATA.PAGE_3.url)
+
+            expect(pageAfter.text.length).toBe(pageBefore.text.length)
+            expect(pageAfter.fullTitle.length).toBe(pageBefore.fullTitle.length)
+            expect(pageAfter.fullUrl.length).toBe(pageBefore.fullUrl.length)
+        })
+
+        test('page re-add appends new terms on updates', async () => {
             const { docs: before } = await search({ query: 'fox' })
             expect(before.length).toBe(1)
 

--- a/src/search/index.test.ts
+++ b/src/search/index.test.ts
@@ -619,13 +619,27 @@ describe('Search index integration', () => {
         test('page does not duplicate text fields on updates', async () => {
             const pageBefore = await idx.getPage(getDb)(DATA.PAGE_3.url)
 
+            // Try a standard update without any changes
             await idx.addPage(getDb)({ pageDoc: DATA.PAGE_3 })
 
-            const pageAfter = await idx.getPage(getDb)(DATA.PAGE_3.url)
+            const pageAfter1 = await idx.getPage(getDb)(DATA.PAGE_3.url)
 
-            expect(pageAfter.text.length).toBe(pageBefore.text.length)
-            expect(pageAfter.fullTitle.length).toBe(pageBefore.fullTitle.length)
-            expect(pageAfter.fullUrl.length).toBe(pageBefore.fullUrl.length)
+            expect(pageAfter1.text.length).toBe(pageBefore.text.length)
+            expect(pageAfter1.fullTitle.length).toBe(
+                pageBefore.fullTitle.length,
+            )
+            expect(pageAfter1.fullUrl.length).toBe(pageBefore.fullUrl.length)
+
+            // Try an update with a tag data change
+            pageAfter1.addTag('test')
+            await pageAfter1.save()
+
+            const pageAfter2 = await idx.getPage(getDb)(DATA.PAGE_3.url)
+            expect(pageAfter2.text.length).toBe(pageBefore.text.length)
+            expect(pageAfter2.fullTitle.length).toBe(
+                pageBefore.fullTitle.length,
+            )
+            expect(pageAfter2.fullUrl.length).toBe(pageBefore.fullUrl.length)
         })
 
         test('page re-add appends new terms on updates', async () => {

--- a/src/search/models/page.ts
+++ b/src/search/models/page.ts
@@ -333,9 +333,6 @@ export default class Page extends AbstractModel
                     .findOneObject<Page>({ url: this.url })
 
                 if (existing) {
-                    this.text = this.text + ' ' + existing.text
-                    this.fullTitle = this.fullTitle + ' ' + existing.fullTitle
-                    this.fullUrl = this.fullUrl + ' ' + existing.fullUrl
                     this._mergeTerms('terms', existing.terms)
                     this._mergeTerms('urlTerms', existing.urlTerms)
                     this._mergeTerms('titleTerms', existing.titleTerms)


### PR DESCRIPTION
Fixes the `text` field duping issues on page updates by updating the `customLists` schema to remove the newly added `updatedAt` field. This field is still important to get in eventually, but need to understand why it causes page terms appending to break.