### PR TITLE
Refresh the user's subsciption if they are logged in and it expires

### DIFF
--- a/src/authentication/README.md
+++ b/src/authentication/README.md
@@ -128,6 +128,26 @@ DEV_AUTH_STATE="user_signed_in"
 or
 DEV_AUTH_STATE="user_signed_out"
 
+### Debugging
+
+in the extension bg console to find out if a user has subscriptions:
+
+```
+(await this.bgModules.auth.subscriptionService.getCurrentUserClaims()).subscriptions
+```
+
+to find out when a subscription expires for monthly:
+
+```
+(new Date((await this.bgModules.auth.subscriptionService.getCurrentUserClaims()).subscriptions['pro-monthly'].expiry * 1000)).toLocaleString()
+```
+
+for yearly:
+
+```
+(new Date((await this.bgModules.auth.subscriptionService.getCurrentUserClaims()).subscriptions['pro-yearly'].expiry * 1000)).toLocaleString()
+```
+
 ## Appendix
 
 ### Checkout flow

--- a/src/authentication/background/setup.ts
+++ b/src/authentication/background/setup.ts
@@ -14,6 +14,7 @@ export type DevAuthState =
     | 'user_signed_in'
     | 'user_subscribed'
     | 'user_subscription_expired'
+    | 'user_subscription_expires_60s'
 
 export function createAuthDependencies(options?: {
     devAuthState?: DevAuthState
@@ -71,7 +72,24 @@ export function createAuthDependencies(options?: {
         }
     }
 
+    if (devAuthState === 'user_subscription_expires_60s') {
+        const expiry = Date.now() + 1000 * 60
+        console['log'](
+            `Using dev auth state: ${devAuthState}, expiring at ${new Date(
+                expiry,
+            ).toLocaleString()}`,
+        )
+        const authService = new MemoryAuthService()
+        authService.setUser(TEST_USER)
+        return {
+            authService,
+            subscriptionService: new MemorySubscriptionsService({
+                expiry,
+            }),
+        }
+    }
+
     throw new Error(
-        `Tried to set up auth dependies with unknow DEV_AUTH_STATE: ${devAuthState}`,
+        `Tried to set up auth dependencies with unknown DEV_AUTH_STATE: ${devAuthState}`,
     )
 }

--- a/src/background-script/setup.ts
+++ b/src/background-script/setup.ts
@@ -151,7 +151,7 @@ export function createBackgroundModules(options: {
         options.auth ||
         new AuthBackground({
             ...createAuthDependencies(options.authOptions),
-            scheduleJob: jobScheduler.scheduler.scheduleJob.bind(
+            scheduleJob: jobScheduler.scheduler.scheduleJobOnce.bind(
                 jobScheduler.scheduler,
             ),
         })

--- a/src/background-script/setup.ts
+++ b/src/background-script/setup.ts
@@ -149,7 +149,12 @@ export function createBackgroundModules(options: {
 
     const auth =
         options.auth ||
-        new AuthBackground(createAuthDependencies(options.authOptions))
+        new AuthBackground({
+            ...createAuthDependencies(options.authOptions),
+            scheduleJob: jobScheduler.scheduler.scheduleJob.bind(
+                jobScheduler.scheduler,
+            ),
+        })
 
     const connectivityChecker = new ConnectivityCheckerBackground({
         xhr: new XMLHttpRequest(),

--- a/src/job-scheduler/background/index.ts
+++ b/src/job-scheduler/background/index.ts
@@ -18,7 +18,7 @@ export default class JobSchedulerBackground {
 
     async setup() {
         for (const job of this.props.jobs) {
-            await this.scheduler.scheduleJob({
+            await this.scheduler.scheduleJobHourly({
                 ...job,
                 job: job.job.bind(job, this.props),
             })

--- a/src/job-scheduler/background/job-scheduler.test.ts
+++ b/src/job-scheduler/background/job-scheduler.test.ts
@@ -8,7 +8,7 @@ class MockAlarmsApi {
     alarms: Map<string, Alarms.CreateAlarmInfoType> = new Map()
 
     onAlarm = {
-        addListener: listener => (this.listener = listener),
+        addListener: (listener) => (this.listener = listener),
     }
 
     create(name: string, info: Alarms.CreateAlarmInfoType) {
@@ -20,11 +20,11 @@ class MockStorageApi {
     values: Map<string, any> = new Map()
 
     local = {
-        set: dict => {
+        set: (dict) => {
             const [[key, value]] = Object.entries(dict)
             this.values.set(key, value)
         },
-        get: dict => {
+        get: (dict) => {
             const [[key, def]] = Object.entries(dict)
             return { [key]: this.values.get(key) || def }
         },
@@ -65,7 +65,7 @@ describe('JobScheduler tests', () => {
             [testJob.name]: JobScheduler.NOT_SET,
         })
 
-        await scheduler.scheduleJob(testJob)
+        await scheduler.scheduleJobHourly(testJob)
 
         expect(scheduler['jobs'].get(testJob.name)).toEqual(testJob)
         expect(
@@ -110,7 +110,7 @@ describe('JobScheduler tests', () => {
             [testJob.name]: JobScheduler.NOT_SET,
         })
 
-        await scheduler.scheduleJob(testJob)
+        await scheduler.scheduleJobHourly(testJob)
 
         expect(scheduler['jobs'].get(testJob.name)).toEqual(testJob)
         expect(

--- a/src/job-scheduler/background/job-scheduler.ts
+++ b/src/job-scheduler/background/job-scheduler.ts
@@ -2,7 +2,6 @@ import { Alarms, Storage } from 'webextension-polyfill-ts'
 
 import { JobDefinition, PrimedJob } from './types'
 import { SCHEDULES } from '../constants'
-import { now as _now } from 'moment'
 
 export type Period = 'month' | 'week' | 'day'
 
@@ -28,7 +27,7 @@ export class JobScheduler {
     }
 
     private static calcTimeFromNow = (minutes: number, now = Date.now()) =>
-        now + minutes * 60 * 1000
+        typeof minutes === 'undefined' ? minutes : now + minutes * 60 * 1000
 
     private setTimeoutKey = (key: string, value: number) =>
         this.props.storageAPI.local.set({
@@ -45,18 +44,31 @@ export class JobScheduler {
         return timeToRun
     }
 
+    private async initJobTimeoutStatus(
+        name: string,
+        reInit = false,
+        now: number = Date.now(),
+    ) {
+        const job = this.jobs.get(name)
+        const timeToRun = await this.getTimeoutKey(name)
+
+        if (timeToRun !== JobScheduler.ALREADY_RUN || reInit) {
+            await this.setTimeoutKey(
+                name,
+                job.when ??
+                    JobScheduler.calcTimeFromNow(job.periodInMinutes, now) ??
+                    JobScheduler.calcTimeFromNow(job.delayInMinutes, now),
+            )
+        }
+    }
+
     private async attemptPeriodicJob(
         { name, periodInMinutes, job }: JobDefinition<PrimedJob>,
         now: number,
     ) {
         const timeToRun = await this.getTimeoutKey(name)
 
-        if (timeToRun === JobScheduler.NOT_SET) {
-            await this.setTimeoutKey(
-                name,
-                JobScheduler.calcTimeFromNow(periodInMinutes, now),
-            )
-        } else if (timeToRun < now) {
+        if (timeToRun < now) {
             await job()
             await this.setTimeoutKey(
                 name,
@@ -66,27 +78,26 @@ export class JobScheduler {
     }
 
     private async attemptOneOffJob(
-        { name, delayInMinutes, job, when }: JobDefinition<PrimedJob>,
+        { name, job }: JobDefinition<PrimedJob>,
         now: number,
     ) {
         const timeToRun = await this.getTimeoutKey(name)
 
-        if (timeToRun === JobScheduler.NOT_SET) {
-            await this.setTimeoutKey(
-                name,
-                when ?? JobScheduler.calcTimeFromNow(delayInMinutes, now),
-            )
-        } else if (timeToRun === JobScheduler.ALREADY_RUN) {
+        if (timeToRun === JobScheduler.ALREADY_RUN) {
             return
-        } else if (timeToRun < now || when) {
-            const response = await job()
+        } else if (timeToRun <= now) {
+            const result = await job()
             await this.setTimeoutKey(name, JobScheduler.ALREADY_RUN)
+            return result
         }
     }
 
     private handleAlarm = async ({ name }: Alarms.Alarm, now = Date.now()) => {
         const job = this.jobs.get(name)
         if (!job) {
+            console['warn']([
+                `Tried fire an alarm but no job was found with name: ${name}`,
+            ])
             return
         }
 
@@ -94,28 +105,33 @@ export class JobScheduler {
             return this.attemptOneOffJob(job, now)
         } else if (job.periodInMinutes) {
             return this.attemptPeriodicJob(job, now)
+        } else {
+            console['warn']([
+                `Tried fire an alarm but no the type of job could not be determined for name: ${name}`,
+            ])
         }
     }
 
     // Schedule all periodic ping attempts at a random minute past the hour, every hour
-    async scheduleJob(job: JobDefinition<PrimedJob>) {
+    async scheduleJobHourly(job: JobDefinition<PrimedJob>) {
+        this.jobs.set(job.name, job)
+
+        const jobDef = {
+            // fire the initial alarm in a random minute,
+            // this will ensure all of the created alarms fire at different time of the hour
+            delayInMinutes: Math.floor(Math.random() * 60),
+            periodInMinutes: SCHEDULES.EVERY_HOUR,
+        }
+        this.props.alarmsAPI.create(job.name, jobDef)
+        await this.initJobTimeoutStatus(job.name)
+    }
+
+    async scheduleJobOnce(job: JobDefinition<PrimedJob>) {
         this.jobs.set(job.name, job)
 
         this.props.alarmsAPI.create(job.name, {
-            // If a definite 'when' is not provided
-            // fire the initial alarm in a random minute,
-            // this will ensure all of the created alarms fire at different time of the hour
-            delayInMinutes:
-                typeof job.when === 'undefined'
-                    ? Math.floor(Math.random() * 60)
-                    : undefined,
-            periodInMinutes:
-                typeof job.when === 'undefined'
-                    ? SCHEDULES.EVERY_HOUR
-                    : undefined,
-            when: job.when < _now() ? _now() + 1000 : job.when,
+            when: job.when,
         })
-
-        await this.handleAlarm({ name: job.name } as Alarms.Alarm)
+        await this.initJobTimeoutStatus(job.name, true)
     }
 }

--- a/src/job-scheduler/background/types.ts
+++ b/src/job-scheduler/background/types.ts
@@ -1,6 +1,6 @@
 import NotificationBackground from 'src/notifications/background'
 
-export type Job = (props: JobProps) => Promise<void> | void
+export type Job = (props?: JobProps) => Promise<void> | void
 export type PrimedJob = () => Promise<void> | void
 
 export interface JobDefinition<T = Job | PrimedJob> {
@@ -8,8 +8,9 @@ export interface JobDefinition<T = Job | PrimedJob> {
     name: string
     periodInMinutes?: number
     delayInMinutes?: number
+    when?: number
 }
 
 export interface JobProps {
-    notifications: NotificationBackground
+    notifications?: NotificationBackground
 }

--- a/src/tests/background-integration-tests.ts
+++ b/src/tests/background-integration-tests.ts
@@ -28,6 +28,7 @@ import { FetchPageProcessor } from 'src/page-analysis/background/types'
 import { FakeAnalytics } from 'src/analytics/mock'
 import AnalyticsManager from 'src/analytics/analytics'
 import { setStorageMiddleware } from 'src/storage/middleware'
+import { JobDefinition } from 'src/job-scheduler/background/types'
 
 export async function setupBackgroundIntegrationTest(options?: {
     customMiddleware?: StorageMiddleware[]
@@ -55,6 +56,13 @@ export async function setupBackgroundIntegrationTest(options?: {
     const auth: AuthBackground = new AuthBackground({
         authService,
         subscriptionService,
+        scheduleJob: (job: JobDefinition) => {
+            console['info'](
+                'Running job immediately while in testing, job:',
+                job,
+            )
+            console['info'](`Ran job ${job.name} returned:`, job.job())
+        },
     })
     const analyticsManager = new AnalyticsManager({
         backend: new FakeAnalytics(),


### PR DESCRIPTION
This PR registeres an alarm with the extension alarm API via our job scheduler, that runs on the user's subscription expiry date if they are logged in, so that any changes (renewal or not) are correctly picked up and updated to the user object. The alarm is registered on a change of the user object itself, so e.g. on logins or purchases.

Also refactored our JobScheduler slightly to extract the init of jobs and the handling of jobs apart to better reason about these different types of job (fire one in the future, fire repeatedly, etc.)