### PR TITLE
Extend Regex for duckduckgo URL detection

### DIFF
--- a/src/search-injection/constants.js
+++ b/src/search-injection/constants.js
@@ -18,7 +18,7 @@ export const SEARCH_ENGINES = {
         containerType: 'id',
     },
     duckduckgo: {
-        regex: /(http[s]?:\/\/)?(www.)?duckduckgo[.\w]+\/\?q=.*/,
+        regex: /(http[s]?:\/\/)?(www.)?duckduckgo[.\w]+\/.*?[?&]q=.*/,
         container: {
             above: 'results--main',
             side: 'results--sidebar',

--- a/src/search-injection/utils.test.js
+++ b/src/search-injection/utils.test.js
@@ -15,6 +15,7 @@ describe('URL', () => {
         },
         ddg: {
             simple: 'https://duckduckgo.com/?q=test&t=canonical&ia=web',
+            unordered: 'https://duckduckgo.com/?t=canonical&q=test&ia=web',
             spacedquery: 'https://duckduckgo.com/?q=spaced+query&t=hb&ia=qa',
             nomatch: 'https://duckduckgo.com/?t=canonical&ia=web',
         },
@@ -27,6 +28,7 @@ describe('URL', () => {
 
     test('should match duckduckgo url', () => {
         expect(utils.matchURL(URLS.ddg.simple)).toBe('duckduckgo')
+        expect(utils.matchURL(URLS.ddg.unordered)).toBe('duckduckgo')
         expect(utils.matchURL(URLS.ddg.spacedquery)).toBe('duckduckgo')
     })
 


### PR DESCRIPTION
A duckduckgo search results URL does not always start with `?q=...`, especially not when coming from a page other than duckduckgo.com (for example when using certain browsers' search bars). This PR changes the URL detection regex string to work with any order of URL parameters.