### PR TITLE
Write changes made while execute initial sync, to sync log

### DIFF
--- a/src/sync/background/index.test.ts
+++ b/src/sync/background/index.test.ts
@@ -816,77 +816,74 @@ function mobileSyncTests(suiteOptions: {
         })
     })
 
-    it(
-        'should log and transfer changes made during initial sync from ext to app',
-        { skip: true },
-        async (setup: TestSetup) => {
-            const { devices } = setup
+    it('should log and transfer changes made during initial sync from ext to app', async (setup: TestSetup) => {
+        const { devices } = setup
 
-            await insertIntegrationTestData(devices.extension)
-            const extensionStorageContents = await getExtensionStorageContents(
-                devices.extension.storageManager,
-            )
+        await insertIntegrationTestData(devices.extension)
+        const extensionStorageContents = await getExtensionStorageContents(
+            devices.extension.storageManager,
+        )
 
-            const extensionInitialSync =
-                devices.extension.backgroundModules.sync.initialSync
-            const origGetPreProcessor = extensionInitialSync.getPreSendProcessor.bind(
-                extensionInitialSync,
-            )
+        const extensionInitialSync =
+            devices.extension.backgroundModules.sync.initialSync
+        const origGetPreProcessor = extensionInitialSync.getPreSendProcessor.bind(
+            extensionInitialSync,
+        )
 
-            let lastObjectCollection: string
-            extensionInitialSync.getPreSendProcessor = () => {
-                const origPreProcessor = origGetPreProcessor()
-                return async params => {
-                    // When done with the bookmarks collection, create another bookmark
-                    if (
-                        lastObjectCollection === 'bookmarks' &&
-                        params.collection !== lastObjectCollection
-                    ) {
-                        await devices.extension.backgroundModules.bookmarks.addBookmark(
-                            {
-                                url: 'http://toolate.com/',
-                                time: new Date('2019-10-10').getTime(),
-                            },
-                        )
-                    }
-                    return origPreProcessor(params)
-                }
-            }
-
-            await doInitialSync({
-                source: devices.extension.backgroundModules.sync,
-                target: devices.mobile.services.sync,
-            })
-
-            const mobileStorageContentsBeforeIncrementalSync = await getMobileStorageContents(
-                devices.mobile.storage.manager,
-            )
-            expect(mobileStorageContentsBeforeIncrementalSync).toEqual({
-                ...extensionStorageContents,
-                syncDeviceInfo: expectedDeviceInfo,
-            })
-
-            await devices.extension.backgroundModules.sync.continuousSync.forceIncrementalSync()
-            await devices.mobile.services.sync.continuousSync.forceIncrementalSync()
-
-            const mobileStorageContentsAfterIncrementalSync = await getMobileStorageContents(
-                devices.mobile.storage.manager,
-            )
-            expect(mobileStorageContentsAfterIncrementalSync).toEqual({
-                ...{
-                    ...extensionStorageContents,
-                    bookmarks: [
-                        ...extensionStorageContents.bookmarks,
+        let lastObjectCollection: string
+        extensionInitialSync.getPreSendProcessor = () => {
+            const origPreProcessor = origGetPreProcessor()
+            return async params => {
+                // When done with the bookmarks collection, create another bookmark
+                if (
+                    lastObjectCollection === 'bookmarks' &&
+                    params.collection !== lastObjectCollection
+                ) {
+                    await devices.extension.backgroundModules.bookmarks.addBookmark(
                         {
-                            url: 'toolate.com',
+                            url: 'http://toolate.com/',
                             time: new Date('2019-10-10').getTime(),
                         },
-                    ],
-                },
-                syncDeviceInfo: expectedDeviceInfo,
-            })
-        },
-    )
+                    )
+                }
+                lastObjectCollection = params.collection
+                return origPreProcessor(params)
+            }
+        }
+
+        await doInitialSync({
+            source: devices.extension.backgroundModules.sync,
+            target: devices.mobile.services.sync,
+        })
+
+        const mobileStorageContentsBeforeIncrementalSync = await getMobileStorageContents(
+            devices.mobile.storage.manager,
+        )
+        expect(mobileStorageContentsBeforeIncrementalSync).toEqual({
+            ...extensionStorageContents,
+            syncDeviceInfo: expectedDeviceInfo,
+        })
+
+        await devices.extension.backgroundModules.sync.continuousSync.forceIncrementalSync()
+        await devices.mobile.services.sync.continuousSync.forceIncrementalSync()
+
+        const mobileStorageContentsAfterIncrementalSync = await getMobileStorageContents(
+            devices.mobile.storage.manager,
+        )
+        expect(mobileStorageContentsAfterIncrementalSync).toEqual({
+            ...{
+                ...extensionStorageContents,
+                bookmarks: [
+                    ...extensionStorageContents.bookmarks,
+                    {
+                        url: 'toolate.com',
+                        time: new Date('2019-10-10').getTime(),
+                    },
+                ],
+            },
+            syncDeviceInfo: expectedDeviceInfo,
+        })
+    })
 }
 
 describe('SyncBackground', () => {


### PR DESCRIPTION
This PR enables the sync logging at the end of the pre sync step, meaning that any changes the user makes while executing the initial sync (like making a bookmark) are eventually synced. [It's built on this PR](https://github.com/WorldBrain/Memex/pull/907).

The test for this was written in a commit that already landed in develop, but it's in `sync/background/index.test` and called:
```
should log and transfer changes made during initial sync from ext to app
```

Can anyone come up with ways this might go wrong? For the initial version, we're only taking 2 devices into account. Work on 3+ device sync will start after these two PRs are merged.

One case I took into account is the object sent through the initial sync ending up in the sync log, which we don't want in the case of 2 devices (but we do in the case of 3 devices.)

Still left to think about is error cases. In case the initial sync fails, I'd say we delete the sync log on the unsynced device, since the user will restart the initial sync later. Since both applications might fail without us being notified, I'd think storing a flag that the sync is in progress would be a solution. If the initial sync is requested again, but we don't detect the initial sync already running, it'd mean the initial sync was not properly finished the last time.

Another thing to consider is that we now write changes made during initial sync to the log, but do not exchange those entries as part of the initial sync. As a result, these changes will only come in after 15 minutes. Do we want this to happen during the initial process.

Anything else?