### PR TITLE
Don't extract page content twice

### DIFF
--- a/src/activity-logger/background/log-page-visit.ts
+++ b/src/activity-logger/background/log-page-visit.ts
@@ -1,9 +1,13 @@
+import update from 'immutability-helper'
 import { Tabs } from 'webextension-polyfill-ts'
 import moment from 'moment'
 
 import { TabManager } from './tab-manager'
 // @ts-ignore
-import analyzePage, { PageAnalyzer } from '../../page-analysis/background'
+import analyzePage, {
+    PageAnalyzer,
+    PageAnalysis,
+} from '../../page-analysis/background'
 
 import { FavIconChecker } from './types'
 import { SearchIndex } from 'src/search'
@@ -15,6 +19,7 @@ interface Props {
     favIconCheck?: FavIconChecker
     pageAnalyzer?: PageAnalyzer
 }
+type PageLoggingPreparation = PageAnalysis
 
 export default class PageVisitLogger {
     private _tabManager: TabManager
@@ -42,6 +47,29 @@ export default class PageVisitLogger {
         this._moment = momentLib
     }
 
+    async preparePageLogging(params: {
+        tab: Tabs.Tab
+        allowScreenshot: boolean
+    }): Promise<PageLoggingPreparation | null> {
+        const internalTabState = this._tabManager.getTabState(params.tab.id)
+        if (internalTabState == null) {
+            return null
+        }
+
+        const allowFavIcon = !(await this._checkFavIcon(params.tab.url))
+        try {
+            const analysisRes = await this._analyzePage({
+                tabId: params.tab.id,
+                allowFavIcon,
+                allowScreenshot: params.allowScreenshot,
+            })
+            return analysisRes
+        } catch (err) {
+            console.error(err)
+            return null
+        }
+    }
+
     /**
      * Performs page data indexing for a browser tab. Immediately
      * indexes display data, and searchable title/URL terms, but returns
@@ -49,7 +77,7 @@ export default class PageVisitLogger {
      */
     async logPageStub(
         tab: Tabs.Tab,
-        allowScreenshot: boolean,
+        pageAnalysis: PageLoggingPreparation,
         secsSinceLastVisit = 20,
     ) {
         const internalTabState = this._tabManager.getTabState(tab.id)
@@ -82,24 +110,16 @@ export default class PageVisitLogger {
                 }
             }
 
-            const allowFavIcon = !(await this._checkFavIcon(tab.url))
-            let analysisRes
-            try {
-                analysisRes = await this._analyzePage({
-                    tabId: tab.id,
-                    allowFavIcon,
-                    allowScreenshot,
-                })
-            } catch (err) {
-                console.error(err)
-                return
+            // Don't index full-text in this stage
+            const pageDoc = {
+                url: tab.url,
+                ...update(pageAnalysis, {
+                    content: { $unset: ['fullText'] },
+                }),
             }
 
-            // Don't index full-text in this stage
-            delete analysisRes.content.fullText
-
             await this._createPage({
-                pageDoc: { url: tab.url, ...analysisRes },
+                pageDoc,
                 visits: [internalTabState.visitTime],
                 rejectNoContent: false,
             })
@@ -111,22 +131,10 @@ export default class PageVisitLogger {
 
     async logPageVisit(
         tab: Tabs.Tab,
-        allowScreenshot: boolean,
+        pageAnalysis: PageLoggingPreparation,
         textOnly = true,
     ) {
-        let analysisRes
-        try {
-            analysisRes = await this._analyzePage({
-                tabId: tab.id,
-                allowFavIcon: false,
-                allowScreenshot,
-            })
-        } catch (err) {
-            console.error(err)
-            return
-        }
-
-        const pageDoc = { url: tab.url, ...analysisRes }
+        const pageDoc = { url: tab.url, ...pageAnalysis }
 
         if (textOnly) {
             return this._addPageTerms({ pageDoc })

--- a/src/page-analysis/background/content-extraction/extract-html-content.ts
+++ b/src/page-analysis/background/content-extraction/extract-html-content.ts
@@ -1,4 +1,3 @@
-import transformPageHTML from 'src/util/transform-page-html'
 import { RawHtmlPageContent } from '../../types'
 import PAGE_METADATA_RULES from '../../page-metadata-rules'
 
@@ -6,13 +5,7 @@ const pick = keys => obj =>
     Object.assign({}, ...keys.map(key => ({ [key]: obj[key] })))
 
 export default function extractHtmlContent(rawContent: RawHtmlPageContent) {
-    // Apply simple transformations to clean the page's HTML
-    const { text: processedHtml } = transformPageHTML({
-        html: rawContent.body,
-    })
-
     return {
-        fullText: processedHtml,
         lang: rawContent.lang,
         // Picking desired fields, as getMetadata adds some unrequested stuff.
         ...pick(Object.keys(PAGE_METADATA_RULES))(rawContent.metadata),

--- a/src/page-analysis/background/content-extraction/extract-pdf-content.ts
+++ b/src/page-analysis/background/content-extraction/extract-pdf-content.ts
@@ -54,18 +54,15 @@ export default async function extractPdfContent(
         blob = await response.blob()
     }
 
-    return new Promise(function(resolve, reject) {
+    const pdfData = new Promise(function(resolve, reject) {
         const fileReader = new FileReader()
         fileReader.onload = async event => {
-            const pdfData = event.target.result
-            try {
-                const pdfContent = await extractContent(pdfData)
-                resolve(pdfContent)
-            } catch (err) {
-                reject(err)
-            }
+            resolve(event.target.result)
         }
         fileReader.onerror = event => reject(event.target.error)
         fileReader.readAsArrayBuffer(blob)
     })
+
+    const pdfContent = await extractContent(pdfData)
+    return pdfContent
 }

--- a/src/page-analysis/background/content-extraction/index.ts
+++ b/src/page-analysis/background/content-extraction/index.ts
@@ -1,13 +1,26 @@
 import { RawPageContent } from 'src/page-analysis/types'
 import extractPdfContent from './extract-pdf-content'
 import extractHtmlContent from './extract-html-content'
+import transformPageHTML from 'src/util/transform-page-html'
+import { PageContent } from 'src/search'
 
-export default function extractPageContentFromRawContent(
+export default function extractPageMetadataFromRawContent(
     rawContent: RawPageContent,
-) {
+): Promise<PageContent> {
     if (rawContent.type === 'pdf') {
         return extractPdfContent(rawContent)
     } else {
         return extractHtmlContent(rawContent)
     }
+}
+
+export async function getPageFullText(
+    rawContent: RawPageContent,
+    metadata: PageContent,
+) {
+    return rawContent.type === 'html'
+        ? transformPageHTML({
+              html: rawContent.body,
+          }).text
+        : metadata.fullText
 }

--- a/src/page-analysis/background/fetch-page-data.ts
+++ b/src/page-analysis/background/fetch-page-data.ts
@@ -3,7 +3,9 @@ import { normalizeUrl } from '@worldbrain/memex-url-utils'
 import extractFavIcon from 'src/page-analysis/background/content-extraction/extract-fav-icon'
 import extractPdfContent from 'src/page-analysis/background/content-extraction/extract-pdf-content'
 import extractRawPageContent from 'src/page-analysis/content_script/extract-page-content'
-import extractPageContentFromRawContent from './content-extraction'
+import extractPageMetadataFromRawContent, {
+    getPageFullText,
+} from './content-extraction'
 import { PageDataResult } from './types'
 import { FetchPageDataError } from './fetch-page-data-error'
 
@@ -79,7 +81,11 @@ const fetchPageData: FetchPageData = ({
 
             const extractPageContent = async () => {
                 const rawContent = await extractRawPageContent(doc, url)
-                return extractPageContentFromRawContent(rawContent)
+                const metadata = await extractPageMetadataFromRawContent(
+                    rawContent,
+                )
+                const fullText = await getPageFullText(rawContent, metadata)
+                return { ...metadata, fullText }
             }
 
             return {

--- a/src/page-analysis/background/index.ts
+++ b/src/page-analysis/background/index.ts
@@ -1,16 +1,20 @@
-import { whenPageDOMLoaded } from 'src/util/tab-events'
 import whenAllSettled from 'when-all-settled'
+import { whenPageDOMLoaded } from 'src/util/tab-events'
 
 import getFavIcon from './get-fav-icon'
 import makeScreenshot from './make-screenshot'
 import { runInTab } from 'src/util/webextensionRPC'
 import { PageAnalyzerInterface } from 'src/page-analysis/types'
-import extractPageContentFromRawContent from './content-extraction'
+import extractPageMetadataFromRawContent, {
+    getPageFullText,
+} from './content-extraction'
+import { PageContent } from 'src/search'
 
 export interface PageAnalysis {
-    favIconURI: string
-    screenshotURI: string
-    content: any
+    favIconURI?: string
+    screenshotURI?: string
+    content: PageContent
+    getFullText: () => Promise<string>
 }
 
 export type PageAnalyzer = (args: {
@@ -37,10 +41,9 @@ const analysePage: PageAnalyzer = async ({
         const rawContent = await runInTab<PageAnalyzerInterface>(
             tabId,
         ).extractRawPageContent()
-        const extractedContent = await extractPageContentFromRawContent(
-            rawContent,
-        )
-        return extractedContent
+        const metadata = await extractPageMetadataFromRawContent(rawContent)
+        const getFullText = async () => getPageFullText(rawContent, metadata)
+        return { metadata, getFullText }
     }
 
     // Fetch the data
@@ -57,7 +60,12 @@ const analysePage: PageAnalyzer = async ({
             onRejection: err => undefined,
         },
     )
-    return { favIconURI, screenshotURI, content: content || {} }
+    return {
+        favIconURI,
+        screenshotURI,
+        content: content.metadata || {},
+        getFullText: content.getFullText,
+    }
 }
 
 export default analysePage

--- a/src/page-analysis/background/index.ts
+++ b/src/page-analysis/background/index.ts
@@ -7,16 +7,18 @@ import { runInTab } from 'src/util/webextensionRPC'
 import { PageAnalyzerInterface } from 'src/page-analysis/types'
 import extractPageContentFromRawContent from './content-extraction'
 
+export interface PageAnalysis {
+    favIconURI: string
+    screenshotURI: string
+    content: any
+}
+
 export type PageAnalyzer = (args: {
     tabId: number
     allowContent?: boolean
     allowScreenshot?: boolean
     allowFavIcon?: boolean
-}) => Promise<{
-    favIconURI: string
-    screenshotURI: string
-    content: any
-}>
+}) => Promise<PageAnalysis>
 
 /**
  * Performs page content analysis on a given Tab's ID.

--- a/src/page-analysis/extract-page-content.test.ts
+++ b/src/page-analysis/extract-page-content.test.ts
@@ -2,7 +2,9 @@
 
 import { JSDOM } from 'jsdom'
 import extractRawPageContent from './content_script/extract-page-content'
-import extractPageContentFromRawContent from './background/content-extraction'
+import extractPageMetadataFromRawContent, {
+    getPageFullText,
+} from './background/content-extraction'
 
 describe('Extract page content', () => {
     // beforeAll(() => {
@@ -46,8 +48,9 @@ describe('Extract page content', () => {
             dom.window.document,
             'https://test.com',
         )
-        const content = await extractPageContentFromRawContent(rawContent)
-        expect(content).toEqual({
+        const metadata = await extractPageMetadataFromRawContent(rawContent)
+        const fullText = await getPageFullText(rawContent, metadata)
+        expect({ ...metadata, fullText }).toEqual({
             fullText: ' Hello world ',
             lang: 'en',
             canonicalUrl: undefined,


### PR DESCRIPTION
On page visit, first a page stub is written to the database (URL and favicon only) and then after a timeout, the rest of the page is indexed. This would involve two page analysis invocations, which are quite expensive CPU-wise and involve an RPC call. This PR fixes this by only analyzing the page once, then re-using that result when indexing the full page.

I've tested the default prefs of indexing pages after 5 seconds. What are the other cases that need to be tested? I can see in the code that there might be a case where even stubs are not indexed, which should also be faster now.