### PR TITLE
Fix collections being added twice in the sidebar filter pane

### DIFF
--- a/src/sidebar-overlay/sidebar/components/lists-container.js
+++ b/src/sidebar-overlay/sidebar/components/lists-container.js
@@ -83,6 +83,7 @@ class ListContainer extends Component {
 
     handleCreateListSubmit = event => {
         event.preventDefault()
+        event.stopPropagation()
         const { value } = event.target.elements['listName']
         // value = list name
         this.props.createPageList(


### PR DESCRIPTION
Due to the form field's submit firing twice in rapid succession. Fixed by stopping propagation of the event.