### PR TITLE
Ribbon and sidebar should eagerly load CSS

### DIFF
--- a/src/content-scripts/content_script/ribbon.ts
+++ b/src/content-scripts/content_script/ribbon.ts
@@ -8,6 +8,15 @@ import { setSidebarState, getSidebarState } from 'src/sidebar-overlay/utils'
 
 export const main: RibbonScriptMain = async (options) => {
     const cssFile = browser.extension.getURL(`/content_script_ribbon.css`)
+    let mount: ReturnType<typeof createInPageUI> | null = null
+    const createMount = () => {
+        if (!mount) {
+            mount = createInPageUI('ribbon', cssFile, [
+                IGNORE_CLICK_OUTSIDE_CLASS,
+            ])
+        }
+    }
+    createMount()
 
     options.inPageUI.events.on('componentShouldSetUp', ({ component }) => {
         if (component === 'ribbon') {
@@ -20,9 +29,8 @@ export const main: RibbonScriptMain = async (options) => {
         }
     })
 
-    let mount: ReturnType<typeof createInPageUI> | null = null
     const setUp = () => {
-        mount = createInPageUI('ribbon', cssFile, [IGNORE_CLICK_OUTSIDE_CLASS])
+        createMount()
         setupRibbonUI(mount.rootElement, {
             containerDependencies: {
                 ...options,

--- a/src/content-scripts/content_script/sidebar.ts
+++ b/src/content-scripts/content_script/sidebar.ts
@@ -7,6 +7,15 @@ import { setupSidebarUI, destroySidebarUI } from 'src/in-page-ui/sidebar/react'
 
 export const main: SidebarScriptMain = async (dependencies) => {
     const cssFile = browser.extension.getURL(`/content_script_sidebar.css`)
+    let mount: ReturnType<typeof createInPageUI> | null = null
+    const createMount = () => {
+        if (!mount) {
+            mount = createInPageUI('sidebar', cssFile, [
+                IGNORE_CLICK_OUTSIDE_CLASS,
+            ])
+        }
+    }
+    createMount()
 
     dependencies.inPageUI.events.on('componentShouldSetUp', ({ component }) => {
         if (component === 'sidebar') {
@@ -22,9 +31,8 @@ export const main: SidebarScriptMain = async (dependencies) => {
         },
     )
 
-    let mount: ReturnType<typeof createInPageUI> | null = null
     const setUp = () => {
-        mount = createInPageUI('sidebar', cssFile, [IGNORE_CLICK_OUTSIDE_CLASS])
+        createMount()
         setupSidebarUI(mount.rootElement, dependencies, {
             env: 'inpage',
         })


### PR DESCRIPTION
In this pull request I set up the shadow DOM and CSS as soon as the ribbon/sidebar loads. In develop, I still see a lag for the ribbon, but not the sidebar. The lag for the ribbon is only a slight delay in loading the icons, but the ribbon itself is instantly in place.