### PR TITLE
Feature/misc fixes 2020 06 11

### DIFF
--- a/src/background-script/index.ts
+++ b/src/background-script/index.ts
@@ -120,6 +120,7 @@ class BackgroundScript {
 
             await migration({
                 db: this.storageManager.backend['dexieInstance'],
+                localStorage: this.storageAPI.local,
                 normalizeUrl: this.urlNormalizer,
             })
             await this.storageAPI.local.set({ [storageKey]: true })

--- a/src/background-script/quick-and-dirty-migrations.ts
+++ b/src/background-script/quick-and-dirty-migrations.ts
@@ -1,10 +1,12 @@
 import Dexie from 'dexie'
+import { Storage } from 'webextension-polyfill-ts'
 import { URLNormalizer } from '@worldbrain/memex-url-utils'
 import { MOBILE_LIST_NAME } from '@worldbrain/memex-storage/lib/mobile-app/features/meta-picker/constants'
 
 export interface MigrationProps {
     db: Dexie
     normalizeUrl: URLNormalizer
+    localStorage: Storage.LocalStorageArea
 }
 
 export interface Migrations {
@@ -12,6 +14,15 @@ export interface Migrations {
 }
 
 export const migrations: Migrations = {
+    'reseed-collections-suggestion-cache': async ({ localStorage, db }) => {
+        const cacheStorageKey = 'custom-lists_suggestions'
+        await localStorage.remove(cacheStorageKey)
+
+        const listEntries = await db.table('customLists').limit(10).toArray()
+        const newCache: string[] = listEntries.map((entry) => entry.name)
+
+        await localStorage.set({ [cacheStorageKey]: newCache })
+    },
     /**
      * If pageUrl is undefined, then re-derive it from url field.
      */
@@ -19,8 +30,8 @@ export const migrations: Migrations = {
         await db
             .table('annotations')
             .toCollection()
-            .filter(annot => annot.pageUrl === undefined)
-            .modify(annot => {
+            .filter((annot) => annot.pageUrl === undefined)
+            .modify((annot) => {
                 annot.pageUrl = normalizeUrl(annot.url)
             })
     },
@@ -32,12 +43,12 @@ export const migrations: Migrations = {
             .table('annotations')
             .toCollection()
             .filter(
-                annot =>
+                (annot) =>
                     annot.lastEdited == null ||
                     (Object.keys(annot.lastEdited).length === 0 &&
                         annot.lastEdited.constructor === Object),
             )
-            .modify(annot => {
+            .modify((annot) => {
                 annot.lastEdited = annot.createdWhen
             })
     },
@@ -91,25 +102,9 @@ export const migrations: Migrations = {
      * associate meta data with pages) was empty.
      */
     'remove-empty-url': async ({ db }) => {
-        await db
-            .table('tags')
-            .where('url')
-            .equals('')
-            .delete()
-        await db
-            .table('visits')
-            .where('url')
-            .equals('')
-            .delete()
-        await db
-            .table('annotations')
-            .where('pageUrl')
-            .equals('')
-            .delete()
-        await db
-            .table('pageListEntries')
-            .where('pageUrl')
-            .equals('')
-            .delete()
+        await db.table('tags').where('url').equals('').delete()
+        await db.table('visits').where('url').equals('').delete()
+        await db.table('annotations').where('pageUrl').equals('').delete()
+        await db.table('pageListEntries').where('pageUrl').equals('').delete()
     },
 }

--- a/src/common-ui/GenericPicker/logic.ts
+++ b/src/common-ui/GenericPicker/logic.ts
@@ -1,7 +1,8 @@
 import { UILogic, UIEvent } from 'ui-logic-core'
 import debounce from 'lodash/debounce'
+import { VALID_TAG_PATTERN } from '@worldbrain/memex-common/lib/storage/constants'
+
 import { KeyEvent, DisplayEntry, PickerUpdateHandler } from './types'
-import { VALID_TAG_PATTERN } from 'src/overview/search-bar/constants'
 
 export const INITIAL_STATE: GenericPickerState = {
     query: '',

--- a/src/common-ui/GenericPicker/logic.ts
+++ b/src/common-ui/GenericPicker/logic.ts
@@ -1,6 +1,7 @@
 import { UILogic, UIEvent } from 'ui-logic-core'
 import debounce from 'lodash/debounce'
 import { KeyEvent, DisplayEntry, PickerUpdateHandler } from './types'
+import { VALID_TAG_PATTERN } from 'src/overview/search-bar/constants'
 
 export const INITIAL_STATE: GenericPickerState = {
     query: '',
@@ -399,6 +400,10 @@ export default abstract class GenericPickerLogic extends UILogic<
         if (entry === '') {
             throw Error(
                 `${this.pickerName} Validation: Can't add entry with only whitespace`,
+            )
+        } else if (!VALID_TAG_PATTERN.test(entry)) {
+            throw Error(
+                `${this.pickerName} Validation: Can't add invalid entry`,
             )
         }
 

--- a/src/common-ui/components/design-library/actions/ExternalLink.tsx
+++ b/src/common-ui/components/design-library/actions/ExternalLink.tsx
@@ -9,9 +9,10 @@ import {
 const StyledExternalLink = styled.a`
     cursor: pointer;
     display: inline-block;
+    font-size: 1em;
 `
 const StyledExternalLinkText = styled(TypographyActionText)`
-    font-size: ${fontSizeTitle}px;
+    font-size: 1em;
     text-decoration-line: underline;
     font-weight: normal;
     color: ${colorText};

--- a/src/common-ui/components/design-library/typography.tsx
+++ b/src/common-ui/components/design-library/typography.tsx
@@ -57,6 +57,7 @@ export const TypographyHeadingSmall = styled.span`
 
 export const TypographyLink = styled.span`
     text-decoration: none;
+    font-size: 1em;
     margin: 5px;
     color: ${colorPrimary};
     cursor: pointer;
@@ -138,6 +139,7 @@ export const TypographyActionText = styled.span`
     font-family: Poppins;
     font-style: normal;
     font-weight: 600;
+    font-size: 1em;
 `
 
 export const TypographyBody = styled.span`

--- a/src/custom-lists/background/index.test.ts
+++ b/src/custom-lists/background/index.test.ts
@@ -232,7 +232,8 @@ export const INTEGRATION_TESTS = backgroundIntegrationTestSuite(
                             execute: async ({ setup }) =>
                                 customLists(setup).updateList({
                                     id: listId,
-                                    name: TEST_LIST_2,
+                                    oldName: TEST_LIST_1,
+                                    newName: TEST_LIST_2,
                                 }),
                             expectedStorageChanges: {
                                 customLists: (): StorageCollectionDiff => ({

--- a/src/custom-lists/background/index.ts
+++ b/src/custom-lists/background/index.ts
@@ -168,6 +168,7 @@ export default class CustomListBackground {
     async _updateListSuggestionsCache(args: {
         added?: string
         removed?: string
+        updated?: [string, string]
     }) {
         return updateSuggestionsCache({
             ...args,
@@ -196,10 +197,20 @@ export default class CustomListBackground {
         return inserted
     }
 
-    async updateList({ id, name }: { id: number; name: string }) {
+    async updateList({
+        id,
+        oldName,
+        newName,
+    }: {
+        id: number
+        oldName: string
+        newName: string
+    }) {
+        await this._updateListSuggestionsCache({ updated: [oldName, newName] })
+
         return this.storage.updateListName({
             id,
-            name,
+            name: newName,
         })
     }
 

--- a/src/custom-lists/background/storage.test.ts
+++ b/src/custom-lists/background/storage.test.ts
@@ -207,7 +207,8 @@ describe('Custom List Integrations', () => {
 
             await customLists.updateList({
                 id,
-                name: updatedName,
+                newName: updatedName,
+                oldName: '',
             })
 
             const after = await customLists.fetchListById({ id })

--- a/src/custom-lists/background/types.ts
+++ b/src/custom-lists/background/types.ts
@@ -26,7 +26,11 @@ export interface RemoteCollectionsInterface {
         url: string
         tabId?: number
     }): Promise<{ object: PageListEntry }>
-    updateListName(args: { id: number; name: string }): Promise<void>
+    updateListName(args: {
+        id: number
+        oldName: string
+        newName: string
+    }): Promise<void>
     removeList(args: { id: number }): Promise<any>
     removePageFromList(args: { id: number; url: string }): Promise<void>
     fetchAllLists(args: {

--- a/src/custom-lists/components/overview/sidebar/Index.js
+++ b/src/custom-lists/components/overview/sidebar/Index.js
@@ -49,20 +49,20 @@ class ListContainer extends Component {
         this.props.getListFromDB()
     }
 
-    setInputRef = el => (this.inputEl = el)
+    setInputRef = (el) => (this.inputEl = el)
 
-    handleSearchChange = field => event => {
+    handleSearchChange = (field) => (event) => {
         const { value } = event.target
 
-        this.setState(state => ({
+        this.setState((state) => ({
             ...state,
             [field]: value,
         }))
     }
 
-    getSearchVal = value => value.trim().replace(/\s\s+/g, ' ')
+    getSearchVal = (value) => value.trim().replace(/\s\s+/g, ' ')
 
-    handleCreateListSubmit = event => {
+    handleCreateListSubmit = (event) => {
         event.preventDefault()
         const { value } = event.target.elements['listName']
         // value = list name
@@ -73,18 +73,20 @@ class ListContainer extends Component {
     }
 
     vacateInputField = () => {
-        this.setState(state => ({
+        this.setState((state) => ({
             ...state,
             listName: null,
         }))
     }
 
-    handleUpdateList = ({ id }, index) => event => {
+    handleUpdateList = ({ id, name: oldName }, index) => (event) => {
         event.preventDefault()
         const { value } = event.target.elements['listName']
-        // value = list name
-        this.props.updateList(index, this.getSearchVal(value), id)
-        this.setState(state => ({
+        const newName = this.getSearchVal(value)
+
+        this.props.updateList([oldName, newName], id)
+
+        this.setState((state) => ({
             ...state,
             updatedListName: null,
         }))
@@ -189,7 +191,7 @@ class ListContainer extends Component {
     }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     lists: selectors.results(state),
     isDeleteConfShown: selectors.isDeleteConfShown(state),
     showCreateList: selectors.showCreateListForm(state),
@@ -211,11 +213,11 @@ const mapDispatchToProps = (dispatch, getState) => ({
         },
         dispatch,
     ),
-    handleEditBtnClick: index => event => {
+    handleEditBtnClick: (index) => (event) => {
         event.preventDefault()
         dispatch(actions.showEditBox(index))
     },
-    handleCrossBtnClick: ({ id }, index) => event => {
+    handleCrossBtnClick: ({ id }, index) => (event) => {
         event.preventDefault()
         dispatch(actions.showListDeleteModal(id, index))
     },
@@ -233,7 +235,7 @@ const mapDispatchToProps = (dispatch, getState) => ({
             dispatch(actions.addUrltoList(url, isSocialPost, index, id))
         }
     },
-    handleDeleteList: e => {
+    handleDeleteList: (e) => {
         e.preventDefault()
         dispatch(actions.deletePageList())
         dispatch(filterActs.delListFilter())

--- a/src/custom-lists/components/overview/sidebar/list-item.tsx
+++ b/src/custom-lists/components/overview/sidebar/list-item.tsx
@@ -147,7 +147,7 @@ class ListItem extends Component<Props, State> {
                             <button
                                 className={cx(styles.editButton, styles.button)}
                                 onClick={this.handleEditBtnClick}
-                                title={'Edit'}
+                                title={'Edt'}
                             />
                             <button
                                 className={cx(

--- a/src/overview/results/actions.ts
+++ b/src/overview/results/actions.ts
@@ -80,6 +80,10 @@ export const setSearchType = createAction<'page' | 'notes' | 'social'>(
 export const initSearchCount = createAction('overview/initSearchCount')
 export const incSearchCount = createAction('overview/incSearchCount')
 
+export const updateListName = createAction<[string, string]>(
+    'overview/updateListName',
+)
+
 export const toggleBookmark: (args: {
     url: string
     fullUrl: string

--- a/src/overview/results/reducer.ts
+++ b/src/overview/results/reducer.ts
@@ -302,4 +302,23 @@ reducer.on(acts.setSearchType, (state, searchType) => ({
     searchType,
 }))
 
+// Go over every result, and update their lists if they have `oldName`
+reducer.on(acts.updateListName, (state, [oldName, newName]) => ({
+    ...state,
+    results: state.results.map((res) => {
+        const index = res.lists.indexOf(oldName)
+
+        return index === -1
+            ? res
+            : {
+                  ...res,
+                  lists: [
+                      ...res.lists.slice(0, index),
+                      newName,
+                      ...res.lists.slice(index + 1),
+                  ],
+              }
+    }),
+}))
+
 export default reducer

--- a/src/overview/search-bar/actions.ts
+++ b/src/overview/search-bar/actions.ts
@@ -1,4 +1,5 @@
 import { createAction } from 'redux-act'
+import { HASH_TAG_PATTERN } from '@worldbrain/memex-common/lib/storage/constants'
 
 import { remoteFunction } from '../../util/webextensionRPC'
 import analytics from '../../analytics'
@@ -42,7 +43,7 @@ export const setQueryTagsDomains: (
         terms.forEach((term) => {
             // If '#tag' pattern in input, and not already tracked, add to filter state
             if (
-                constants.HASH_TAG_PATTERN.test(term) &&
+                HASH_TAG_PATTERN.test(term) &&
                 !filters.tags(state).includes(stripTagPattern(term))
             ) {
                 dispatch(filterActs.toggleTagFilter(stripTagPattern(term)))

--- a/src/overview/search-bar/constants.ts
+++ b/src/overview/search-bar/constants.ts
@@ -20,7 +20,7 @@ export const TERM_CLEAN_PATTERN = /^-?(site:)?-?(?=\w+)/
 /**
  * Pattern to match hashtag prefix syntax for tags.
  */
-export const HASH_TAG_PATTERN = /^-?#\w+(\-\w+)*$/
+export const HASH_TAG_PATTERN = /^-?#\w+([-\.]\w+)*$/
 
 export const DATE_PICKER_DATE_FORMAT = 'DD-MM-YYYY'
 

--- a/src/overview/search-bar/constants.ts
+++ b/src/overview/search-bar/constants.ts
@@ -19,8 +19,10 @@ export const TERM_CLEAN_PATTERN = /^-?(site:)?-?(?=\w+)/
 
 /**
  * Pattern to match hashtag prefix syntax for tags.
+ * NOTE: Please update these together if they change.
  */
 export const HASH_TAG_PATTERN = /^-?#\w+([-\.]\w+)*$/
+export const VALID_TAG_PATTERN = /^\w+([-\.]\w+)*$/
 
 export const DATE_PICKER_DATE_FORMAT = 'DD-MM-YYYY'
 

--- a/src/overview/search-bar/constants.ts
+++ b/src/overview/search-bar/constants.ts
@@ -20,7 +20,7 @@ export const TERM_CLEAN_PATTERN = /^-?(site:)?-?(?=\w+)/
 /**
  * Pattern to match hashtag prefix syntax for tags.
  */
-export const HASH_TAG_PATTERN = /^-?#\w[\w+]*$/
+export const HASH_TAG_PATTERN = /^-?#\w+(\-\w+)*$/
 
 export const DATE_PICKER_DATE_FORMAT = 'DD-MM-YYYY'
 

--- a/src/overview/search-bar/constants.ts
+++ b/src/overview/search-bar/constants.ts
@@ -17,13 +17,6 @@ export const EXCLUDE_PATTERN = /^-(site:)?(?=\w+)/
  */
 export const TERM_CLEAN_PATTERN = /^-?(site:)?-?(?=\w+)/
 
-/**
- * Pattern to match hashtag prefix syntax for tags.
- * NOTE: Please update these together if they change.
- */
-export const HASH_TAG_PATTERN = /^-?#\w+([-\.]\w+)*$/
-export const VALID_TAG_PATTERN = /^\w+([-\.]\w+)*$/
-
 export const DATE_PICKER_DATE_FORMAT = 'DD-MM-YYYY'
 
 export const PAGE_SIZE = 10

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -1,4 +1,4 @@
-import { HASH_TAG_PATTERN } from './constants'
+import { VALID_TAG_PATTERN, HASH_TAG_PATTERN } from './constants'
 
 describe('Overview search bar tests', () => {
     it('hashtag regexp should match desired patterns', () => {
@@ -21,6 +21,30 @@ describe('Overview search bar tests', () => {
 
         for (const { pattern, shouldPass } of testCases) {
             expect([pattern, HASH_TAG_PATTERN.test(pattern)]).toEqual([
+                pattern,
+                shouldPass,
+            ])
+        }
+    })
+
+    it('tag validity regexp should match desired patterns', () => {
+        interface TestCase {
+            pattern: string
+            shouldPass: boolean
+        }
+        const testCases: TestCase[] = [
+            { pattern: 'tag-tag', shouldPass: true },
+            { pattern: 'tag.tag', shouldPass: true },
+            { pattern: 'tag_tag', shouldPass: true },
+            { pattern: 'tag_tag.tag-tag', shouldPass: true },
+            { pattern: 'tag', shouldPass: true },
+            { pattern: 'tag-', shouldPass: false },
+            { pattern: 'tag.', shouldPass: false },
+            { pattern: 'tag tag', shouldPass: false },
+        ]
+
+        for (const { pattern, shouldPass } of testCases) {
+            expect([pattern, VALID_TAG_PATTERN.test(pattern)]).toEqual([
                 pattern,
                 shouldPass,
             ])

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -1,4 +1,7 @@
-import { VALID_TAG_PATTERN, HASH_TAG_PATTERN } from './constants'
+import {
+    VALID_TAG_PATTERN,
+    HASH_TAG_PATTERN,
+} from '@worldbrain/memex-common/lib/storage/constants'
 
 describe('Overview search bar tests', () => {
     it('hashtag regexp should match desired patterns', () => {

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -8,8 +8,13 @@ describe('Overview search bar tests', () => {
         }
         const testCases: TestCase[] = [
             { pattern: '#tag-tag', shouldPass: true },
+            { pattern: '#tag.tag', shouldPass: true },
+            { pattern: '#tag_tag', shouldPass: true },
+            { pattern: '#tag_tag.tag-tag', shouldPass: true },
             { pattern: '#tag', shouldPass: true },
             { pattern: '#tag-', shouldPass: false },
+            { pattern: '#tag.', shouldPass: false },
+            { pattern: 'tag tag', shouldPass: false },
             { pattern: 'tag', shouldPass: false },
             { pattern: '#', shouldPass: false },
         ]

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -1,0 +1,24 @@
+import { HASH_TAG_PATTERN } from './constants'
+
+describe('Overview search bar tests', () => {
+    it('hashtag regexp should match desired patterns', () => {
+        interface TestCase {
+            pattern: string
+            shouldPass: boolean
+        }
+        const testCases: TestCase[] = [
+            { pattern: '#tag-tag', shouldPass: true },
+            { pattern: '#tag', shouldPass: true },
+            { pattern: '#tag-', shouldPass: false },
+            { pattern: 'tag', shouldPass: false },
+            { pattern: '#', shouldPass: false },
+        ]
+
+        for (const { pattern, shouldPass } of testCases) {
+            expect([pattern, HASH_TAG_PATTERN.test(pattern)]).toEqual([
+                pattern,
+                shouldPass,
+            ])
+        }
+    })
+})

--- a/src/overview/sidebar-left/components/collections-container.tsx
+++ b/src/overview/sidebar-left/components/collections-container.tsx
@@ -3,21 +3,14 @@ import { connect } from 'react-redux'
 import CollectionsButton from './collections-button'
 import { actions as acts } from 'src/overview/sidebar-left/'
 import { selectors as filters, actions as filterActs } from 'src/search-filters'
-import { selectors as lists } from 'src/custom-lists'
-import * as selectors from '../selectors'
 
-const mapState = state => ({
-    activeCollectionName: lists.activeCollectionName(state),
+const mapState = (state) => ({
     isListFilterActive: filters.listFilterActive(state),
-    isSidebarLocked: selectors.sidebarLocked(state),
 })
 
-const mapDispatch = dispatch => ({
+const mapDispatch = (dispatch) => ({
     listBtnClick: () => dispatch(acts.openSidebar()),
     onShowBtnClick: () => dispatch(filterActs.delListFilter()),
 })
 
-export default connect(
-    mapState,
-    mapDispatch,
-)(CollectionsButton)
+export default connect(mapState, mapDispatch)(CollectionsButton)

--- a/src/search/background/pages.test.data.ts
+++ b/src/search/background/pages.test.data.ts
@@ -2,7 +2,7 @@ export const VISIT_1 = 1569987700000
 export const VISIT_2 = 1569987800000
 export const VISIT_3 = 1569989800000
 
-export const TAG_1 = 'test 1'
+export const TAG_1 = 'test-1'
 
 export const PAGE_1 = {
     url: 'lorem.com',

--- a/src/search/query-builder.js
+++ b/src/search/query-builder.js
@@ -1,3 +1,5 @@
+import { HASH_TAG_PATTERN } from '@worldbrain/memex-common/lib/storage/constants'
+
 import transformPageText from 'src/util/transform-page-text'
 import * as constants from '../overview/search-bar/constants'
 import { DEFAULT_TERM_SEPARATOR } from './util'
@@ -11,7 +13,7 @@ class QueryBuilder {
     /**
      * Pattern to match hashtags - spaces can be represented via '+'.
      */
-    static HASH_TAG_PATTERN = constants.HASH_TAG_PATTERN
+    static HASH_TAG_PATTERN = HASH_TAG_PATTERN
 
     /**
      * Matches a given excluded domain or term query term. Hyphen must be before some word/s.
@@ -29,11 +31,7 @@ class QueryBuilder {
      * @param {string} tag
      * @return {string}
      */
-    static stripTagPattern = tag =>
-        tag
-            .slice(1)
-            .split('+')
-            .join(' ')
+    static stripTagPattern = (tag) => tag.slice(1).split('+').join(' ')
 
     /**
      * Splits up an input string into terms.
@@ -43,10 +41,7 @@ class QueryBuilder {
      * @return {string[]}
      */
     static getTermsFromInput = (input, delim = DEFAULT_TERM_SEPARATOR) =>
-        input
-            .toLowerCase()
-            .trim()
-            .split(delim)
+        input.toLowerCase().trim().split(delim)
 
     skip = 0
     limit = 10
@@ -104,7 +99,7 @@ class QueryBuilder {
         return this
     }
 
-    _filterGen = filterName => (dataToAdd = []) => {
+    _filterGen = (filterName) => (dataToAdd = []) => {
         for (const data of dataToAdd) {
             this[filterName].add(data)
         }
@@ -185,13 +180,13 @@ class QueryBuilder {
 
         if (textInclude.length) {
             // Add post-processed terms to `query` Set
-            QueryBuilder.getTermsFromInput(textInclude).forEach(term =>
+            QueryBuilder.getTermsFromInput(textInclude).forEach((term) =>
                 this.query.add(term),
             )
         }
 
         if (textExclude.length) {
-            QueryBuilder.getTermsFromInput(textExclude).forEach(term =>
+            QueryBuilder.getTermsFromInput(textExclude).forEach((term) =>
                 this.queryExclude.add(term),
             )
         }

--- a/src/sidebar-overlay/sidebar/components/lists-container.js
+++ b/src/sidebar-overlay/sidebar/components/lists-container.js
@@ -51,18 +51,18 @@ class ListContainer extends Component {
         this.props.getListFromDB()
     }
 
-    setInputRef = el => (this.inputEl = el)
+    setInputRef = (el) => (this.inputEl = el)
 
-    handleSearchChange = field => event => {
+    handleSearchChange = (field) => (event) => {
         const { value } = event.target
 
-        this.setState(state => ({
+        this.setState((state) => ({
             ...state,
             [field]: value,
         }))
     }
 
-    handleSearchKeyDown = (field, listName = '') => e => {
+    handleSearchKeyDown = (field, listName = '') => (e) => {
         if (
             this.props.env === 'inpage' &&
             !(e.ctrlKey || e.metaKey) &&
@@ -71,7 +71,7 @@ class ListContainer extends Component {
             e.preventDefault()
             e.stopPropagation()
 
-            this.setState(state => ({
+            this.setState((state) => ({
                 ...state,
                 [field]:
                     (state[field] !== null ? state[field] : listName) + e.key,
@@ -79,9 +79,9 @@ class ListContainer extends Component {
         }
     }
 
-    getSearchVal = value => value.trim().replace(/\s\s+/g, ' ')
+    getSearchVal = (value) => value.trim().replace(/\s\s+/g, ' ')
 
-    handleCreateListSubmit = event => {
+    handleCreateListSubmit = (event) => {
         event.preventDefault()
         event.stopPropagation()
         const { value } = event.target.elements['listName']
@@ -93,18 +93,20 @@ class ListContainer extends Component {
     }
 
     vacateInputField = () => {
-        this.setState(state => ({
+        this.setState((state) => ({
             ...state,
             listName: null,
         }))
     }
 
-    handleUpdateList = ({ id }, index) => event => {
+    handleUpdateList = ({ id, name: oldName }, index) => (event) => {
         event.preventDefault()
         const { value } = event.target.elements['listName']
-        // value = list name
-        this.props.updateList(index, this.getSearchVal(value), id)
-        this.setState(state => ({
+        const newName = this.getSearchVal(value)
+
+        this.props.updateList([oldName, newName], id)
+
+        this.setState((state) => ({
             ...state,
             updatedListName: null,
         }))
@@ -201,7 +203,7 @@ class ListContainer extends Component {
     }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     lists: selectors.results(state),
     isDeleteConfShown: selectors.isDeleteConfShown(state),
     showCrowdFundingModal: selectors.showCrowdFundingModal(state),
@@ -222,16 +224,16 @@ const mapDispatchToProps = (dispatch, getState) => ({
         },
         dispatch,
     ),
-    handleEditBtnClick: index => event => {
+    handleEditBtnClick: (index) => (event) => {
         event.preventDefault()
         dispatch(actions.showEditBox(index))
     },
-    setShowCrowdFundingModal: value => e => {
+    setShowCrowdFundingModal: (value) => (e) => {
         e.preventDefault()
         e.stopPropagation()
         dispatch(actions.setShowCrowdFundingModal(value))
     },
-    handleCrossBtnClick: ({ id }, index) => event => {
+    handleCrossBtnClick: ({ id }, index) => (event) => {
         event.preventDefault()
         dispatch(actions.showListDeleteModal(id, index))
     },
@@ -243,7 +245,7 @@ const mapDispatchToProps = (dispatch, getState) => ({
     handleAddPageList: ({ id }, index) => (url, isSocialPost) => {
         dispatch(actions.addUrltoList(url, isSocialPost, index, id))
     },
-    handleDeleteList: e => {
+    handleDeleteList: (e) => {
         e.preventDefault()
         dispatch(actions.deletePageList())
     },

--- a/src/sync/background/index.test.ts
+++ b/src/sync/background/index.test.ts
@@ -300,7 +300,8 @@ function extensionSyncTests(suiteOptions: {
 
         await customLists(devices[1]).updateList({
             id: listId,
-            name: 'Updated List Title',
+            newName: 'Updated List Title',
+            oldName: 'My list',
         })
 
         await syncModule(devices[1]).remoteFunctions.forceIncrementalSync()
@@ -324,7 +325,8 @@ function extensionSyncTests(suiteOptions: {
 
         await customLists(devices[0]).updateList({
             id: listId,
-            name: 'Another Updated List Title',
+            newName: 'Another Updated List Title',
+            oldName: 'Updated List Title',
         })
 
         await syncModule(devices[0]).remoteFunctions.forceIncrementalSync()

--- a/src/sync/components/initial-sync/initial-sync-setup/steps/SyncDeviceScreen.tsx
+++ b/src/sync/components/initial-sync/initial-sync-setup/steps/SyncDeviceScreen.tsx
@@ -41,16 +41,17 @@ export const SyncDeviceScreen = ({
         >
             <ProgressBox>
                 <CenterText>
-                    <TypographyBodyBold>
-                        {'Initial sync is in progress... this may take a while'}
-                    </TypographyBodyBold>
-                    <TypographyBodyCenter>
-                        {'Make sure both devices stay connected'}
-                    </TypographyBodyCenter>
-
                     <div className={styles.progressBar}>
                         {!error ? (
                             <div className={styles.progressBox}>
+
+                             <TypographyBodyBold>
+                                    {'Initial sync is in progress... this may take a while'}
+                                </TypographyBodyBold>
+                                <TypographyBodyCenter>
+                                    {'Make sure both devices stay connected'}
+                             </TypographyBodyCenter>
+
                                 <WhiteSpacer20 />
                                 <CancelAction
                                     label={'Cancel'}
@@ -70,11 +71,6 @@ export const SyncDeviceScreen = ({
                         ) : (
                             <div className={styles.progressBox}>
                                 <Warning>⚠️ Something went wrong</Warning>
-                                <PrimaryAction
-                                    label={'Retry Syncing'}
-                                    onClick={handleRetry}
-                                />
-                                <WhiteSpacer30 />
                             </div>
                         )}
                     </div>

--- a/src/tags/background/storage.ts
+++ b/src/tags/background/storage.ts
@@ -7,8 +7,7 @@ import {
     COLLECTION_NAMES,
 } from '@worldbrain/memex-storage/lib/tags/constants'
 import { normalizeUrl } from '@worldbrain/memex-url-utils'
-
-import { VALID_TAG_PATTERN } from 'src/overview/search-bar/constants'
+import { VALID_TAG_PATTERN } from '@worldbrain/memex-common/lib/storage/constants'
 
 export default class TagStorage extends StorageModule {
     static TAGS_COLL = COLLECTION_NAMES.tag

--- a/src/tags/background/storage.ts
+++ b/src/tags/background/storage.ts
@@ -8,6 +8,8 @@ import {
 } from '@worldbrain/memex-storage/lib/tags/constants'
 import { normalizeUrl } from '@worldbrain/memex-url-utils'
 
+import { VALID_TAG_PATTERN } from 'src/overview/search-bar/constants'
+
 export default class TagStorage extends StorageModule {
     static TAGS_COLL = COLLECTION_NAMES.tag
 
@@ -43,6 +45,10 @@ export default class TagStorage extends StorageModule {
     }
 
     async addTag({ name, url }: { name: string; url: string }) {
+        if (!VALID_TAG_PATTERN.test(name)) {
+            throw new Error(`Attempted to create a badly shaped tag: ${name}`)
+        }
+
         url = normalizeUrl(url, {})
         return this.operation('createTag', { name, url })
     }

--- a/src/tags/ui/TagPicker/index.tsx
+++ b/src/tags/ui/TagPicker/index.tsx
@@ -23,7 +23,7 @@ import { fontSizeNormal } from 'src/common-ui/components/design-library/typograp
 import ButtonTooltip from 'src/common-ui/components/button-tooltip'
 import { TagResultItem } from './components/TagResultItem'
 import { ActiveTag } from './components/ActiveTag'
-import { VALID_TAG_PATTERN } from 'src/overview/search-bar/constants'
+import { VALID_TAG_PATTERN } from '@worldbrain/memex-common/lib/storage/constants'
 
 class TagPicker extends StatefulUIElement<
     TagPickerDependencies,

--- a/src/tags/ui/TagPicker/index.tsx
+++ b/src/tags/ui/TagPicker/index.tsx
@@ -23,6 +23,7 @@ import { fontSizeNormal } from 'src/common-ui/components/design-library/typograp
 import ButtonTooltip from 'src/common-ui/components/button-tooltip'
 import { TagResultItem } from './components/TagResultItem'
 import { ActiveTag } from './components/ActiveTag'
+import { VALID_TAG_PATTERN } from 'src/overview/search-bar/constants'
 
 class TagPicker extends StatefulUIElement<
     TagPickerDependencies,
@@ -31,6 +32,11 @@ class TagPicker extends StatefulUIElement<
 > {
     constructor(props: TagPickerDependencies) {
         super(props, new TagPickerLogic(props))
+    }
+
+    get shouldShowAddNew(): boolean {
+        const { newEntryName } = this.state
+        return newEntryName !== '' && VALID_TAG_PATTERN.test(newEntryName)
     }
 
     handleClickOutside = () => {
@@ -122,9 +128,11 @@ class TagPicker extends StatefulUIElement<
 
     renderMainContent() {
         if (this.state.loadingSuggestions) {
-            return <LoadingBox>
-                        <LoadingIndicator/>
-                    </LoadingBox>
+            return (
+                <LoadingBox>
+                    <LoadingIndicator />
+                </LoadingBox>
+            )
         }
 
         return (
@@ -146,7 +154,7 @@ class TagPicker extends StatefulUIElement<
                         />
                     }
                 />
-                {this.state.newEntryName !== '' && (
+                {this.shouldShowAddNew && (
                     <AddNewEntry
                         resultItem={
                             <TagResultItem>
@@ -183,7 +191,7 @@ class TagPicker extends StatefulUIElement<
     }
 }
 
-const LoadingBox = styled.div `
+const LoadingBox = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/tags/utils.ts
+++ b/src/tags/utils.ts
@@ -1,6 +1,7 @@
 export async function updateSuggestionsCache(args: {
     added?: string
     removed?: string
+    updated?: [string, string]
     suggestionLimit?: number
     getCache(): Promise<string[]>
     setCache(suggestions: string[]): Promise<void>
@@ -14,6 +15,15 @@ export async function updateSuggestionsCache(args: {
             suggestions = suggestions.filter(Boolean)
         }
         suggestions.unshift(args.added)
+    }
+
+    if (args.updated) {
+        const [oldName, newName] = args.updated
+        const i = suggestions.indexOf(oldName)
+
+        if (i !== -1) {
+            suggestions[i] = newName
+        }
     }
 
     if (args.removed) {


### PR DESCRIPTION
- addresses #1045 and the searching of hyphenated tags (https://www.notion.so/worldbrain/Searching-for-tags-collections-with-punctuation-characters-e-g-bd59454974bd4d778c258194779ea68e)

Discussion points @blackforestboi :

1. The issue described in #1045 was indeed related to the suggestions cache (local storage) getting out-of-sync as it was never implemented with renaming in mind. cc906fc fixes that, however any user that has renamed a collection will have an out-of-sync collections suggestion cache, possibly containing lists that do no exist in the actual DB. This needs to be addressed.

Ideas:
i. drop collection suggestion cache for all users on update
ii. "re-seed" collection suggestion cache from DB on update

Both should be fairly straightforward.

Note there's no nice constant time check to determine whether a user's collection cache is out-of-sync - you must compare the cache entries to what exist in the DB.

2. In the notion doc describing the tag issue it talks about it in terms of "punctuation characters" in general, although the only example mentioned is hyphen "-". Are there other concrete examples of characters to add support for or this suffices for now?

### TODOs:

- [x] quick-n-dirty migration for reseeding collections cache
  - [x] test with a simulated upgrade
- [x] update tag adding logic to reject tags with spaces
- [x] update tag matching pattern to include characters `_` and `.`
- [x] update tag adding logic to reject tags with punctuation other than `-._` 