### PR TITLE
Fix pages found via terms searches losing their bookmark status

### DIFF
--- a/src/search/background/page-url-mapper.test.data.ts
+++ b/src/search/background/page-url-mapper.test.data.ts
@@ -1,0 +1,31 @@
+export const VISIT_3 = 1569260261209
+export const VISIT_2 = VISIT_3 - 1000 * 60
+export const VISIT_1 = VISIT_2 - 1000 * 60
+
+export const BOOKMARK_1 = VISIT_1 + 1000 * 60 // Bookmark 1min after visit
+export const BOOKMARK_2 = VISIT_2 + 1000 * 60
+
+export const PAGE_1 = {
+    url: 'http://lorem.com/test2',
+    content: {
+        fullText:
+            'Lorem ipsum dolor sit amet, printing consectetur adipiscing elit.',
+        title: 'page 3 dummy',
+    },
+}
+
+export const PAGE_2 = {
+    url: 'http://sub.lorem.com/test1',
+    content: {
+        fullText: 'Lorem Ipsum is simply dummy text of the printing industry',
+        title: 'page 2',
+    },
+}
+
+export const PAGE_3 = {
+    url: 'http://sub.lorem.com/test3',
+    content: {
+        fullText: 'Lorem Ipsum is simply dummy text of the printing industry',
+        title: 'page 2',
+    },
+}

--- a/src/search/background/page-url-mapper.test.ts
+++ b/src/search/background/page-url-mapper.test.ts
@@ -1,0 +1,68 @@
+import Storex from '@worldbrain/storex'
+
+import * as DATA from './page-url-mapper.test.data'
+import { PageUrlMapperPlugin } from './page-url-mapper'
+import { setupBackgroundIntegrationTest } from 'src/tests/background-integration-tests'
+
+describe('Page URL Mapper storex plugin', () => {
+    async function setupTest() {
+        const { storageManager } = await setupBackgroundIntegrationTest()
+
+        return { storageManager }
+    }
+
+    const findMatchingPages: (
+        s: Storex,
+    ) => typeof PageUrlMapperPlugin.prototype.findMatchingPages = (man) => (
+        ...args
+    ) => man.operation(PageUrlMapperPlugin.MAP_OP_ID, ...args)
+
+    /*
+        This test came about as we noticed bookmarked pages would lose their bookmark status
+        in search results, only during terms search. Non-terms searches would set the bookmark
+        status correctly.
+        https://www.notion.so/worldbrain/using-keywords-and-bookmark-filter-does-not-show-bookmark-icon-in-result-list-047017dfde734dd1a5444340e230b125
+     */
+    it('found pages should be exactly the same for both terms and non-terms search cases when searched terms available in all results', async () => {
+        const { storageManager } = await setupTest()
+
+        // Set up 3 visited pages, 2 of which are bookmarked
+        await storageManager.collection('pages').createObject(DATA.PAGE_1)
+        await storageManager
+            .collection('visits')
+            .createObject({ url: DATA.PAGE_1.url, time: DATA.VISIT_1 })
+        await storageManager
+            .collection('bookmarks')
+            .createObject({ url: DATA.PAGE_1.url, time: DATA.BOOKMARK_1 })
+
+        await storageManager.collection('pages').createObject(DATA.PAGE_2)
+        await storageManager
+            .collection('visits')
+            .createObject({ url: DATA.PAGE_2.url, time: DATA.VISIT_2 })
+        await storageManager
+            .collection('bookmarks')
+            .createObject({ url: DATA.PAGE_2.url, time: DATA.BOOKMARK_2 })
+
+        await storageManager.collection('pages').createObject(DATA.PAGE_3)
+        await storageManager
+            .collection('visits')
+            .createObject({ url: DATA.PAGE_3.url, time: DATA.VISIT_3 })
+
+        // Simulates non-terms search
+        const nonTermsSearchResults = await findMatchingPages(storageManager)(
+            [DATA.PAGE_1.url, DATA.PAGE_2.url, DATA.PAGE_3.url],
+            { base64Img: true },
+        )
+
+        // Simulates terms search (latest times already retrieved in search process)
+        const termsSearchResults = await findMatchingPages(storageManager)(
+            [DATA.PAGE_1.url, DATA.PAGE_2.url, DATA.PAGE_3.url],
+            {
+                base64Img: true,
+                latestTimes: [DATA.BOOKMARK_1, DATA.BOOKMARK_2, DATA.VISIT_3],
+            },
+        )
+
+        expect(termsSearchResults).toEqual(nonTermsSearchResults)
+    })
+})

--- a/src/sync/background/index.test.ts
+++ b/src/sync/background/index.test.ts
@@ -1029,7 +1029,7 @@ function mobileSyncTests(suiteOptions: {
                     annotsCount: 1,
                     displayTime: expect.any(Number),
                     favIcon: undefined,
-                    hasBookmark: false,
+                    hasBookmark: true,
                     screenshot: undefined,
                     tags: ['eggs', 'spam'],
                     title: 'This is a test page',


### PR DESCRIPTION
- adds another DB query for the results of a terms search to get their bookmark status
- test added to ensure results from terms and non-terms searches are the same when all terms appear in all results