### PR TITLE
[WIP] Fix annotation states (amoung shortcut keys and sidebar, and other)

### DIFF
--- a/src/content-tooltip/components/container.jsx
+++ b/src/content-tooltip/components/container.jsx
@@ -66,8 +66,8 @@ class TooltipContainer extends React.Component {
         addTag,
         addToCollection,
         createAnnotation,
+        createHighlight,
         createBookmark,
-        highlight,
         link,
         toggleHighlights,
         toggleSidebar,
@@ -119,11 +119,8 @@ class TooltipContainer extends React.Component {
                 case link.shortcut:
                     link.enabled && (await this.createLink())
                     break
-                case highlight.shortcut:
-                    if (highlight.enabled) {
-                        await this.props.createHighlight()
-                        this.toggleHighlightsAct()
-                    }
+                case createHighlight.shortcut:
+                    createHighlight.enabled && (await this.createHighlight(e))
                     break
                 case createAnnotation.shortcut:
                     createAnnotation.enabled && (await this.createAnnotation(e))

--- a/src/content-tooltip/constants.js
+++ b/src/content-tooltip/constants.js
@@ -10,11 +10,11 @@ export const KEYBOARDSHORTCUTS_STORAGE_NAME = 'memex-keyboardshortcuts'
 
 export const KEYBOARDSHORTCUTS_DEFAULT_STATE = {
     shortcutsEnabled: true,
-    highlightShortcut: 'n',
     linkShortcut: 'l',
     toggleSidebarShortcut: 'r',
     toggleHighlightsShortcut: 'h',
     createAnnotationShortcut: 'a',
+    createHighlightShortcut: 'n',
     createBookmarkShortcut: 'b',
     addTagShortcut: 't',
     addToCollectionShortcut: 'u',

--- a/src/content-tooltip/content_script.ts
+++ b/src/content-tooltip/content_script.ts
@@ -24,7 +24,7 @@ import { KeyboardShortcuts } from './types'
 import { createHighlight } from 'src/highlighting/ui'
 import {
     fetchAnnotationsAndHighlight,
-    createAnnotationDraftInSidebar as createAnnotationAct,
+    createAnnotationDraftInSidebar,
 } from 'src/annotations'
 import { toggleSidebarOverlay } from 'src/sidebar-overlay/utils'
 import { removeHighlights } from 'src/highlighting/ui/highlight-interactions'
@@ -139,7 +139,7 @@ const toggleHighlightsAct = () => {
 const createNewAnnotation = async e => {
     e.preventDefault()
     e.stopPropagation()
-    await createAnnotationAct()
+    await createAnnotationDraftInSidebar()
 
     // Remove onboarding select option notification if it's present
     await conditionallyRemoveSelectOption(STAGES.annotation.annotationCreated)

--- a/src/content-tooltip/types.ts
+++ b/src/content-tooltip/types.ts
@@ -6,12 +6,12 @@ export interface Shortcut {
 export interface KeyboardShortcuts {
     shortcutsEnabled?: boolean
     createAnnotation: Shortcut
+    createHighlight: Shortcut
     toggleHighlights: Shortcut
     addToCollection: Shortcut
     createBookmark: Shortcut
     toggleSidebar: Shortcut
     addComment: Shortcut
-    highlight: Shortcut
     addTag: Shortcut
     link: Shortcut
 }

--- a/src/content-tooltip/utils.ts
+++ b/src/content-tooltip/utils.ts
@@ -77,7 +77,7 @@ const shortcutStorageToState = (storage): KeyboardShortcuts => {
         'toggleSidebar',
         'toggleHighlights',
         'createAnnotation',
-        'highlight',
+        'createHighlight',
         'link',
         'createBookmark',
         'shortcutsEnabled',

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -10,7 +10,7 @@ import initRibbonAndSidebar from './sidebar-overlay/content_script'
 import 'src/backup-restore/content_script'
 import ToolbarNotifications from 'src/toolbar-notification/content_script'
 import initSocialIntegration from 'src/social-integration/content_script'
-import { HighlightInteraction } from './highlighting/ui/highlight-interactions'
+import configureStore from './sidebar-overlay/store'
 
 const remoteFunctionRegistry = new RemoteFunctionRegistry()
 
@@ -19,10 +19,11 @@ toolbarNotifications.registerRemoteFunctions(remoteFunctionRegistry)
 // toolbarNotifications.showToolbarNotification('tooltip-first-close')
 window['toolbarNotifications'] = toolbarNotifications
 
-const annotationsManager = new AnnotationsManager()
-const highlighter = new HighlightInteraction()
+const store = configureStore()
 
-initContentTooltip({ toolbarNotifications })
-initRibbonAndSidebar({ annotationsManager, toolbarNotifications, highlighter })
+const annotationsManager = new AnnotationsManager()
+
+initContentTooltip({ toolbarNotifications, store })
+initRibbonAndSidebar({ annotationsManager, toolbarNotifications, store })
 
 initSocialIntegration({ annotationsManager })

--- a/src/options/settings/components/keyboard-shortcuts-container.tsx
+++ b/src/options/settings/components/keyboard-shortcuts-container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Checkbox } from '../../../common-ui/components'
 import * as utils from 'src/content-tooltip/utils'
-import { convertKeyboardEventToKeyString } from '../../../content-tooltip/utils'
+import { convertKeyboardEventToKeyString } from 'src/content-tooltip/utils'
 import { KeyboardShortcuts } from 'src/content-tooltip/types'
 import { shortcuts, ShortcutElData } from '../keyboard-shortcuts'
 
@@ -21,11 +21,11 @@ class KeyboardShortcutsContainer extends React.PureComponent<Props, State> {
 
     state: State = {
         shortcutsEnabled: true,
-        highlight: { shortcut: 'n', enabled: true },
         link: { shortcut: 'l', enabled: true },
         toggleSidebar: { shortcut: 'r', enabled: true },
         toggleHighlights: { shortcut: 'h', enabled: true },
         createAnnotation: { shortcut: 'a', enabled: true },
+        createHighlight: { shortcut: 'n', enabled: true },
         addTag: { shortcut: 't', enabled: true },
         addComment: { shortcut: 'c', enabled: true },
         addToCollection: { shortcut: 'u', enabled: true },
@@ -80,25 +80,29 @@ class KeyboardShortcutsContainer extends React.PureComponent<Props, State> {
     }
 
     renderCheckboxes() {
-        return this.props.shortcutsData.map(({ id, name, children }) => (
-            <Checkbox
-                key={id}
-                id={id}
-                isChecked={this.state[name].enabled}
-                handleChange={this.handleEnabledToggle}
-                isDisabled={!this.state.shortcutsEnabled}
-                name={name}
-            >
-                {children}
-                <input
-                    type="text"
-                    value={this.state[name].shortcut}
-                    onKeyDown={this.recordBinding}
-                    onChange={e => e.preventDefault()}
-                    name={name}
-                />{' '}
-            </Checkbox>
-        ))
+        return this.props.shortcutsData.map(({ id, name, children }) => {
+            if (this.state[name]) {
+                return (
+                    <Checkbox
+                        key={id}
+                        id={id}
+                        isChecked={this.state[name].enabled}
+                        handleChange={this.handleEnabledToggle}
+                        isDisabled={!this.state.shortcutsEnabled}
+                        name={name}
+                    >
+                        {children}
+                        <input
+                            type="text"
+                            value={this.state[name].shortcut}
+                            onKeyDown={this.recordBinding}
+                            onChange={e => e.preventDefault()}
+                            name={name}
+                        />{' '}
+                    </Checkbox>
+                )
+            }
+        })
     }
 
     render() {

--- a/src/options/settings/keyboard-shortcuts.ts
+++ b/src/options/settings/keyboard-shortcuts.ts
@@ -11,7 +11,7 @@ export const shortcuts: ShortcutElData[] = [
     { id: 'link-shortcut', name: 'link', children: 'Create links' },
     {
         id: 'highlight-shortcut',
-        name: 'highlight',
+        name: 'createHighlight',
         children: 'Highlight selected text',
     },
     {

--- a/src/sidebar-overlay/comment-box/components/comment-box-container.tsx
+++ b/src/sidebar-overlay/comment-box/components/comment-box-container.tsx
@@ -11,7 +11,6 @@ import CommentBoxForm from './comment-box-form'
 import { MapDispatchToProps } from '../../types'
 import { Anchor, HighlightInteractionInterface } from 'src/highlighting/types'
 import { withSidebarContext } from 'src/sidebar-overlay/ribbon-sidebar-controller/sidebar-context'
-import { createHighlight } from 'src/highlighting/ui'
 
 const styles = require('./comment-box-container.css')
 

--- a/src/sidebar-overlay/content_script/index.ts
+++ b/src/sidebar-overlay/content_script/index.ts
@@ -4,13 +4,6 @@ import * as interactions from './ribbon-interactions'
 import { getSidebarState } from '../utils'
 import AnnotationsManager from 'src/annotations/annotations-manager'
 import { runOnScriptShutdown } from 'src/content-tooltip/utils'
-import { HighlightInteractionInterface } from 'src/highlighting/types'
-
-interface ContentScriptProps {
-    annotationsManager: AnnotationsManager
-    toolbarNotifications: ToolbarNotifications
-    highlighter: HighlightInteractionInterface
-}
 
 // TODO (ch - annotations extra) - huh? If commenting this out doesn't break anything remove it
 // const onKeydown = (
@@ -26,12 +19,14 @@ interface ContentScriptProps {
 const initRibbonAndSidebar = async ({
     annotationsManager,
     toolbarNotifications,
+    store,
 }: {
     annotationsManager: AnnotationsManager
     toolbarNotifications: ToolbarNotifications
+    store: any
 }) => {
     runOnScriptShutdown(() => interactions.removeRibbon())
-    interactions.setupRPC({ annotationsManager, toolbarNotifications })
+    interactions.setupRPC({ annotationsManager, toolbarNotifications, store })
 
     const isSidebarEnabled = await getSidebarState()
     if (!isSidebarEnabled) {
@@ -50,7 +45,11 @@ const initRibbonAndSidebar = async ({
     // TODO (ch - annotations extra) - huh?
     // document.removeEventListener('keydown', onKeydownWrapper, false)
 
-    interactions.insertRibbon({ annotationsManager, toolbarNotifications })
+    interactions.insertRibbon({
+        annotationsManager,
+        toolbarNotifications,
+        store,
+    })
 }
 
 export default initRibbonAndSidebar

--- a/src/sidebar-overlay/content_script/ribbon-interactions.ts
+++ b/src/sidebar-overlay/content_script/ribbon-interactions.ts
@@ -37,11 +37,13 @@ export const insertRibbon = async ({
     annotationsManager,
     toolbarNotifications,
     forceExpandRibbon = false,
+    store,
     ...args
 }: {
     annotationsManager: AnnotationsManager
     toolbarNotifications: ToolbarNotifications
     forceExpandRibbon?: boolean
+    store: any
 }) => {
     // If target is set, Ribbon has already been injected.
     if (target) {
@@ -72,13 +74,14 @@ export const insertRibbon = async ({
             if (isTooltipEnabled) {
                 removeTooltip()
             } else {
-                await insertTooltip({ toolbarNotifications })
+                await insertTooltip({ toolbarNotifications, store })
             }
         },
         setRibbonSidebarRef: ref => {
             ribbonSidebarRef = ref
         },
         forceExpandRibbon,
+        store,
         ...args,
     })
 }
@@ -121,9 +124,11 @@ export const removeRibbon = () => {
 const _insertOrRemoveRibbon = async ({
     annotationsManager,
     toolbarNotifications,
+    store,
 }: {
     annotationsManager: AnnotationsManager
     toolbarNotifications: ToolbarNotifications
+    store
 }) => {
     if (manualOverride) {
         return
@@ -133,7 +138,7 @@ const _insertOrRemoveRibbon = async ({
     const isRibbonPresent = !!target
 
     if (isRibbonEnabled && !isRibbonPresent) {
-        insertRibbon({ annotationsManager, toolbarNotifications })
+        insertRibbon({ annotationsManager, toolbarNotifications, store })
     } else if (!isRibbonEnabled && isRibbonPresent) {
         removeRibbon()
     }
@@ -175,9 +180,11 @@ const updateRibbon = async (
 export const setupRPC = ({
     annotationsManager,
     toolbarNotifications,
+    store,
 }: {
     annotationsManager: AnnotationsManager
     toolbarNotifications: ToolbarNotifications
+    store: any
 }) => {
     makeRemotelyCallableType<RibbonInteractionsInterface>({
         /**
@@ -206,6 +213,7 @@ export const setupRPC = ({
             await _insertOrRemoveRibbon({
                 annotationsManager,
                 toolbarNotifications,
+                store,
             })
         },
         /**

--- a/src/sidebar-overlay/index.tsx
+++ b/src/sidebar-overlay/index.tsx
@@ -5,7 +5,6 @@ import RibbonSidebarController from './ribbon-sidebar-controller'
 import AnnotationsManager from '../annotations/annotations-manager'
 import { KeyboardActions } from 'src/sidebar-overlay/sidebar/types'
 import { HighlightInteraction } from '../highlighting/ui/highlight-interactions'
-import { HighlightInteractionInterface } from 'src/highlighting/types'
 import { SidebarContextInterface } from 'src/sidebar-overlay/types'
 
 export const SidebarContext = React.createContext<SidebarContextInterface>(null)
@@ -20,6 +19,7 @@ export const setupRibbonAndSidebarUI = (
         insertOrRemoveTooltip,
         setRibbonSidebarRef,
         forceExpandRibbon = false,
+        store,
         ...props
     }: {
         annotationsManager: AnnotationsManager
@@ -27,6 +27,7 @@ export const setupRibbonAndSidebarUI = (
         insertOrRemoveTooltip: (isTooltipEnabled: boolean) => void
         setRibbonSidebarRef: any
         forceExpandRibbon?: boolean
+        store: any
     } & Partial<KeyboardActions>,
 ) => {
     ReactDOM.render(
@@ -37,6 +38,7 @@ export const setupRibbonAndSidebarUI = (
                 handleRemoveRibbon={handleRemoveRibbon}
                 insertOrRemoveTooltip={insertOrRemoveTooltip}
                 forceExpand={forceExpandRibbon}
+                store={store}
                 {...props}
             />
         </SidebarContext.Provider>,

--- a/src/sidebar-overlay/ribbon-sidebar-controller/ribbon-sidebar-controller.tsx
+++ b/src/sidebar-overlay/ribbon-sidebar-controller/ribbon-sidebar-controller.tsx
@@ -1,15 +1,10 @@
 import * as React from 'react'
 import { Provider } from 'react-redux'
 
-import configureStore from '../store'
 import RibbonSidebarContainer from './ribbon-sidebar-container'
 import { ErrorBoundary, RuntimeError } from 'src/common-ui/components'
 import AnnotationsManager from 'src/annotations/annotations-manager'
 import { KeyboardActions } from 'src/sidebar-overlay/sidebar/types'
-import { Annotation } from 'src/annotations/types'
-import { withSidebarContext } from 'src/sidebar-overlay/ribbon-sidebar-controller/sidebar-context'
-
-const store = configureStore()
 
 interface Props extends Partial<KeyboardActions> {
     annotationsManager: AnnotationsManager
@@ -17,11 +12,12 @@ interface Props extends Partial<KeyboardActions> {
     insertOrRemoveTooltip: (isTooltipEnabled: boolean) => void
     setRibbonSidebarRef: any
     forceExpand?: boolean
+    store: any
 }
 
 /* tslint:disable-next-line variable-name */
 const RibbonSidebarController = (props: Props) => {
-    const { setRibbonSidebarRef, ...rest } = props
+    const { setRibbonSidebarRef, store, ...rest } = props
 
     return (
         <ErrorBoundary component={RuntimeError}>


### PR DESCRIPTION
This WIP PR is aiming to fix:

- [ ] When adding a highlight through a keyboard shortcut, ensure it appears in the sidebar without needing to reload it.

This also touches on 
- [ ] When adding a highlight through highlight shortcut on the tooptip (the instant save button, not the annotate that opens the sidebar), the annotation is added, but it does not immediately appear in the sidebar annotations list (needs a reload) and also it does not replace the highlight anchor on the page with a highlight with a real url primary key, it stays as a temporary highlight until the page is reloaded. (preventing the deleting and clicking it to bring up the specific highlight in the sidebar).

And potentially other complexities due to the annotation actions and state are doing different things in different places.

I feel ideally there would be one redux state for the page that updates annotaions, changes to this state should be relfected by both annotations on the page and in the sidebar list. Though the scope of this change is unknown at this point pending the next set of investigation and refactoring in persuit of fixing this issue.