### PR TITLE
Ensure page `fullUrl` passed to needed overview XHRs

### DIFF
--- a/src/bookmarks/background/types.ts
+++ b/src/bookmarks/background/types.ts
@@ -1,13 +1,10 @@
 export interface BookmarksInterface {
-    addPageBookmark({
-        url,
-        timestamp,
-        tabId,
-    }: {
+    addPageBookmark(args: {
         url: string
+        fullUrl?: string
         timestamp?: number
         tabId?: number
     }): Promise<any>
 
-    delPageBookmark({ url }: { url: string }): Promise<any>
+    delPageBookmark(args: { url: string }): Promise<any>
 }

--- a/src/overview/results/actions.ts
+++ b/src/overview/results/actions.ts
@@ -66,10 +66,11 @@ export const setSearchType = createAction<'page' | 'notes' | 'social'>(
 export const initSearchCount = createAction('overview/initSearchCount')
 export const incSearchCount = createAction('overview/incSearchCount')
 
-export const toggleBookmark: (url: string, i: number) => Thunk = (
-    url,
-    index,
-) => async (dispatch, getState) => {
+export const toggleBookmark: (args: {
+    url: string
+    fullUrl: string
+    index: number
+}) => Thunk = ({ url, fullUrl, index }) => async (dispatch, getState) => {
     const results = selectors.results(getState())
     const { hasBookmark, user } = results[index]
     dispatch(changeHasBookmark(index))
@@ -87,7 +88,7 @@ export const toggleBookmark: (url: string, i: number) => Thunk = (
             : EVENT_NAMES.CREATE_RESULT_BOOKMARK,
     })
 
-    let bookmarkRPC: (args: { url: string }) => Promise<void>
+    let bookmarkRPC: (args: { url: string; fullUrl: string }) => Promise<void>
     // tslint:disable-next-line: prefer-conditional-expression
     if (hasBookmark) {
         bookmarkRPC = user ? deleteSocialBookmarkRPC : bookmarks.delPageBookmark
@@ -96,7 +97,7 @@ export const toggleBookmark: (url: string, i: number) => Thunk = (
     }
 
     try {
-        await bookmarkRPC({ url })
+        await bookmarkRPC({ url, fullUrl })
     } catch (err) {
         dispatch(changeHasBookmark(index))
         handleDBQuotaErrors(

--- a/src/overview/results/components/ResultListContainer.tsx
+++ b/src/overview/results/components/ResultListContainer.tsx
@@ -326,9 +326,9 @@ const mapDispatch: (dispatch, props: OwnProps) => DispatchProps = dispatch => ({
             }),
         )
     },
-    handleToggleBm: ({ url }, index) => event => {
+    handleToggleBm: ({ url, fullUrl }, index) => event => {
         event.preventDefault()
-        dispatch(acts.toggleBookmark(url, index))
+        dispatch(acts.toggleBookmark({ url, fullUrl, index }))
     },
     handleTrashBtnClick: ({ url }, index) => event => {
         event.preventDefault()

--- a/src/page-indexing/background/index.ts
+++ b/src/page-indexing/background/index.ts
@@ -176,7 +176,7 @@ export class PageIndexingBackground {
 
     async createPageFromUrl(props: PageCreationProps) {
         const fetchRes = await fetchPageData({
-            url: props.url,
+            url: props.fullUrl,
             opts: {
                 includePageContent: true,
                 includeFavIcon: false,

--- a/src/search/bookmarks.ts
+++ b/src/search/bookmarks.ts
@@ -10,11 +10,17 @@ export const addBookmark = (
     pages: PageIndexingBackground,
     bookmarksStorage: BookmarksStorage,
     tabManager: TabManager,
-) => async (params: { url: string; timestamp?: number; tabId?: number }) => {
+) => async (params: {
+    url: string
+    fullUrl: string
+    timestamp?: number
+    tabId?: number
+}) => {
     let page = await pages.storage.getPage(params.url)
     if (page == null || pageIsStub(page)) {
         page = await pages.createPageViaBmTagActs({
             url: params.url,
+            fullUrl: params.fullUrl,
             tabId: params.tabId,
         })
     }

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -132,6 +132,7 @@ export interface SearchIndex {
 
     addBookmark: (params: {
         url: string
+        fullUrl?: string
         timestamp?: number
         tabId?: number
     }) => Promise<void>
@@ -156,6 +157,7 @@ export interface SearchIndex {
 
 export interface PageCreationProps {
     url: string
+    fullUrl?: string
     tabId?: number
     stubOnly?: boolean
     allowScreenshot?: boolean

--- a/src/sidebar-overlay/sidebar/components/result-list-container.tsx
+++ b/src/sidebar-overlay/sidebar/components/result-list-container.tsx
@@ -302,9 +302,9 @@ const mapDispatch: (dispatch, props: OwnProps) => DispatchProps = dispatch => ({
             }),
         )
     },
-    handleToggleBm: ({ url }, index) => event => {
+    handleToggleBm: ({ url, fullUrl }, index) => event => {
         event.preventDefault()
-        dispatch(resultActs.toggleBookmark(url, index))
+        dispatch(resultActs.toggleBookmark({ url, fullUrl, index }))
     },
     handleTrashBtnClick: ({ url }, index) => event => {
         event.preventDefault()
@@ -329,7 +329,4 @@ const mapDispatch: (dispatch, props: OwnProps) => DispatchProps = dispatch => ({
     },
 })
 
-export default connect(
-    mapState,
-    mapDispatch,
-)(ResultListContainer)
+export default connect(mapState, mapDispatch)(ResultListContainer)


### PR DESCRIPTION
- addresses bug described in my comment in https://github.com/WorldBrain/Memex/pull/958#issuecomment-593201641
- previously was passing the already normalized `url` field to it, which resulted in attempting an XHR on the ext's URL concat'd with the normalized URL (we throw away the protocol part in our normalization logic)