### PR TITLE
Feature/jon hack day tasks

### DIFF
--- a/src/content-tooltip/utils.ts
+++ b/src/content-tooltip/utils.ts
@@ -135,19 +135,23 @@ export const setKeyboardShortcutsState = async (
 }
 
 function isAlpha(str) {
-    return /^[a-zA-Z]+$/.test(str)
+    return /^[a-zA-Z]$/.test(str)
 }
 
 export const convertKeyboardEventToKeyString = (
     e,
     getKeyVal = event => event.key,
 ) => {
+    if (!isAlpha(e.key)) {
+        return ''
+    }
+
     return (
         (e.altKey ? 'alt+' : '') +
         (e.ctrlKey ? 'ctrl+' : '') +
         (e.metaKey ? 'meta+' : '') +
         (e.shiftKey ? 'shift+' : '') +
-        (isAlpha(e.key) ? getKeyVal(e).toLowerCase() : getKeyVal(e))
+        getKeyVal(e).toLowerCase()
     )
 }
 

--- a/src/custom-lists/background/index.test.ts
+++ b/src/custom-lists/background/index.test.ts
@@ -1,0 +1,40 @@
+import * as expect from 'expect'
+import { registerModuleMapCollections } from '@worldbrain/storex-pattern-modules'
+
+import CustomListBackground from '.'
+import initStorageManager from 'src/search/memory-storex'
+
+async function setupTest() {
+    const storageManager = initStorageManager()
+    const background = new CustomListBackground({ storageManager })
+
+    registerModuleMapCollections(storageManager.registry, {
+        customLists: background.storage,
+    })
+    await storageManager.finishInitialization()
+
+    return { background }
+}
+
+describe('custom list background tests', () => {
+    it('should be able to bulk insert lists without affecting existing lists', async () => {
+        const { background } = await setupTest()
+
+        const listNames = ['listA', 'listB', 'listC', 'listD', 'listE']
+
+        // Ensure some lists exists first
+        const listAId = await background.createCustomList({
+            name: listNames[0],
+        })
+        const listBId = await background.createCustomList({
+            name: listNames[1],
+        })
+
+        // Try bulk inserting, including those lists that already exist
+        const listIds = await background.createCustomLists({ names: listNames })
+
+        expect(listIds.length).toBe(listNames.length)
+        // Those previously created list IDs should be present in the bulk output
+        expect(listIds).toEqual(expect.arrayContaining([listAId, listBId]))
+    })
+})

--- a/src/custom-lists/background/index.ts
+++ b/src/custom-lists/background/index.ts
@@ -71,11 +71,15 @@ export default class CustomListBackground {
         return this.storage.fetchListIgnoreCase({ name })
     }
 
-    async insertMissingLists({ names }: { names: string[] }) {
+    async createCustomLists({ names }: { names: string[] }) {
         const existingLists = new Map<string, number>()
 
-        for (const { name, id } of await this.storage.fetchListByNames(names)) {
-            existingLists.set(name, id)
+        for (const name of names) {
+            const list = await this.fetchListByName({ name })
+
+            if (list) {
+                existingLists.set(list.name, list.id)
+            }
         }
 
         const missing = names.filter(name => !existingLists.has(name))

--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -105,14 +105,6 @@ export default class CustomListStorage extends StorageModule {
                     operation: 'findObject',
                     args: [{ name: '$name:string' }, { ignoreCase: ['name'] }],
                 },
-                findListByNames: {
-                    collection: CustomListStorage.CUSTOM_LISTS_COLL,
-                    operation: 'findObjects',
-                    args: [
-                        { name: { $in: '$names:string' } },
-                        { ignoreCase: ['name'] },
-                    ],
-                },
                 updateListName: {
                     collection: CustomListStorage.CUSTOM_LISTS_COLL,
                     operation: 'updateObject',
@@ -197,10 +189,6 @@ export default class CustomListStorage extends StorageModule {
             pages.map(p => p.fullUrl),
             pages.length > 0,
         )
-    }
-
-    async fetchListByNames(names: string[]) {
-        return this.operation('findListByNames', { names })
     }
 
     async fetchListPagesById({

--- a/src/imports/background/item-processor.js
+++ b/src/imports/background/item-processor.js
@@ -124,16 +124,9 @@ export default class ImportItemProcessor {
                 names: collections,
             })
             await Promise.all(
-                listIds.map(async listId => {
-                    await listStorage.insertPageToList({
-                        id: listId,
-                        url,
-                    })
-                }),
-                tags.map(async tag => {
-                    await tagStorage.addTag({ url, name: tag })
-                }),
+                listIds.map(id => listStorage.insertPageToList({ id, url })),
             )
+            await Promise.all(tags.map(tag => tagStorage.addTag({ url, tag })))
         } catch (e) {
             console.error(e, url)
         }

--- a/src/imports/background/item-processor.js
+++ b/src/imports/background/item-processor.js
@@ -4,6 +4,7 @@ import * as searchIndex from 'src/search'
 import { tags as tagStorage, customList as listStorage } from 'src/background'
 import { getLocalStorage, setLocalStorage } from 'src/util/storage'
 import { TAG_SUGGESTIONS_KEY } from 'src/constants'
+import { padShortTimestamp } from './utils'
 
 const fetchPageDataOpts = {
     includePageContent: true,
@@ -199,18 +200,14 @@ export default class ImportItemProcessor {
         return { status: DOWNLOAD_STATUS.SUCC }
     }
 
-    async _processService(importItem, options = {}) {
-        const {
-            url,
-            title,
-            tags,
-            collections,
-            annotations,
-            timeAdded,
-        } = importItem
+    async _processService(
+        { url, title, tags, collections, annotations, timeAdded },
+        options = {},
+    ) {
+        timeAdded = padShortTimestamp(timeAdded)
 
         const pageDoc = !options.indexTitle
-            ? await this._createPageDoc(importItem)
+            ? await this._createPageDoc({ url })
             : {
                   url,
                   content: {
@@ -218,10 +215,10 @@ export default class ImportItemProcessor {
                   },
               }
 
-        const visits = await getVisitTimes(importItem)
+        const visits = await getVisitTimes({ url })
 
         if (timeAdded) {
-            visits.push(timeAdded, Date.now())
+            visits.push(timeAdded)
         }
 
         const bookmark = options.bookmarkImports

--- a/src/imports/background/item-processor.js
+++ b/src/imports/background/item-processor.js
@@ -120,7 +120,7 @@ export default class ImportItemProcessor {
     async _storeOtherData({ url, tags, collections, annotations }) {
         this._checkCancelled()
         try {
-            const listIds = await listStorage.insertMissingLists({
+            const listIds = await listStorage.createCustomLists({
                 names: collections,
             })
             await Promise.all(

--- a/src/imports/background/utils.test.ts
+++ b/src/imports/background/utils.test.ts
@@ -1,0 +1,35 @@
+import * as expect from 'expect'
+
+import { padShortTimestamp } from './utils'
+
+describe('padding of short epoch timestamp tests', () => {
+    it('should throw errors on long timestamps', () => {
+        const timestamps = [
+            1566980564800234,
+            15669805648001566980564800,
+            156698056480015669805648001566980564800,
+        ]
+
+        for (const timestamp of timestamps) {
+            expect(() => padShortTimestamp(timestamp)).toThrow(Error)
+        }
+    })
+
+    it('should leave correct timestamps untouched', () => {
+        const timestamps = [1566980564800, 1566980562800, 1566980524800]
+
+        for (const timestamp of timestamps) {
+            expect(padShortTimestamp(timestamp)).toEqual(timestamp)
+        }
+    })
+
+    it('should pad short timestamps with zeroes', () => {
+        const timestampA = 15669805
+        const timestampB = 156698056
+        const timestampC = 1566980562
+
+        expect(padShortTimestamp(timestampA)).toEqual(1566980500000)
+        expect(padShortTimestamp(timestampB)).toEqual(1566980560000)
+        expect(padShortTimestamp(timestampC)).toEqual(1566980562000)
+    })
+})

--- a/src/imports/background/utils.ts
+++ b/src/imports/background/utils.ts
@@ -17,3 +17,22 @@ export const loadBlob = ({
         req.send()
     })
 }
+
+export const padShortTimestamp = (timestamp: number) => {
+    const timestampStr = timestamp.toString()
+    const expectedLength = Date.now().toString().length
+    const actualLength = timestampStr.length
+
+    const difference = expectedLength - actualLength
+
+    if (difference === 0) {
+        return timestamp
+    }
+
+    if (difference < 0) {
+        throw new Error(`Invalid timestamp: ${timestamp}`)
+    }
+
+    const newTimestampStr = timestampStr + '0'.repeat(difference)
+    return Number.parseInt(newTimestampStr, 10)
+}

--- a/src/options/settings/components/keyboard-shortcuts-container.tsx
+++ b/src/options/settings/components/keyboard-shortcuts-container.tsx
@@ -55,11 +55,23 @@ class KeyboardShortcutsContainer extends React.PureComponent<Props, State> {
 
     recordBinding = async e => {
         e.preventDefault()
-        const shortcut = convertKeyboardEventToKeyString(
-            e,
-            event => event.target.value,
-        )
+
         const name = e.target.name as string
+
+        // Afford way of clearing shortcut
+        if (['Escape', 'Backspace'].includes(e.key)) {
+            this.setState(
+                state => ({ [name]: { ...state[name], shortcut: '' } } as any),
+                () => utils.setKeyboardShortcutsState({ ...this.state }),
+            )
+            return
+        }
+
+        const shortcut = convertKeyboardEventToKeyString(e)
+
+        if (!shortcut.length) {
+            return
+        }
 
         this.setState(
             state => ({ [name]: { ...state[name], shortcut } } as any),
@@ -81,7 +93,8 @@ class KeyboardShortcutsContainer extends React.PureComponent<Props, State> {
                 <input
                     type="text"
                     value={this.state[name].shortcut}
-                    onChange={this.recordBinding}
+                    onKeyDown={this.recordBinding}
+                    onChange={e => e.preventDefault()}
                     name={name}
                 />{' '}
             </Checkbox>

--- a/src/overview/enhancer.js
+++ b/src/overview/enhancer.js
@@ -118,13 +118,14 @@ const locationSync = ReduxQuerySync.enhancer({
 })
 
 const hydrateStateFromStorage = store => {
-    const hydrate = (key, action) =>
+    const hydrate = (key, action, defaultValue) =>
         browser.storage.local.get(key).then(data => {
-            if (data[key] == null) {
+            if (data[key] == null && defaultValue == null) {
                 return
             }
 
-            store.dispatch(action(data[key]))
+            const value = data[key] == null ? defaultValue : data[key]
+            store.dispatch(action(value))
         })
 
     // Keep each of these storage keys in sync
@@ -133,7 +134,11 @@ const hydrateStateFromStorage = store => {
         constants.ANNOTATIONS_EXPANDED_KEY,
         resultsActs.setAreAnnotationsExpanded,
     )
-    hydrate(constants.SIDEBAR_LOCKED_KEY, sidebarLeftActs.setSidebarLocked)
+    hydrate(
+        constants.SIDEBAR_LOCKED_KEY,
+        sidebarLeftActs.setSidebarLocked,
+        true,
+    )
     hydrate(
         optConsts.STORAGE_KEYS.SCREENSHOTS,
         optActs.initScreenshots,


### PR DESCRIPTION
These are my fixes from the hackday on Wednesday. Most commits have info on what the changes are for. 
2548f06 (Ensure short timestamps get padded) was needed as the exported HTML files for Raindrop data seem to have truncated epoch timestamps which need to be padded with zeroes to properly construct JS `Date`s from.