### PR TITLE
Tiny hackday UI fix

### DIFF
--- a/src/options/backup/components/overlays/download-overlay.tsx
+++ b/src/options/backup/components/overlays/download-overlay.tsx
@@ -14,15 +14,17 @@ export default class DownloadOverlay extends PureComponent<Props, {}> {
                 header="Download Memex' Backup App to continue."
                 description={
                     <Fragment>
-                        Start the app & pick a backup folder. Then return here
-                        to continue your backup.
-                        <a
-                            className={styles.link}
-                            target="_blank"
-                            href="https://www.notion.so/worldbrain/7dacad9e95b44c5db681033fc264fb59"
-                        >
-                            &nbsp; Learn more ▸
-                        </a>
+                        <div className={styles.text}>
+                            Start the app & pick a backup folder. Then return
+                            here to continue your backup.
+                            <a
+                                className={styles.link}
+                                target="_blank"
+                                href="https://www.notion.so/worldbrain/7dacad9e95b44c5db681033fc264fb59"
+                            >
+                                &nbsp; Learn more ▸
+                            </a>
+                        </div>
                     </Fragment>
                 }
                 continueButtonText="I'm ready"

--- a/src/options/backup/components/overlays/download-overlay.tsx
+++ b/src/options/backup/components/overlays/download-overlay.tsx
@@ -14,15 +14,14 @@ export default class DownloadOverlay extends PureComponent<Props, {}> {
                 header="Download Memex' Backup App to continue."
                 description={
                     <Fragment>
-                        Start the app & pick a backup folder. Then return here to continue
-                        your backup.
-                        <br />
+                        Start the app & pick a backup folder. Then return here
+                        to continue your backup.
                         <a
                             className={styles.link}
                             target="_blank"
                             href="https://www.notion.so/worldbrain/7dacad9e95b44c5db681033fc264fb59"
                         >
-                            Learn More ▸
+                            &nbsp; Learn more ▸
                         </a>
                     </Fragment>
                 }

--- a/src/options/backup/components/overlays/styles.css
+++ b/src/options/backup/components/overlays/styles.css
@@ -1,3 +1,6 @@
+@value colors: 'src/common-ui/colors.css';
+@value color5, color6 from colors;
+
 .linkbox {
     grid-area: linkbox;
     display: inline-block;
@@ -6,8 +9,8 @@
 }
 
 .logo {
-    width: 4em;
-    height: 4em;
+    width: 3em;
+    height: 3em;
     margin: 0px 20px;
     cursor: pointer;
     opacity: 0.6;
@@ -25,4 +28,8 @@
     composes: darkBlue from '../../../../common-ui/colors.css';
     font-weight: 600;
     text-decoration: none;
+}
+
+.text {
+    color: color5;
 }

--- a/src/options/backup/components/overlays/styles.css
+++ b/src/options/backup/components/overlays/styles.css
@@ -1,5 +1,5 @@
 @value colors: 'src/common-ui/colors.css';
-@value color5, color6 from colors;
+@value color5 from colors;
 
 .linkbox {
     grid-area: linkbox;

--- a/src/options/backup/components/overlays/styles.css
+++ b/src/options/backup/components/overlays/styles.css
@@ -6,8 +6,8 @@
 }
 
 .logo {
-    width: 2em;
-    height: 2em;
+    width: 4em;
+    height: 4em;
     margin: 0px 20px;
     cursor: pointer;
     opacity: 0.6;
@@ -25,7 +25,4 @@
     composes: darkBlue from '../../../../common-ui/colors.css';
     font-weight: 600;
     text-decoration: none;
-    position: absolute;
-    bottom: 50px;
-    right: 60px;
 }


### PR DESCRIPTION
**Overlapping content inside the backup modal**

_A tiny UI fix as a way to learn about the codebase / git flow._

To replicate, navigate on the dashboard to 
_Backup & Restore_ then select _Backup locally or to any cloud provider_

You'll see this overlap of elements and also grey text that is hard to read.
<img width="466" alt="Screen Shot 2019-09-04 at 9 33 51 PM" src="https://user-images.githubusercontent.com/121013/64264100-5538ab80-cf63-11e9-80bb-86dcc2d64a38.png">

Now it looks like:
<img width="470" alt="Screen Shot 2019-09-04 at 10 12 23 PM" src="https://user-images.githubusercontent.com/121013/64264144-64b7f480-cf63-11e9-9c9d-c54369f297fa.png">
