### PR TITLE
Properly style dependent keyboard shortcut checkbox

### DIFF
--- a/src/common-ui/components/Checkbox.css
+++ b/src/common-ui/components/Checkbox.css
@@ -1,3 +1,6 @@
+@value colors: 'src/common-ui/colors.css';
+@value color14 from colors;
+
 .container {
     margin: 5px 0;
 }
@@ -30,6 +33,14 @@
     cursor: pointer;
 }
 
+.disabledIcon {
+    background-color: color14;
+}
+
+.disabledLabel {
+    cursor: default;
+}
+
 .label__check {
     border-radius: 3px;
     border: 2px solid rgba(0, 0, 0, 0.1);
@@ -38,16 +49,9 @@
     margin-right: 20px;
     width: 25px;
     height: 25px;
-    cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-
-    /* background-image: url('../../../img/check-solid.svg'); */
-
-    /* background-repeat: no-repeat; */
-
-    /* background-position: center; */
 
     &:hover {
         outline: none;
@@ -60,13 +64,11 @@
 
 .label__checkbox {
     display: none;
-    cursor: pointer;
     padding: 2px;
 }
 
 .label__text {
     font-size: 0.9rem;
-    cursor: pointer;
     display: flex;
     align-items: center;
     width: inherit;
@@ -90,11 +92,6 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    cursor: pointer;
-
-    & > label {
-        cursor: pointer;
-    }
 }
 
 @keyframes icon {

--- a/src/common-ui/components/Checkbox.tsx
+++ b/src/common-ui/components/Checkbox.tsx
@@ -20,13 +20,23 @@ export interface Props {
 }
 
 class Checkbox extends React.PureComponent<Props> {
+    private get labelClass() {
+        return cx(styles.label, this.props.labelClass, {
+            [styles.disabledLabel]: !!this.props.isDisabled,
+        })
+    }
+
+    private get iconClass() {
+        return cx(styles.icon, {
+            [styles.checkedIcon]: !!this.props.isChecked,
+            [styles.disabledIcon]: !!this.props.isDisabled,
+        })
+    }
+
     render() {
         return (
             <div className={cx(styles.container, this.props.containerClass)}>
-                <label
-                    className={cx(styles.label, this.props.labelClass)}
-                    htmlFor={this.props.id}
-                >
+                <label className={this.labelClass} htmlFor={this.props.id}>
                     <input
                         className={cx(
                             styles.label__checkbox,
@@ -43,12 +53,7 @@ class Checkbox extends React.PureComponent<Props> {
                         className={cx(styles.label__text, this.props.textClass)}
                     >
                         <span className={styles.label__check}>
-                            <span
-                                className={cx(styles.icon, {
-                                    [styles.checkedIcon]:
-                                        this.props.isChecked === true,
-                                })}
-                            />
+                            <span className={this.iconClass} />
                         </span>
                         <span className={styles.childrenBox}>
                             {this.props.children}

--- a/src/options/settings/components/keyboard-shortcuts-container.tsx
+++ b/src/options/settings/components/keyboard-shortcuts-container.tsx
@@ -100,6 +100,7 @@ class KeyboardShortcutsContainer extends React.PureComponent<Props, State> {
                             value={this.state[name].shortcut}
                             onKeyDown={this.recordBinding}
                             onChange={e => e.preventDefault()}
+                            disabled={!this.state.shortcutsEnabled}
                             name={name}
                         />{' '}
                     </Checkbox>

--- a/src/options/settings/keyboard-shortcuts.ts
+++ b/src/options/settings/keyboard-shortcuts.ts
@@ -8,7 +8,6 @@ export interface ShortcutElData {
 }
 
 export const shortcuts: ShortcutElData[] = [
-    { id: 'link-shortcut', name: 'link', children: 'Create links' },
     {
         id: 'highlight-shortcut',
         name: 'createHighlight',


### PR DESCRIPTION
- previously checkboxes had the same styles when not disabled and the assoc. key shortcut recording input didn't get disabled
- now new styles assigned to the custom rendered checkbox when the underlying input is disabled + key shortcut recording input is disabled when corresponding checkbox is