### PR TITLE
Explicitly tell browser to persist storage

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -69,6 +69,7 @@ export async function main() {
         },
     })
     registerBackgroundModuleCollections(storageManager, backgroundModules)
+
     await storageManager.finishInitialization()
     await navigator?.storage?.persist?.()
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -70,6 +70,7 @@ export async function main() {
     })
     registerBackgroundModuleCollections(storageManager, backgroundModules)
     await storageManager.finishInitialization()
+    await navigator?.storage?.persist?.()
 
     await setStorageMiddleware(storageManager, {
         syncService: backgroundModules.sync,


### PR DESCRIPTION
Call `navigator.storage.persist()` on startup after setting up storage. We're unsure whether this is necessary because of permissions asked in `manifest.json`, but the hope is to get less data evictions by the browser. I've done this in Memex instead of the Dexie back-end so we can `await` for this call before setting up the rest of the extension.