### PR TITLE
Improve highlight readablity for dark mode websites

### DIFF
--- a/src/highlighting/ui/highlight-dom-range.ts
+++ b/src/highlighting/ui/highlight-dom-range.ts
@@ -219,14 +219,12 @@ function rgbToHex(rgb: number[]): number {
 
 const MIDDLE_HEX_COLOR = 0x7fffff
 const checkBGColor = (color: string) => {
-    console.log(color)
     if (!color.startsWith('#')) {
         const extractedRgb: number[] = color
             .replace(/\w+\(?(.+)\)/, '$1')
             .split(',')
             .map((n) => parseInt(n, 10))
         const parsed = rgbToHex(extractedRgb)
-        console.log(parsed < MIDDLE_HEX_COLOR)
         return parsed < MIDDLE_HEX_COLOR
     } else {
         return parseInt(color.replace('#', '0x'), 16) < MIDDLE_HEX_COLOR
@@ -248,7 +246,9 @@ const highlightNode = (node: Node, highlightClass: string) => {
     // Create a highlight
     const highlight: HTMLElement = document.createElement('memex-highlight')
     highlight.classList.add(highlightClass)
-    isDark && highlight.classList.add(styles['dark-mode'])
+    if (isDark) {
+        highlight.classList.add(styles['dark-mode'])
+    }
 
     // Wrap it around the text node
     node.parentNode.replaceChild(highlight, node)

--- a/src/highlighting/ui/highlight-dom-range.ts
+++ b/src/highlighting/ui/highlight-dom-range.ts
@@ -204,12 +204,14 @@ const getFirstTextNode = (node: Node) => {
     return walker.firstChild()
 }
 
-function decimalToHex(num: number) {
+// Converts a decimal number to a hexidecimal number
+const decimalToHex = (num: number): string => {
     const hex = num.toString(16)
     return hex.length === 1 ? '0' + hex : hex
 }
 
-function rgbToHex(rgb: number[]): number {
+// Converts a rgb number array to a hexidecimal number (e.g. [255,255,255] -> 16777215)
+const rgbToHex = (rgb: number[]): number => {
     const [r, g, b] = rgb
     return parseInt(
         '0x' + decimalToHex(r) + decimalToHex(g) + decimalToHex(b),
@@ -217,7 +219,10 @@ function rgbToHex(rgb: number[]): number {
     )
 }
 
+// Very rudimentary, created by dividing the hexidecimal representation for white (0xFFFFFF) in half
 const MIDDLE_HEX_COLOR = 0x7fffff
+
+// Takes a color string and deterimes whether or not it is "dark" by comparing it to the MIDDLE_HEX_COLOR
 const checkBGColor = (color: string) => {
     if (!color.startsWith('#')) {
         const extractedRgb: number[] = color
@@ -231,6 +236,7 @@ const checkBGColor = (color: string) => {
     }
 }
 
+// Calculates the background or background-color of the parent element of a highlight
 const calculateParentBG = (el: HTMLElement): boolean => {
     const computedStyles = getComputedStyle(el)
     const { background, backgroundColor } = computedStyles

--- a/src/highlighting/ui/highlight-dom-range.ts
+++ b/src/highlighting/ui/highlight-dom-range.ts
@@ -1,3 +1,4 @@
+import { calculateBG } from '../../util/computed-styles'
 const styles = require('src/highlighting/ui/styles.css')
 /**
  * Custom implementation of `dom-highlight-range`.
@@ -204,51 +205,9 @@ const getFirstTextNode = (node: Node) => {
     return walker.firstChild()
 }
 
-// Converts a decimal number to a hexidecimal number
-const decimalToHex = (num: number): string => {
-    const hex = num.toString(16)
-    return hex.length === 1 ? '0' + hex : hex
-}
-
-// Converts a rgb number array to a hexidecimal number (e.g. [255,255,255] -> 16777215)
-const rgbToHex = (rgb: number[]): number => {
-    const [r, g, b] = rgb
-    return parseInt(
-        '0x' + decimalToHex(r) + decimalToHex(g) + decimalToHex(b),
-        16,
-    )
-}
-
-// Very rudimentary, created by dividing the hexidecimal representation for white (0xFFFFFF) in half
-const MIDDLE_HEX_COLOR = 0x7fffff
-
-// Takes a color string and deterimes whether or not it is "dark" by comparing it to the MIDDLE_HEX_COLOR
-const checkBGColor = (color: string) => {
-    if (!color.startsWith('#')) {
-        const extractedRgb: number[] = color
-            .replace(/\w+\(?(.+)\)/, '$1')
-            .split(',')
-            .map((n) => parseInt(n, 10))
-        const parsed = rgbToHex(extractedRgb)
-        return parsed < MIDDLE_HEX_COLOR
-    } else {
-        return parseInt(color.replace('#', '0x'), 16) < MIDDLE_HEX_COLOR
-    }
-}
-
-// Calculates the background or background-color of the parent element of a highlight
-const calculateParentBG = (el: HTMLElement): boolean => {
-    const computedStyles = getComputedStyle(el)
-    const { background, backgroundColor } = computedStyles
-    if (background.length > 0) {
-        return checkBGColor(background)
-    }
-    return checkBGColor(backgroundColor)
-}
-
 // Replace [node] with <memex-highlight class=[highlightClass]>[node]</memex-highlight>
 const highlightNode = (node: Node, highlightClass: string) => {
-    const isDark = calculateParentBG(node.parentElement.parentElement)
+    const isDark = calculateBG(node.parentElement.parentElement)
     // Create a highlight
     const highlight: HTMLElement = document.createElement('memex-highlight')
     highlight.classList.add(highlightClass)

--- a/src/highlighting/ui/styles.css
+++ b/src/highlighting/ui/styles.css
@@ -21,3 +21,7 @@
     transition: all 0.1s;
     cursor: pointer;
 }
+
+.dark-mode {
+    color: #000;
+}

--- a/src/util/computed-styles.test.ts
+++ b/src/util/computed-styles.test.ts
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import { checkBGColor, hexToRgb } from './computed-styles'
+
+describe('checkBGColor', () => {
+    test('should return true for dark background colors', () => {
+        expect(checkBGColor('#000')).toBe(true)
+        expect(checkBGColor('#FFF')).toBe(false)
+        expect(checkBGColor('rgb(0,0,0)')).toBe(true)
+        expect(checkBGColor('rgba(0,0,0,1)')).toBe(true)
+        expect(checkBGColor('white')).toBe(false)
+        expect(checkBGColor('blanchedalmond')).toBe(false)
+        expect(checkBGColor('slate')).toBe(true)
+        expect(checkBGColor('#BADA55')).toBe(false)
+    })
+})
+
+describe('hexToRgb', () => {
+    test('should parse hex colors to rgba number arrays', () => {
+        expect(hexToRgb('#000')).toEqual([0, 0, 0])
+        expect(hexToRgb('#FFF')).toEqual([255, 255, 255])
+        expect(hexToRgb('#BADA55')).toEqual([186, 218, 85])
+    })
+})

--- a/src/util/computed-styles.ts
+++ b/src/util/computed-styles.ts
@@ -1,0 +1,209 @@
+// from https://github.com/styled-components/polished/
+export default function getLuminance(color: string): number {
+    if (color === 'transparent') {
+        return 0
+    }
+    const rgbColors = parseToRgb(color)
+    const [r, g, b] = rgbColors.map((color) => {
+        const channel = color / 255
+        return channel <= 0.03928
+            ? channel / 12.92
+            : ((channel + 0.055) / 1.055) ** 2.4
+    })
+    return parseFloat((0.2126 * r + 0.7152 * g + 0.0722 * b).toFixed(3))
+}
+
+// parses a css color string to rgb number array
+const parseToRgb = (colorString: string): number[] => {
+    if (colorString.startsWith('#')) {
+        return hexToRgb(colorString)
+    } else if (colorString.startsWith('r')) {
+        return colorString
+            .replace(/\w+\(?(.+)\)/, '$1')
+            .split(',')
+            .map((n) => parseInt(n, 10))
+    } else {
+        return hexToRgb(cssNamedColors[colorString] || '#000')
+    }
+}
+
+// Converts a hexidecimal color string to rgb number array
+export const hexToRgb = (hex: string): number[] => {
+    const hexString = hex.slice(1)
+    if (hexString.length > 3) {
+        return [
+            parseInt(`${hexString[0]}${hexString[1]}`, 16),
+            parseInt(`${hexString[2]}${hexString[3]}`, 16),
+            parseInt(`${hexString[4]}${hexString[5]}`, 16),
+        ]
+    }
+    return [
+        parseInt(`${hexString[0]}${hexString[0]}`, 16),
+        parseInt(`${hexString[1]}${hexString[1]}`, 16),
+        parseInt(`${hexString[2]}${hexString[2]}`, 16),
+    ]
+}
+
+// Takes a color string and deterimes whether or not it is "dark" by calculating its luminance
+export const checkBGColor = (color: string) => getLuminance(color) < 0.179
+
+// Calculates the background or background-color of an element
+export const calculateBG = (el: HTMLElement): boolean => {
+    const computedStyles = getComputedStyle(el)
+    const { background, backgroundColor } = computedStyles
+    if (background.length > 0) {
+        return checkBGColor(background)
+    }
+    return checkBGColor(backgroundColor)
+}
+
+const cssNamedColors = {
+    aliceblue: '#f0f8ff',
+    antiquewhite: '#faebd7',
+    aqua: '#00ffff',
+    aquamarine: '#7fffd4',
+    azure: '#f0ffff',
+    beige: '#f5f5dc',
+    bisque: '#ffe4c4',
+    black: '#000',
+    blanchedalmond: '#ffebcd',
+    blue: '#0000ff',
+    blueviolet: '#8a2be2',
+    brown: '#a52a2a',
+    burlywood: '#deb887',
+    cadetblue: '#5f9ea0',
+    chartreuse: '#7fff00',
+    chocolate: '#d2691e',
+    coral: '#ff7f50',
+    cornflowerblue: '#6495ed',
+    cornsilk: '#fff8dc',
+    crimson: '#dc143c',
+    cyan: '#00ffff',
+    darkblue: '#00008b',
+    darkcyan: '#008b8b',
+    darkgoldenrod: '#b8860b',
+    darkgray: '#a9a9a9',
+    darkgreen: '#006400',
+    darkgrey: '#a9a9a9',
+    darkkhaki: '#bdb76b',
+    darkmagenta: '#8b008b',
+    darkolivegreen: '#556b2f',
+    darkorange: '#ff8c00',
+    darkorchid: '#9932cc',
+    darkred: '#8b0000',
+    darksalmon: '#e9967a',
+    darkseagreen: '#8fbc8f',
+    darkslateblue: '#483d8b',
+    darkslategray: '#2f4f4f',
+    darkslategrey: '#2f4f4f',
+    darkturquoise: '#00ced1',
+    darkviolet: '#9400d3',
+    deeppink: '#ff1493',
+    deepskyblue: '#00bfff',
+    dimgray: '#696969',
+    dimgrey: '#696969',
+    dodgerblue: '#1e90ff',
+    firebrick: '#b22222',
+    floralwhite: '#fffaf0',
+    forestgreen: '#228b22',
+    fuchsia: '#ff00ff',
+    gainsboro: '#dcdcdc',
+    ghostwhite: '#f8f8ff',
+    gold: '#ffd700',
+    goldenrod: '#daa520',
+    gray: '#808080',
+    green: '#008000',
+    greenyellow: '#adff2f',
+    grey: '#808080',
+    honeydew: '#f0fff0',
+    hotpink: '#ff69b4',
+    indianred: '#cd5c5c',
+    indigo: '#4b0082',
+    ivory: '#fffff0',
+    khaki: '#f0e68c',
+    lavender: '#e6e6fa',
+    lavenderblush: '#fff0f5',
+    lawngreen: '#7cfc00',
+    lemonchiffon: '#fffacd',
+    lightblue: '#add8e6',
+    lightcoral: '#f08080',
+    lightcyan: '#e0ffff',
+    lightgoldenrodyellow: '#fafad2',
+    lightgray: '#d3d3d3',
+    lightgreen: '#90ee90',
+    lightgrey: '#d3d3d3',
+    lightpink: '#ffb6c1',
+    lightsalmon: '#ffa07a',
+    lightseagreen: '#20b2aa',
+    lightskyblue: '#87cefa',
+    lightslategray: '#789',
+    lightslategrey: '#789',
+    lightsteelblue: '#b0c4de',
+    lightyellow: '#ffffe0',
+    lime: '#0f0',
+    limegreen: '#32cd32',
+    linen: '#faf0e6',
+    magenta: '#f0f',
+    maroon: '#800000',
+    mediumaquamarine: '#66cdaa',
+    mediumblue: '#0000cd',
+    mediumorchid: '#ba55d3',
+    mediumpurple: '#9370db',
+    mediumseagreen: '#3cb371',
+    mediumslateblue: '#7b68ee',
+    mediumspringgreen: '#00fa9a',
+    mediumturquoise: '#48d1cc',
+    mediumvioletred: '#c71585',
+    midnightblue: '#191970',
+    mintcream: '#f5fffa',
+    mistyrose: '#ffe4e1',
+    moccasin: '#ffe4b5',
+    navajowhite: '#ffdead',
+    navy: '#000080',
+    oldlace: '#fdf5e6',
+    olive: '#808000',
+    olivedrab: '#6b8e23',
+    orange: '#ffa500',
+    orangered: '#ff4500',
+    orchid: '#da70d6',
+    palegoldenrod: '#eee8aa',
+    palegreen: '#98fb98',
+    paleturquoise: '#afeeee',
+    palevioletred: '#db7093',
+    papayawhip: '#ffefd5',
+    peachpuff: '#ffdab9',
+    peru: '#cd853f',
+    pink: '#ffc0cb',
+    plum: '#dda0dd',
+    powderblue: '#b0e0e6',
+    purple: '#800080',
+    rebeccapurple: '#639',
+    red: '#f00',
+    rosybrown: '#bc8f8f',
+    royalblue: '#4169e1',
+    saddlebrown: '#8b4513',
+    salmon: '#fa8072',
+    sandybrown: '#f4a460',
+    seagreen: '#2e8b57',
+    seashell: '#fff5ee',
+    sienna: '#a0522d',
+    silver: '#c0c0c0',
+    skyblue: '#87ceeb',
+    slateblue: '#6a5acd',
+    slategray: '#708090',
+    slategrey: '#708090',
+    snow: '#fffafa',
+    springgreen: '#00ff7f',
+    steelblue: '#4682b4',
+    tan: '#d2b48c',
+    teal: '#008080',
+    thistle: '#d8bfd8',
+    tomato: '#ff6347',
+    turquoise: '#40e0d0',
+    violet: '#ee82ee',
+    wheat: '#f5deb3',
+    white: '#fff',
+    whitesmoke: '#f5f5f5',
+    yellow: '#ff0',
+    yellowgreen: '#9acd32',
+}


### PR DESCRIPTION
Addresses #885

This makes sure that the text color of highlights can be read on websites that use dark mode. The value for determining whether or not the website qualifies as "dark" is more or less arbitrary, so suggestions on how to make that better would be great!

Before
![Screenshot_2020-04-17_19-09-17](https://user-images.githubusercontent.com/19915504/79603165-7ca84700-80f4-11ea-97a5-3eeb76fc5b7f.png)

After
![Screenshot_2020-04-17_20-42-46](https://user-images.githubusercontent.com/19915504/79603183-85008200-80f4-11ea-8c93-0402be860e0e.png)

