### PR TITLE
Allow remote apps to add page to lists while indexing a page

### DIFF
--- a/src/custom-lists/background/storage.ts
+++ b/src/custom-lists/background/storage.ts
@@ -211,6 +211,11 @@ export default class CustomListStorage extends StorageModule {
         return this.operation('findListEntriesByListId', { listId })
     }
 
+    async fetchListIdsByUrl(url: string): Promise<number[]> {
+        const entries = await this.operation('findListEntriesByUrl', { url })
+        return entries.map((entry) => entry.listId)
+    }
+
     async fetchListPagesByUrl({ url }: { url: string }) {
         const pages = await this.operation('findListEntriesByUrl', { url })
 

--- a/src/storex-hub/background/types.ts
+++ b/src/storex-hub/background/types.ts
@@ -3,4 +3,5 @@ export interface IndexPageArgs {
     visitTime?: number
     bookmark?: true | { creationTime: number }
     tags?: string[]
+    lists?: number[]
 }


### PR DESCRIPTION
As described by the title. Extra arg added to `indexPage` is `lists?: number[]`. CLI example:
```
yarn cli calls:execute io.worldbrain.memex indexPage '{"url": "https://en.wikipedia.org/wiki/Genome", "bookmark": true, "tags": ["tag-one", "tag-two"], "lists": [1591267315220]}'
```

Tested and works  :)