### PR TITLE
Emojis in page titles wont create scroll bars any more

### DIFF
--- a/src/backup-restore/ui/backup-pane/panes/overview.tsx
+++ b/src/backup-restore/ui/backup-pane/panes/overview.tsx
@@ -256,7 +256,7 @@ export class OverviewContainer extends Component<Props & UserProps> {
                                             )}
                                         >
                                             {
-                                                "You successfully upgraded but haven't enable automatic backups"
+                                                "You successfully upgraded but haven't enabled automatic backups"
                                             }
                                         </span>
                                     </div>
@@ -366,6 +366,6 @@ export class OverviewContainer extends Component<Props & UserProps> {
     }
 }
 
-export default connect(null, dispatch => ({
+export default connect(null, (dispatch) => ({
     showSubscriptionModal: () => dispatch(show({ modalId: 'Subscription' })),
 }))(withCurrentUser(OverviewContainer))

--- a/src/common-ui/components/result-item.css
+++ b/src/common-ui/components/result-item.css
@@ -231,7 +231,7 @@
     flex-direction: row;
     justify-content: flex-start;
     width: 100%;
-    height: 26px;
+    min-height: 26px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Just a tiny issue.

I only noticed this when accessing Memex from a different computer than i normally do, however they are both OSX and running latest chrome.

Issue: When a page title has an emoji in it, scroll bar would appear due to there being a fixed height set on title. 

I'm guessing for some reason this new computer has slightly different emoji rendering. Fixed by making title not a fixed height but have a min height. Height could also be removed but maybe there as a reason 26px had been set.

Also fixed a typo i noticed with the Backup help text.

<img width="597" alt="Screen Shot 2020-04-20 at 8 52 09 PM" src="https://user-images.githubusercontent.com/121013/79748763-11fc4300-8362-11ea-85ef-98ffbcbdd9f8.png">
<img width="890" alt="Screen Shot 2020-04-17 at 8 49 41 PM" src="https://user-images.githubusercontent.com/121013/79748767-13c60680-8362-11ea-8ac6-ff06835e7d86.png">
