### PR TITLE
Fix excessive visits reading

### DIFF
--- a/src/background-script/setup.ts
+++ b/src/background-script/setup.ts
@@ -112,6 +112,7 @@ export function createBackgroundModules(options: {
         searchIndex,
         browserAPIs: options.browserAPIs,
         tabManager,
+        pageStorage: pages.storage,
     })
 
     const search = new SearchBackground({

--- a/src/page-indexing/background/storage.ts
+++ b/src/page-indexing/background/storage.ts
@@ -53,6 +53,13 @@ export default class PageStorage extends StorageModule {
                 operation: 'createObject',
                 collection: 'visits',
             },
+            countVisits: {
+                operation: 'countObjects',
+                collection: 'visits',
+                args: {
+                    url: '$url:string',
+                },
+            },
             findVisitsByUrl: {
                 operation: 'findObjects',
                 collection: 'visits',
@@ -186,10 +193,10 @@ export default class PageStorage extends StorageModule {
 
     async pageHasVisits(url: string): Promise<boolean> {
         const normalizedUrl = normalizeUrl(url, {})
-        const visits = await this.operation('findVisitsByUrl', {
+        const visitCount = await this.operation('countVisits', {
             url: normalizedUrl,
         })
-        return !!visits.length
+        return visitCount > 0
     }
 
     async addPageVisit(url: string, time: number) {
@@ -248,10 +255,10 @@ export default class PageStorage extends StorageModule {
 
     async deletePageIfOrphaned(url: string) {
         const normalizedUrl = normalizeUrl(url, {})
-        if (
-            (await this.operation('findVisitsByUrl', { url: normalizeUrl }))
-                .length
-        ) {
+        const visitCount = await this.operation('countVisits', {
+            url: normalizeUrl,
+        })
+        if (visitCount > 0) {
             return
         }
         if (

--- a/src/page-indexing/background/storage.ts
+++ b/src/page-indexing/background/storage.ts
@@ -60,6 +60,14 @@ export default class PageStorage extends StorageModule {
                     url: '$url:string',
                 },
             },
+            findLatestVisitByUrl: {
+                operation: 'findObjects',
+                collection: 'visits',
+                args: [
+                    { url: '$url:string' },
+                    { sort: [['time', 'desc']], limit: 1 },
+                ],
+            },
             findVisitsByUrl: {
                 operation: 'findObjects',
                 collection: 'visits',
@@ -270,6 +278,16 @@ export default class PageStorage extends StorageModule {
         await this.operation('deletePage', {
             url: normalizedUrl,
         })
+    }
+
+    async getLatestVisit(
+        url: string,
+    ): Promise<{ url: string; time: number } | null> {
+        const normalizedUrl = normalizeUrl(url, {})
+        const result = await this.operation('findLatestVisitByUrl', {
+            url: normalizedUrl,
+        })
+        return result.length ? result[0] : null
     }
 
     async _maybeDecodeBlob(

--- a/src/page-indexing/background/storage.ts
+++ b/src/page-indexing/background/storage.ts
@@ -167,18 +167,9 @@ export default class PageStorage extends StorageModule {
             time: number
         }
         const normalizedUrl = normalizeUrl(url, {})
-        const existingVisits: Visit[] = await this.operation(
-            'findVisitsByUrl',
-            { url: normalizedUrl },
-        )
-        const existingVisitTimes = new Set(
-            existingVisits.map(visit => visit.time),
-        )
         const newVisits: Visit[] = []
         for (const visitTime of visitTimes) {
-            if (!existingVisitTimes.has(visitTime)) {
-                newVisits.push({ url: normalizedUrl, time: visitTime })
-            }
+            newVisits.push({ url: normalizedUrl, time: visitTime })
         }
         for (const visit of newVisits) {
             await this.operation('createVisit', visit)

--- a/src/storage/middleware.ts
+++ b/src/storage/middleware.ts
@@ -22,14 +22,17 @@ export async function setStorageMiddleware(
     storageManager.setMiddleware(
         modifyMiddleware([
             {
-                process: (context) => {
-                    const result = context.next.process({
+                process: async (context) => {
+                    const result = await context.next.process({
                         operation: context.operation,
                     })
+                    console.groupCollapsed('operation', context.operation[0])
                     console.log({
                         operation: context.operation,
                         result,
                     })
+                    console.trace()
+                    console.groupEnd()
                     return result
                 },
             },

--- a/src/storage/middleware.ts
+++ b/src/storage/middleware.ts
@@ -21,21 +21,21 @@ export async function setStorageMiddleware(
     const syncedCollections = new Set(SYNCED_COLLECTIONS)
     storageManager.setMiddleware(
         modifyMiddleware([
-            {
-                process: async (context) => {
-                    const result = await context.next.process({
-                        operation: context.operation,
-                    })
-                    console.groupCollapsed('operation', context.operation[0])
-                    console.log({
-                        operation: context.operation,
-                        result,
-                    })
-                    console.trace()
-                    console.groupEnd()
-                    return result
-                },
-            },
+            // {
+            //     process: async (context) => {
+            //         const result = await context.next.process({
+            //             operation: context.operation,
+            //         })
+            //         console.groupCollapsed('operation', context.operation[0])
+            //         console.log({
+            //             operation: context.operation,
+            //             result,
+            //         })
+            //         console.trace()
+            //         console.groupEnd()
+            //         return result
+            //     },
+            // },
             new ChangeWatchMiddleware({
                 storageManager,
                 shouldWatchCollection: (collection) =>

--- a/src/storage/middleware.ts
+++ b/src/storage/middleware.ts
@@ -16,16 +16,28 @@ export async function setStorageMiddleware(
     },
 ) {
     const modifyMiddleware =
-        options.modifyMiddleware ?? (middleware => middleware)
+        options.modifyMiddleware ?? ((middleware) => middleware)
 
     const syncedCollections = new Set(SYNCED_COLLECTIONS)
     storageManager.setMiddleware(
         modifyMiddleware([
+            {
+                process: (context) => {
+                    const result = context.next.process({
+                        operation: context.operation,
+                    })
+                    console.log({
+                        operation: context.operation,
+                        result,
+                    })
+                    return result
+                },
+            },
             new ChangeWatchMiddleware({
                 storageManager,
-                shouldWatchCollection: collection =>
+                shouldWatchCollection: (collection) =>
                     syncedCollections.has(collection),
-                postprocessOperation: async event => {
+                postprocessOperation: async (event) => {
                     await options.storexHub.handlePostStorageChange(event)
                 },
             }),


### PR DESCRIPTION
On every page visit, all visit object were read from the database, only to check if the last visit was more than X ago. By removing use of the Page model, these and some other queries are replaced by simpler, more direct and less expensive alternatives.