### PR TITLE
[WIP] Show and action the 'clear filters' for lists/collections

### DIFF
--- a/src/overview/search-bar/selectors.ts
+++ b/src/overview/search-bar/selectors.ts
@@ -54,6 +54,7 @@ export const showClearFiltersBtn = createSelector(
     filterSelectors.usersExc,
     filterSelectors.hashtagsInc,
     filterSelectors.hashtagsExc,
+    filterSelectors.listFilter,
     startDate,
     endDate,
     (
@@ -66,6 +67,7 @@ export const showClearFiltersBtn = createSelector(
         usersExc,
         hashtagsInc,
         hashtagsExc,
+        listFilter,
         startDate,
         endDate,
     ) =>
@@ -78,6 +80,7 @@ export const showClearFiltersBtn = createSelector(
         !!usersExc.length ||
         !!hashtagsInc.length ||
         !!hashtagsExc.length ||
+        !!listFilter.length ||
         startDate ||
         endDate,
 )

--- a/src/search-filters/reducer.js
+++ b/src/search-filters/reducer.js
@@ -194,6 +194,7 @@ const setFilters = filterKey => (state, filters) => {
         newState.usersInc.length > 0 ||
         newState.hashtagsInc.length > 0 ||
         newState.hashtagsExc.length > 0 ||
+        newState.lists.length > 0 ||
         newState.onlyBookmarks
 
     return newState
@@ -226,7 +227,7 @@ const setSuggestedHashtags = (state, hashtags) => ({
 
 const resetFilters = state => ({
     ...defaultState,
-    lists: state.lists,
+    lists: '',
     showFilterBar: state.showFilterBar,
 })
 


### PR DESCRIPTION
_Edit: Best not to merge this yet, I'm finding bigger issues with the querying by collection that weren't apperant before_

This PR synchronises the state of a collection filter being applied with the state that shows the 'clear filters' toggle button.

So that when adding a collection as a filter criteria in the sidebar search, you can then clear it via the button.

Does not yet highlight that collection in the list. 