### PR TITLE
Fix sync on startup

### DIFF
--- a/src/sync/background/index.test.ts
+++ b/src/sync/background/index.test.ts
@@ -328,9 +328,6 @@ function extensionSyncTests(suiteOptions: {
             userId,
         } = setup
 
-        devices[0].authService.setUser({ ...TEST_USER, id: userId as string })
-        devices[1].authService.setUser({ ...TEST_USER, id: userId as string })
-
         const deviceIds = [
             await sharedSyncLog.createDeviceId({ userId }),
             await sharedSyncLog.createDeviceId({ userId }),
@@ -346,6 +343,10 @@ function extensionSyncTests(suiteOptions: {
         })
 
         await forEachSetup(s => syncModule(s).setup())
+
+        devices[0].authService.setUser({ ...TEST_USER, id: userId as string })
+        devices[1].authService.setUser({ ...TEST_USER, id: userId as string })
+
         await forEachSetup(s => syncModule(s).firstContinuousSyncPromise)
         // await forEachSetup(
         //     s => (syncModule(s).continuousSync.useEncryption = false),
@@ -393,7 +394,6 @@ function extensionSyncTests(suiteOptions: {
         } = setup
 
         devices[0].authService.setUser({ ...TEST_USER, id: userId as string })
-        devices[1].authService.setUser({ ...TEST_USER, id: userId as string })
 
         const deviceIds = [
             await sharedSyncLog.createDeviceId({ userId }),
@@ -421,6 +421,7 @@ function extensionSyncTests(suiteOptions: {
         )
         await devices[0].backgroundModules.sync.continuousSync.forceIncrementalSync()
         await syncModule(devices[1]).setup()
+        devices[1].authService.setUser({ ...TEST_USER, id: userId as string })
         // syncModule(devices[1]).continuousSync.useEncryption = false
         await syncModule(devices[1]).firstContinuousSyncPromise
 

--- a/src/sync/background/index.ts
+++ b/src/sync/background/index.ts
@@ -109,7 +109,6 @@ export default class SyncBackground extends SyncService {
                 authChangePromise,
                 new Promise(resolve => setTimeout(resolve, 2000)),
             ])
-            await authChangePromise
             await maybeSync()
         })()
     }

--- a/src/sync/background/index.ts
+++ b/src/sync/background/index.ts
@@ -18,6 +18,7 @@ import {
 import { INCREMENTAL_SYNC_FREQUENCY } from './constants'
 import { filterBlobsFromSyncLog } from './sync-logging'
 import { MemexExtSyncSettingStore } from './setting-store'
+import { resolvablePromise } from 'src/util/promises'
 
 export default class SyncBackground extends SyncService {
     remoteFunctions: PublicSyncInterface
@@ -25,6 +26,7 @@ export default class SyncBackground extends SyncService {
     getSharedSyncLog: () => Promise<SharedSyncLog>
 
     readonly syncedCollections: string[] = SYNCED_COLLECTIONS
+    readonly auth: AuthService
 
     constructor(options: {
         auth: AuthService
@@ -49,6 +51,8 @@ export default class SyncBackground extends SyncService {
             productVersion: options.appVersion,
             disableEncryption: true,
         })
+
+        this.auth = options.auth
 
         const bound = <Target, Key extends keyof Target>(
             object: Target,
@@ -83,7 +87,31 @@ export default class SyncBackground extends SyncService {
 
     async setup() {
         await this.continuousSync.setup()
-        this.firstContinuousSyncPromise = this.continuousSync.forceIncrementalSync()
+
+        const authChangePromise = resolvablePromise()
+        this.auth.events.once('changed', () => {
+            authChangePromise.resolve()
+        })
+
+        this.firstContinuousSyncPromise = (async () => {
+            const maybeSync = async () => {
+                const isAuthenticated = !!(await this.auth.getCurrentUser())
+                if (isAuthenticated) {
+                    await this.continuousSync.forceIncrementalSync()
+                }
+                return isAuthenticated
+            }
+            if (await maybeSync()) {
+                return
+            }
+
+            await Promise.race([
+                authChangePromise,
+                new Promise(resolve => setTimeout(resolve, 2000)),
+            ])
+            await authChangePromise
+            await maybeSync()
+        })()
     }
 
     async tearDown() {


### PR DESCRIPTION
Didn't test in browser with Firebase yet, but this should solve the error about not being able to sync without a user on startup, caused by the Firebase auth layer not immediately knowing whether the user is logged in on startup. It now waits for Firebase to realize there's already a user, with a timeout of 2 seconds.