### PR TITLE
Fix backup and restore flows

### DIFF
--- a/src/backup-restore/background/backend/google-drive/index.ts
+++ b/src/backup-restore/background/backend/google-drive/index.ts
@@ -140,6 +140,9 @@ export class DriveBackupBackend extends BackupBackend {
             'appDataFolder',
             collection,
         )
+        if (!collectionFolderId) {
+            return []
+        }
         return Object.keys(await this.client.listFolder(collectionFolderId))
     }
 

--- a/src/backup-restore/background/index.ts
+++ b/src/backup-restore/background/index.ts
@@ -248,7 +248,7 @@ export class BackupBackgroundModule {
             handleLoginRedirectedBack: backend
                 ? backend.handleLoginRedirectedBack.bind(backend)
                 : null,
-            isAutomaticBackupEnabled: () => this.isAutomaticBackupEnabled(),
+            // isAutomaticBackupEnabled: () => this.isAutomaticBackupEnabled(),
             memexCloudOrigin: _getMemexCloudOrigin(),
         })
     }
@@ -346,7 +346,7 @@ export class BackupBackgroundModule {
         this.backupProcedure.events.on('success', async () => {
             // sets a flag that the progress of the backup has been successful so that the UI can set a proper state
             localStorage.setItem('progress-successful', 'true')
-            
+
             this.lastBackupStorage.storeLastBackupFinishTime(new Date())
             always()
         })

--- a/src/backup-restore/background/redirect.ts
+++ b/src/backup-restore/background/redirect.ts
@@ -3,7 +3,6 @@ import { browser } from 'webextension-polyfill-ts'
 export function setupRequestInterceptors({
     webRequest,
     handleLoginRedirectedBack,
-    isAutomaticBackupEnabled,
     memexCloudOrigin,
 }) {
     if (handleLoginRedirectedBack) {
@@ -13,7 +12,6 @@ export function setupRequestInterceptors({
             ['blocking'],
         )
     }
-
 }
 
 export function makeGoogleCallbackHandler({ handleLoginRedirectedBack }) {
@@ -24,14 +22,14 @@ export function makeGoogleCallbackHandler({ handleLoginRedirectedBack }) {
         }
 
         handleLoginRedirectedBack(url)
+        const targetUrl = `${browser.extension.getURL('/options.html')}#/backup`
 
-        // to get around the blocked state of the request, we update the original tab with the backup screen. 
-        // this is probably a bit glitchy at first, but we may be able to improve on that experience. For now it should be OK. 
-        setTimeout(()=> {
-            const targetUrl = `${browser.extension.getURL('/options.html')}#/backup`
-            browser.tabs.update(tabId, {active: true, url: targetUrl})
+        // to get around the blocked state of the request, we update the original tab with the backup screen.
+        // this is probably a bit glitchy at first, but we may be able to improve on that experience. For now it should be OK.
+        setTimeout(() => {
+            browser.tabs.update(tabId, { active: true, url: targetUrl })
         }, 1000)
 
-        return {}
+        return { redirectUrl: targetUrl }
     }
 }

--- a/src/backup-restore/ui/backup-pane/container.logic.test.ts
+++ b/src/backup-restore/ui/backup-pane/container.logic.test.ts
@@ -34,7 +34,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => false,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
-                getBackendLocation: () => 'google-drive',
+                getBackendLocation: () => undefined,
             }),
         })
         expect(firstSessionState).toEqual({
@@ -68,13 +68,15 @@ describe('Backup settings container logic', () => {
         ])
 
         // User chooses backup location
+        let backendLocation: string
         await triggerEvent(
             firstSessionState,
             { type: 'onChoice', choice: 'google-drive' },
             {
                 remoteFunctions: {
                     isAutomaticBackupEnabled: () => false,
-                    setBackendLocation: choice => undefined,
+                    setBackendLocation: newChoice =>
+                        (backendLocation = newChoice),
                 },
             },
         )
@@ -90,6 +92,7 @@ describe('Backup settings container logic', () => {
                 },
             },
         ])
+        expect(backendLocation).toEqual('google-drive')
 
         // User chooses manual backup
         await triggerEvent(
@@ -144,6 +147,9 @@ describe('Backup settings container logic', () => {
             },
         ])
 
+        localStorage.setItem('drive-token-access', 'bla token')
+        localStorage.popChanges()
+
         // User lands back on the backup settings page after logging in
         const secondSessionState = await logic.getInitialState({
             analytics,
@@ -152,6 +158,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => true,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
             }),
         })
         expect(secondSessionState).toEqual({
@@ -159,8 +166,8 @@ describe('Backup settings container logic', () => {
             screen: 'running-backup',
         })
         expect(localStorage.popChanges()).toEqual([
-            { type: 'remove', key: 'backup.onboarding.authenticating' },
             { type: 'remove', key: 'backup.onboarding' },
+            { type: 'remove', key: 'backup.onboarding.authenticating' },
         ])
 
         // Backup finished, return to overview
@@ -190,6 +197,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => false,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => undefined,
             }),
         })
 
@@ -277,6 +285,7 @@ describe('Backup settings container logic', () => {
     it('should be able to guide the user through the restore flow when they try to restore without being logged in', async () => {
         const { localStorage, analytics, triggerEvent } = setupTest()
 
+        let backendLocation: string
         const firstSessionState = await logic.getInitialState({
             analytics,
             localStorage,
@@ -284,6 +293,9 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => false,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
+                setBackendLocation: (newChoice: string) =>
+                    (backendLocation = newChoice),
             }),
         })
         expect(firstSessionState).toEqual({
@@ -306,7 +318,8 @@ describe('Backup settings container logic', () => {
             { type: 'onChoice', choice: 'google-drive' },
             {
                 remoteFunctions: {
-                    initRestoreProcedure: provider => null,
+                    initRestoreProcedure: provider =>
+                        (backendLocation = provider),
                 },
             },
         )
@@ -321,6 +334,9 @@ describe('Backup settings container logic', () => {
             },
         ])
 
+        localStorage.setItem('drive-token-access', 'bla token')
+        localStorage.popChanges()
+
         const secondSessionState = await logic.getInitialState({
             analytics,
             localStorage,
@@ -328,6 +344,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => true,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
             }),
         })
         expect(secondSessionState).toEqual({
@@ -345,6 +362,7 @@ describe('Backup settings container logic', () => {
     it('should be able to handle a Drive login cancel during restore flow', async () => {
         const { localStorage, analytics, triggerEvent } = setupTest()
 
+        let backendLocation: string
         const firstSessionState = await logic.getInitialState({
             analytics,
             localStorage,
@@ -352,6 +370,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => false,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
             }),
         })
         expect(firstSessionState).toEqual({
@@ -375,6 +394,8 @@ describe('Backup settings container logic', () => {
             {
                 remoteFunctions: {
                     initRestoreProcedure: provider => null,
+                    setBackendLocation: (choice: string) =>
+                        (backendLocation = choice),
                 },
             },
         )
@@ -396,6 +417,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => false,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
             }),
         })
         expect(secondSessionState).toEqual({
@@ -413,6 +435,7 @@ describe('Backup settings container logic', () => {
     it('should be able to guide the user through the restore flow when they try to restore while being logged in', async () => {
         const { localStorage, analytics, triggerEvent } = setupTest()
 
+        let backendLocation: string
         const firstSessionState = await logic.getInitialState({
             analytics,
             localStorage,
@@ -420,6 +443,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => true,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
             }),
         })
         expect(firstSessionState).toEqual({
@@ -442,7 +466,8 @@ describe('Backup settings container logic', () => {
             { type: 'onChoice', choice: 'google-drive' },
             {
                 remoteFunctions: {
-                    initRestoreProcedure: provider => null,
+                    initRestoreProcedure: provider =>
+                        (backendLocation = provider),
                 },
             },
         )
@@ -455,6 +480,7 @@ describe('Backup settings container logic', () => {
     it('should be able to guide the user through the restore flow when using local', async () => {
         const { localStorage, analytics, triggerEvent } = setupTest()
 
+        let backendLocation: string
         const firstSessionState = await logic.getInitialState({
             analytics,
             localStorage,
@@ -462,6 +488,7 @@ describe('Backup settings container logic', () => {
                 isBackupBackendAuthenticated: () => false,
                 hasInitialBackup: () => false,
                 getBackupInfo: () => null,
+                getBackendLocation: () => backendLocation,
             }),
         })
         expect(firstSessionState).toEqual({
@@ -484,7 +511,8 @@ describe('Backup settings container logic', () => {
             { type: 'onChoice', choice: 'local' },
             {
                 remoteFunctions: {
-                    initRestoreProcedure: provider => null,
+                    initRestoreProcedure: provider =>
+                        (backendLocation = provider),
                 },
             },
         )

--- a/src/util/tests/local-storage.ts
+++ b/src/util/tests/local-storage.ts
@@ -12,7 +12,9 @@ export class MemoryLocalStorage {
     }
 
     removeItem(key: string) {
-        this.changes.push({ type: 'remove', key })
+        if (key in this.items) {
+            this.changes.push({ type: 'remove', key })
+        }
         delete this.items[key]
     }
 

--- a/src/util/webextensionRPC.ts
+++ b/src/util/webextensionRPC.ts
@@ -276,6 +276,11 @@ export function fakeRemoteFunctions(functions: {
     [name: string]: (...args) => any
 }) {
     return name => {
+        if (!functions[name]) {
+            throw new Error(
+                `Tried to call fake remote function '${name}' for which no implementation was provided`,
+            )
+        }
         return (...args) => {
             return Promise.resolve(functions[name](...args))
         }


### PR DESCRIPTION
Turns out that also when testing manually, the backup flow seemed to be broken, as it took me to the overview right after Google Drive login. I've fixed this and verified manually the flow works both with GDrive and the local server.

However, for some reason I don't get an access token anymore, maybe because of the hack we did (Google probably doesn't like two requests coming in.) This means I couldn't fully test GDrive backup/restore.

I'll now investigate this and fix it in this PR if possible.