### PR TITLE
Misc hackday tasks

### DIFF
--- a/src/background-script/index.ts
+++ b/src/background-script/index.ts
@@ -8,16 +8,12 @@ import {
 } from 'webextension-polyfill-ts'
 
 import * as utils from './utils'
-import { UNINSTALL_URL } from './constants'
 import ActivityLoggerBackground from 'src/activity-logger/background'
 import NotifsBackground from '../notifications/background'
 import { onInstall, onUpdate } from './on-install-hooks'
 import { makeRemotelyCallable } from '../util/webextensionRPC'
 import { USER_ID } from '../util/generate-token'
-import {
-    storageChangesManager,
-    StorageChangesManager,
-} from '../util/storage-changes'
+import { StorageChangesManager } from '../util/storage-changes'
 import { migrations } from './quick-and-dirty-migrations'
 import { AlarmsConfig } from './alarms'
 import { fetchUserId } from 'src/analytics/utils'
@@ -39,7 +35,7 @@ class BackgroundScript {
         notifsBackground,
         loggerBackground,
         utilFns = utils,
-        storageChangesMan = storageChangesManager,
+        storageChangesMan,
         storageAPI = browser.storage,
         runtimeAPI = browser.runtime,
         commandsAPI = browser.commands,
@@ -49,7 +45,7 @@ class BackgroundScript {
         notifsBackground: NotifsBackground
         loggerBackground: ActivityLoggerBackground
         utilFns?: typeof utils
-        storageChangesMan?: StorageChangesManager
+        storageChangesMan: StorageChangesManager
         storageAPI?: Storage.Static
         runtimeAPI?: Runtime.Static
         commandsAPI?: Commands.Static

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,16 +1,14 @@
 import 'babel-polyfill'
 import 'core-js/es7/symbol'
+import { browser } from 'webextension-polyfill-ts'
 import { registerModuleMapCollections } from '@worldbrain/storex-pattern-modules'
 
-import { browser } from 'webextension-polyfill-ts'
 import initStorex from './search/memex-storex'
 import getDb, { setStorex } from './search/get-db'
 import internalAnalytics from './analytics/internal'
 import initSentry from './util/raven'
-import {
-    makeRemotelyCallable,
-    setupRemoteFunctionsImplementations,
-} from 'src/util/webextensionRPC'
+import { createPageViaBmTagActs as createPage, getPage } from 'src/search'
+import { setupRemoteFunctionsImplementations } from 'src/util/webextensionRPC'
 
 // Features that require manual instantiation to setup
 import DirectLinkingBackground from './direct-linking/background'
@@ -70,6 +68,8 @@ export const customList = new CustomListBackground({
     storageManager,
     tabMan: activityLogger.tabManager,
     windows: browser.windows,
+    createPage: createPage(getDb),
+    getPage: getPage(getDb),
 })
 customList.setupRemoteFunctions()
 
@@ -83,11 +83,11 @@ tags.setupRemoteFunctions()
 export const bookmarks = new BookmarksBackground({ storageManager })
 
 const backupModule = new backup.BackupBackgroundModule({
+    notifications,
     storageManager,
     lastBackupStorage: new backupStorage.LocalLastBackupStorage({
         key: 'lastBackup',
     }),
-    notifications,
 })
 
 backupModule.setBackendFromStorage()

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,6 +9,7 @@ import internalAnalytics from './analytics/internal'
 import initSentry from './util/raven'
 import { createPageViaBmTagActs as createPage, getPage } from 'src/search'
 import { setupRemoteFunctionsImplementations } from 'src/util/webextensionRPC'
+import { StorageChangesManager } from 'src/util/storage-changes'
 
 // Features that require manual instantiation to setup
 import DirectLinkingBackground from './direct-linking/background'
@@ -32,9 +33,12 @@ import './imports/background'
 import './omnibar'
 import analytics from './analytics'
 
-initSentry()
-
 const storageManager = initStorex()
+const localStorageChangesManager = new StorageChangesManager({
+    storage: browser.storage,
+})
+
+initSentry({ storageChangesManager: localStorageChangesManager })
 
 const notifications = new NotificationBackground({ storageManager })
 notifications.setupRemoteFunctions()
@@ -117,6 +121,7 @@ storageManager.finishInitialization().then(() => {
         storageManager,
         notifsBackground: notifications,
         loggerBackground: activityLogger,
+        storageChangesMan: localStorageChangesManager,
     })
     bgScript.setupRemoteFunctions()
     bgScript.setupWebExtAPIHandlers()

--- a/src/content-tooltip/components/container.jsx
+++ b/src/content-tooltip/components/container.jsx
@@ -46,6 +46,8 @@ class TooltipContainer extends React.Component {
     async componentDidMount() {
         this.props.onInit(this.showTooltip)
 
+        this.fetchAndHighlightAnnotations()
+
         const {
             shortcutsEnabled,
             ...shortcuts

--- a/src/content-tooltip/components/container.jsx
+++ b/src/content-tooltip/components/container.jsx
@@ -21,6 +21,7 @@ import {
     removeHighlights,
 } from '../../sidebar-overlay/content_script/highlight-interactions'
 import {
+    getTooltipState,
     getKeyboardShortcutsState,
     convertKeyboardEventToKeyString,
 } from '../utils'
@@ -47,6 +48,10 @@ class TooltipContainer extends React.Component {
         this.props.onInit(this.showTooltip)
 
         this.fetchAndHighlightAnnotations()
+
+        // Highlights state is coupled to whether or not the tooltip is enabled
+        const highlightsOn = await getTooltipState()
+        this.setState(() => ({ highlightsOn }))
 
         const {
             shortcutsEnabled,

--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -211,7 +211,7 @@ export default class CustomListStorage extends StorageModule {
             entriesByListId.set(page.listId, [...current, page.fullUrl])
         })
 
-        const lists = await this.operation('findListsIncluding', {
+        const lists: PageList[] = await this.operation('findListsIncluding', {
             includedIds: [...listIds],
         })
 

--- a/src/options/store.js
+++ b/src/options/store.js
@@ -60,7 +60,7 @@ const stateTransformer = ({ overview, ...state }) => ({
 export default function configureStore({ ReduxDevTools = undefined } = {}) {
     const middlewares = [createEpicMiddleware(rootEpic), thunk]
 
-    initSentry(middlewares, stateTransformer)
+    initSentry({ reduxMiddlewares: middlewares, stateTransformer })
 
     const enhancers = [
         overviewPage.enhancer,

--- a/src/popup/components/Button.css
+++ b/src/popup/components/Button.css
@@ -151,7 +151,7 @@
 }
 
 .highlighterIcon {
-    background-image: url('/img/tooltip.svg');
+    background-image: url('/img/highlightOff.svg');
     background-repeat: no-repeat;
     background-size: 24px;
     float: left;

--- a/src/popup/store.ts
+++ b/src/popup/store.ts
@@ -27,7 +27,7 @@ const rootReducer = combineReducers({
 export default function configureStore() {
     const middlewares = [thunk]
 
-    initSentry(middlewares)
+    initSentry({ reduxMiddlewares: middlewares })
 
     const enhancers = [applyMiddleware(...middlewares)]
 

--- a/src/popup/tooltip-button/actions.ts
+++ b/src/popup/tooltip-button/actions.ts
@@ -31,8 +31,8 @@ export const toggleTooltipFlag: () => Thunk = () => async (
             : EVENT_NAMES.ENABLE_TOOLTIP_POPUP,
     })
 
-    await setTooltipState(!wasEnabled)
     dispatch(setTooltipFlag(!wasEnabled))
+    await setTooltipState(!wasEnabled)
 
     const isLoggable = popup.isLoggable(state)
     if (!isLoggable) {

--- a/src/popup/tooltip-button/components/TooltipButton.tsx
+++ b/src/popup/tooltip-button/components/TooltipButton.tsx
@@ -72,7 +72,6 @@ const mapDispatch: (dispatch, props: OwnProps) => DispatchProps = (
     props,
 ) => ({
     showTooltip: async e => {
-        // console.log('dispatch')
         e.preventDefault()
         await dispatch(acts.showTooltip())
         setTimeout(props.closePopup, 200)

--- a/src/search/models/page.ts
+++ b/src/search/models/page.ts
@@ -230,7 +230,7 @@ export default class Page extends AbstractModel
      * @param {TermsIndexName} termProp The name of which terms state to update.
      * @param {string[]} terms Array of terms to merge with current state.
      */
-    _mergeTerms(termProp: TermsIndexName, terms: string[]) {
+    _mergeTerms(termProp: TermsIndexName, terms: string[] = []) {
         this[termProp] = !this[termProp]
             ? terms
             : [...new Set([...this[termProp], ...terms])]

--- a/src/sidebar-overlay/ribbon-sidebar-controller/ribbon-sidebar-container.tsx
+++ b/src/sidebar-overlay/ribbon-sidebar-controller/ribbon-sidebar-container.tsx
@@ -335,7 +335,6 @@ class RibbonSidebarContainer extends React.Component<Props, State> {
     private _closeSidebarCallback = () => {
         this.props.setActiveAnnotationUrl(null)
         this.props.setHoverAnnotationUrl(null)
-        this.props.removeHighlights()
     }
 
     private _goToAnnotation = async (annotation: Annotation) => {

--- a/src/sidebar-overlay/ribbon/actions.ts
+++ b/src/sidebar-overlay/ribbon/actions.ts
@@ -17,7 +17,6 @@ export const setShowCommentBox = createAction<boolean>('setShowCommentBox')
 export const setShowSearchBox = createAction<boolean>('setShowSearchBox')
 export const setShowTagsPicker = createAction<boolean>('setShowTagsPicker')
 export const setShowCollsPicker = createAction<boolean>('setShowCollsPicker')
-export const setShowHighlights = createAction<boolean>('setShowHighlights')
 export const setSearchValue = createAction<string>('setSearchValue')
 
 export const toggleFullScreen: () => Thunk = () => (dispatch, getState) => {

--- a/src/sidebar-overlay/ribbon/components/ribbon-container.tsx
+++ b/src/sidebar-overlay/ribbon/components/ribbon-container.tsx
@@ -39,7 +39,6 @@ interface StateProps {
     showSearchBox: boolean
     showTagsPicker: boolean
     showCollectionsPicker: boolean
-    showHighlights?: boolean
     searchValue: string
 }
 
@@ -58,7 +57,6 @@ interface DispatchProps {
     setShowTagsPicker: (value: boolean) => void
     setShowCollectionsPicker: (value: boolean) => void
     setShowSearchBox: (value: boolean) => void
-    setShowHighlights: (value: boolean) => void
     setSearchValue: (value: string) => void
     openRibbon: () => void
 }
@@ -183,8 +181,6 @@ const mapDispatchToProps: MapDispatchToProps<
         dispatch(actions.setShowTagsPicker(value)),
     setShowCollectionsPicker: (value: boolean) =>
         dispatch(actions.setShowCollsPicker(value)),
-    setShowHighlights: (value: boolean) =>
-        dispatch(actions.setShowHighlights(value)),
 })
 
 export default connect(

--- a/src/sidebar-overlay/ribbon/components/ribbon.tsx
+++ b/src/sidebar-overlay/ribbon/components/ribbon.tsx
@@ -410,9 +410,7 @@ class Ribbon extends Component<Props, State> {
                             </ButtonTooltip>
 
                             <ButtonTooltip
-                                tooltipText={this.getTooltipText(
-                                    'toggleHighlights',
-                                )}
+                                tooltipText="Toggle highlights"
                                 position="left"
                             >
                                 <button

--- a/src/sidebar-overlay/ribbon/components/ribbon.tsx
+++ b/src/sidebar-overlay/ribbon/components/ribbon.tsx
@@ -30,7 +30,6 @@ export interface Props {
     showSearchBox: boolean
     showTagsPicker: boolean
     showCollectionsPicker: boolean
-    showHighlights?: boolean
     searchValue: string
     isCommentSaved: boolean
     commentText: string
@@ -49,7 +48,6 @@ export interface Props {
     setShowTagsPicker: (value: boolean) => void
     setShowCollectionsPicker: (value: boolean) => void
     setShowSearchBox: (value: boolean) => void
-    setShowHighlights: (value: boolean) => void
     setSearchValue: (value: string) => void
 }
 
@@ -116,14 +114,13 @@ class Ribbon extends Component<Props, State> {
     }
 
     private toggleHighlights = () => {
-        const { showHighlights } = this.props
-
-        if (showHighlights) {
+        if (this.props.isTooltipEnabled) {
             removeHighlights()
         } else {
             this.fetchAndHighlightAnnotations()
         }
-        this.props.setShowHighlights(!showHighlights)
+
+        this.props.handleTooltipToggle()
     }
 
     private fetchAndHighlightAnnotations = async () => {
@@ -419,38 +416,17 @@ class Ribbon extends Component<Props, State> {
                                 position="left"
                             >
                                 <button
+                                    onClick={this.toggleHighlights}
                                     className={cx(
                                         styles.button,
                                         styles.ribbonIcon,
                                         {
                                             [styles.highlightsOn]: this.props
-                                                .showHighlights,
+                                                .isTooltipEnabled,
                                             [styles.highlightsOff]: !this.props
-                                                .showHighlights,
+                                                .isTooltipEnabled,
                                         },
                                     )}
-                                    onClick={this.toggleHighlights}
-                                />
-                            </ButtonTooltip>
-
-                            <ButtonTooltip
-                                tooltipText={
-                                    !this.props.isTooltipEnabled
-                                        ? 'Enable Highlighter tooltip'
-                                        : 'Disable Highlighter tooltip'
-                                }
-                                position="left"
-                            >
-                                <button
-                                    className={cx(styles.button, {
-                                        [styles.tooltipOn]: this.props
-                                            .isTooltipEnabled,
-                                        [styles.tooltipOff]: !this.props
-                                            .isTooltipEnabled,
-                                    })}
-                                    onClick={() =>
-                                        this.props.handleTooltipToggle()
-                                    }
                                 />
                             </ButtonTooltip>
 

--- a/src/sidebar-overlay/ribbon/types.ts
+++ b/src/sidebar-overlay/ribbon/types.ts
@@ -12,7 +12,6 @@ export default interface State {
     showSearchBox: boolean
     showTagsPicker: boolean
     showCollectionsPicker: boolean
-    showHighlights?: boolean
     searchValue: string
 }
 

--- a/src/util/raven.ts
+++ b/src/util/raven.ts
@@ -2,7 +2,7 @@ import { browser } from 'webextension-polyfill-ts'
 import * as AllRaven from 'raven-js'
 import createRavenMiddleware from 'raven-for-redux'
 
-import { storageChangesManager } from './storage-changes'
+import { StorageChangesManager } from './storage-changes'
 import { SHOULD_TRACK_STORAGE_KEY as SHOULD_TRACK } from '../options/privacy/constants'
 
 // Issue with the export being a default but something with our tsconfig; TODO
@@ -14,21 +14,28 @@ browser.storage.local // tslint:disable-line
     .get(SHOULD_TRACK)
     .then(storage => (sentryEnabled = !!storage[SHOULD_TRACK]))
 
-// Update global tracking flag every time stored flag changes
-storageChangesManager.addListener(
-    'local',
-    SHOULD_TRACK,
-    ({ newValue }) => (sentryEnabled = newValue),
-)
-
 /**
  * Inits Sentry's JS client Raven. Optionally supports adding redux middleware,
  * if middleware array passed in. Note this array will be updated.
  */
-export default function initSentry(
-    reduxMiddlewares?: Function[], // tslint:disable-line
+export default function initSentry({
+    reduxMiddlewares,
     stateTransformer = f => f,
-) {
+    storageChangesManager = new StorageChangesManager({
+        storage: browser.storage,
+    }),
+}: {
+    reduxMiddlewares?: Function[] // tslint:disable-line
+    stateTransformer?: (state: any) => any
+    storageChangesManager?: StorageChangesManager
+}) {
+    // Update global tracking flag every time stored flag changes
+    storageChangesManager.addListener(
+        'local',
+        SHOULD_TRACK,
+        ({ newValue }) => (sentryEnabled = newValue),
+    )
+
     if (process.env.SENTRY_DSN) {
         raven
             .config(process.env.SENTRY_DSN, {

--- a/src/util/storage-changes.test.ts
+++ b/src/util/storage-changes.test.ts
@@ -1,10 +1,17 @@
-import { storageChangesManager, StorageAreaName } from './storage-changes'
+import { browser } from 'webextension-polyfill-ts'
+
+import { StorageChangesManager } from 'src/util/storage-changes'
+import { StorageAreaName } from './storage-changes'
 
 const storageAreas: StorageAreaName[] = ['sync', 'local', 'managed']
 const testKeyA = 'testA'
 const testKeyB = 'testB'
 
-describe('Storage changes listeners manager', () =>
+describe('Storage changes listeners manager', () => {
+    const storageChangesManager = new StorageChangesManager({
+        storage: browser.storage,
+    })
+
     storageAreas.forEach(areaName =>
         describe(`${areaName} storage`, () => {
             beforeEach(() => storageChangesManager.resetListeners())
@@ -86,4 +93,5 @@ describe('Storage changes listeners manager', () =>
                 expect(mockListenerB.mock.calls[0][0]).toEqual(change)
             })
         }),
-    ))
+    )
+})

--- a/src/util/storage-changes.ts
+++ b/src/util/storage-changes.ts
@@ -1,4 +1,4 @@
-import { browser, Storage } from 'webextension-polyfill-ts'
+import { Storage } from 'webextension-polyfill-ts'
 
 export interface StorageChanges {
     [key: string]: Storage.StorageChange
@@ -7,13 +7,19 @@ export interface StorageChanges {
 export type StorageAreaName = 'sync' | 'local' | 'managed'
 export type StorageKeyListener = (vals: Storage.StorageChange) => void
 
+export interface Props {
+    storage: Storage.Static
+}
+
 export class StorageChangesManager {
     private listeners: Map<StorageAreaName, Map<string, StorageKeyListener>>
+    private storage: Storage.Static
 
-    constructor() {
+    constructor({ storage }: Props) {
         this.resetListeners()
+        this.storage = storage
 
-        browser.storage.onChanged.addListener(this.handleChanges)
+        this.storage.onChanged.addListener(this.handleChanges)
     }
 
     /**
@@ -60,7 +66,3 @@ export class StorageChangesManager {
         listener: StorageKeyListener,
     ) => this.listeners.get(areaName).set(storageKey, listener)
 }
-
-const storageChangesManager = new StorageChangesManager()
-
-export { storageChangesManager }


### PR DESCRIPTION
Includes fixes for:
- [adding non-indexed pages to collections not being indexed on-demand](https://www.notion.so/worldbrain/Bugfixing-Marathon-b4b0b75688414f48978c7375ee57a388?p=7cd09f7be828459a87cb081e409f4b64): doc also talks about the same issue with tagging, however that seems to have been already fixed
- [restored annots not showing up in blank terms searches](https://www.notion.so/worldbrain/Bugfixing-Marathon-b4b0b75688414f48978c7375ee57a388?p=0b1767119f974ae3aa43751383abe29f): annot search assumed that no annotations could be created before the ext install time, thus don't bother searching back further. However, with the restore feature, there can indeed be annotations in the DB created before the ext was installed!
- [unifying of tooltip and highlights states + related new behaviours](https://www.notion.so/worldbrain/Bugfixing-Marathon-b4b0b75688414f48978c7375ee57a388?p=f122acd2d0fe40f0bc6f6cccd9082d33): this was unexpectedly difficult trying to wrap my head around this part of the code. Want to test this more.