### PR TITLE
Removed `offline_enabled` from manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,6 @@
     "name": "WorldBrain's Memex",
     "short_name": "Memex",
     "version": "0.3.3",
-    "offline_enabled": true,
     "description": "Search, annotate and organize what you've read online.",
     "background": {
         "scripts": ["lib/browser-polyfill.js", "background.js"]


### PR DESCRIPTION
It defaults to the current value `true` on Chromium anyway, and it isn't supported by all web browsers, see:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/offline_enabled