### PR TITLE
Re-instate Managing Existing subscriptions via the extension

### DIFF
--- a/src/authentication/components/AccountInfo.tsx
+++ b/src/authentication/components/AccountInfo.tsx
@@ -3,12 +3,16 @@ import {
     UserProps,
     withCurrentUser,
 } from 'src/authentication/components/AuthConnector'
-import { TypographyHeadingPage } from 'src/common-ui/components/design-library/typography'
+import {
+    TypographyHeadingPage,
+    TypographyInputTitle,
+} from 'src/common-ui/components/design-library/typography'
 import { FullPage } from 'src/common-ui/components/design-library/FullPage'
 import { PrimaryButton } from 'src/common-ui/components/primary-button'
 import Link from 'src/common-ui/components/link'
 import { connect } from 'react-redux'
 import { show } from 'src/overview/modals/actions'
+import { InputTextField } from 'src/common-ui/components/design-library/form/InputTextField'
 
 interface Props {
     initiallyShowSubscriptionModal?: boolean
@@ -25,14 +29,28 @@ export class AccountInfo extends React.PureComponent<Props & UserProps> {
     render() {
         const user = this.props.currentUser
         const features = this.props.authorizedFeatures
-        const url = 'https://getmemex.com/subscriptions'
         return (
             <FullPage>
                 <TypographyHeadingPage>My Account</TypographyHeadingPage>
+                <br />
                 {user != null && (
                     <div>
-                        <PrimaryButton>
-                            <Link url={url} text={'Manage Subscriptions'} />
+                        <TypographyInputTitle>
+                            {' '}
+                            Email Address{' '}
+                        </TypographyInputTitle>
+
+                        <InputTextField
+                            type={'text'}
+                            defaultValue={user.email}
+                            readonly
+                            disabled
+                        />
+
+                        <PrimaryButton
+                            onClick={this.props.showSubscriptionModal}
+                        >
+                            {'Manage Subscriptions'}
                         </PrimaryButton>
 
                         <input

--- a/src/authentication/components/AccountMenu.tsx
+++ b/src/authentication/components/AccountMenu.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import OverlayMenu from 'src/common-ui/components/design-library/overlay-menu/OverlayMenu'
-import {
-    TypographyHeadingSmall,
-    TypographyHeadingBig,
-} from 'src/common-ui/components/design-library/typography'
+import { TypographyHeadingBig } from 'src/common-ui/components/design-library/typography'
 import { auth } from 'src/util/remote-functions-background'
 import {
     UserProps,
@@ -16,20 +13,21 @@ import { MemexLogo } from 'src/common-ui/components/MemexLogo'
 import { connect } from 'react-redux'
 import { show } from 'src/overview/modals/actions'
 
-
 const handleLoginClick = () => {
     window.location.href = LOGIN_URL
 }
 
 const handleAccountClick = () => {
-    window.location.href = 'https://getmemex.com/subscriptions'
+    window.location.href = LOGIN_URL
 }
 
 const handleLogOutClick = () => {
     return auth.signOut()
 }
 
-const AccountMenu = (props: UserProps & {showSubscriptionModal: () => void}) => {
+const AccountMenu = (
+    props: UserProps & { showSubscriptionModal: () => void },
+) => {
     if (props.currentUser === null) {
         return (
             <BottomLeft>
@@ -51,7 +49,10 @@ const AccountMenu = (props: UserProps & {showSubscriptionModal: () => void}) => 
                     </ButtonSideMenu>
                 }
                 menuItems={[
-                    { label: '⭐️ Upgrade', handler: props.showSubscriptionModal },
+                    {
+                        label: '⭐️ Upgrade',
+                        handler: props.showSubscriptionModal,
+                    },
                     { label: 'Account Info', handler: handleAccountClick },
                     { label: 'Log Out', handler: handleLogOutClick },
                 ]}

--- a/src/authentication/components/Subscription/SubscriptionOptionsChargebee.tsx
+++ b/src/authentication/components/Subscription/SubscriptionOptionsChargebee.tsx
@@ -4,10 +4,17 @@ import { Helmet } from 'react-helmet'
 import { UserPlan } from '@worldbrain/memex-common/lib/subscriptions/types'
 import { AuthenticatedUser } from '@worldbrain/memex-common/lib/authentication/types'
 import { auth } from 'src/util/remote-functions-background'
-import { PricingPlanTitle, PricingPlanItem, LoginTitle, LoginButton, WhiteSpacer30 } from 'src/authentication/components/Subscription/pricing.style'
+import {
+    PricingPlanTitle,
+    PricingPlanItem,
+    LoginTitle,
+    LoginButton,
+    WhiteSpacer30,
+} from 'src/authentication/components/Subscription/pricing.style'
 import { PrimaryButton } from 'src/common-ui/components/primary-button'
 import styled from 'styled-components'
 import { SubscriptionInnerOptions } from 'src/authentication/components/Subscription/SubscriptionInnerOptions'
+import { CenterText } from 'src/common-ui/components/design-library/typography'
 const chargeBeeScriptSource = 'https://js.chargebee.com/v2/chargebee.js'
 
 export const subscriptionConfig = {
@@ -148,11 +155,21 @@ export class SubscriptionOptionsChargebee extends React.Component<
                 </Helmet>
                 <div>
                     <SubscriptionInnerOptions
-                        openCheckoutBackupMonthly={this.openCheckoutBackupMonthly}
+                        openCheckoutBackupMonthly={
+                            this.openCheckoutBackupMonthly
+                        }
                         openCheckoutBackupYearly={this.openCheckoutBackupYearly}
                         openPortal={this.openPortal}
                         plans={this.props.plans}
                     />
+
+                    <CenterText>
+                        {this.state.subscribed && (
+                            <PrimaryButton onClick={this.openPortal}>
+                                {'Existing Subscriptions'}
+                            </PrimaryButton>
+                        )}
+                    </CenterText>
                 </div>
             </div>
         )


### PR DESCRIPTION

This PR adds back into the extension the ability to 'Manage Existing Subscriptions' rather than needing to be redirected to the website. 

Needs a seccond test by someone other than me :)