### PR TITLE
Updated installation requirements from Node LTS -> Node 10.x

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -4,7 +4,7 @@
 
 **This assumes a basic knowledge of `git`, `npm` and usage of the `command line`.**
 
-** Please ensure you are running on an environment using [the latest LTS version of Node](https://nodejs.org/en/).**
+**Please ensure you are running on an environment using [a v10.x release of Node](https://nodejs.org/en/).** As of writing, this is currently Node [v10.17.0](https://nodejs.org/download/release/v10.17.0/). Newer versions could result in a failing `yarn install` as they haven't been assessed just yet.
 
 ### First steps:
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -4,7 +4,9 @@
 
 **This assumes a basic knowledge of `git`, `npm` and usage of the `command line`.**
 
-**Please ensure you are running on an environment using [a v10.x release of Node](https://nodejs.org/en/).** As of writing, this is currently Node [v10.17.0](https://nodejs.org/download/release/v10.17.0/). Newer versions could result in a failing `yarn install` as they haven't been assessed just yet.
+**Please ensure you are running on an environment using [a v10.x release of Node](https://nodejs.org/en/).** As of writing, this is currently Node [v10.17.0](https://nodejs.org/download/release/v10.17.0/).
+
+Newer versions could result in a failing `yarn install` as they haven't been assessed just yet.
 
 ### First steps:
 


### PR DESCRIPTION
In response to the build failures that popped up recently, I've updated the installation note to mention Node 10.x as a requirement, as opposed to the latest Node LTS which recently changed from 10 -> 12