### PR TITLE
Hotfix/2.2.5 - filter tags with spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": "https://github.com/WorldBrain/Memex",

--- a/src/overview/search-bar/actions.ts
+++ b/src/overview/search-bar/actions.ts
@@ -16,6 +16,7 @@ import { actions as notifActs } from '../../notifications'
 import { EVENT_NAMES } from '../../analytics/internal/constants'
 import * as Raven from 'src/util/raven'
 import { auth, featuresBeta } from 'src/util/remote-functions-background'
+import { stripTagPattern } from './utils'
 
 const processEventRPC = remoteFunction('processEvent')
 const pageSearchRPC = remoteFunction('searchPages')
@@ -28,8 +29,6 @@ export const setEndDate = createAction<number>('header/setEndDate')
 export const setStartDateText = createAction<string>('header/setStartDateText')
 export const setEndDateText = createAction<string>('header/setEndDateText')
 export const clearFilters = createAction('header/clearFilters')
-
-const stripTagPattern = (tag) => tag.slice(1).split('+').join(' ')
 
 export const setQueryTagsDomains: (
     input: string,

--- a/src/overview/search-bar/actions.ts
+++ b/src/overview/search-bar/actions.ts
@@ -16,7 +16,7 @@ import { actions as notifActs } from '../../notifications'
 import { EVENT_NAMES } from '../../analytics/internal/constants'
 import * as Raven from 'src/util/raven'
 import { auth, featuresBeta } from 'src/util/remote-functions-background'
-import { stripTagPattern } from './utils'
+import { stripTagPattern, splitInputIntoTerms } from './utils'
 
 const processEventRPC = remoteFunction('processEvent')
 const pageSearchRPC = remoteFunction('searchPages')
@@ -37,10 +37,7 @@ export const setQueryTagsDomains: (
     const state = getState()
 
     if (input[input.length - 1] === ' ' || isEnter) {
-        // Split input into terms and try to extract any tag/domain patterns to add to filters
-        const terms =
-            input.toLowerCase().match(constants.SEARCH_INPUT_SPLIT_PATTERN) ||
-            []
+        const terms = splitInputIntoTerms(input)
 
         terms.forEach((term) => {
             // If '#tag' pattern in input, and not already tracked, add to filter state

--- a/src/overview/search-bar/constants.ts
+++ b/src/overview/search-bar/constants.ts
@@ -21,4 +21,4 @@ export const DATE_PICKER_DATE_FORMAT = 'DD-MM-YYYY'
 
 export const PAGE_SIZE = 10
 
-export const SEARCH_INPUT_SPLIT_PATTERN = /-?#\"(\w+ ?)+\"|\S+/g
+export const SEARCH_INPUT_SPLIT_PATTERN = /-?#\"([-.\w]+ ?)+\"|\S+/g

--- a/src/overview/search-bar/constants.ts
+++ b/src/overview/search-bar/constants.ts
@@ -22,3 +22,9 @@ export const DATE_PICKER_DATE_FORMAT = 'DD-MM-YYYY'
 export const PAGE_SIZE = 10
 
 export const SEARCH_INPUT_SPLIT_PATTERN = /-?#\"([-.\w]+ ?)+\"|\S+/g
+
+/**
+ * Used to clean the hashtag syntax off any tag filtered via the search bar filter syntax.
+ * eg: #tag #"tag tag" -#tag
+ */
+export const TAG_CLEAN_PATTERN = /[#"]/g

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -4,7 +4,7 @@ import {
 } from '@worldbrain/memex-common/lib/storage/constants'
 
 import { SEARCH_INPUT_SPLIT_PATTERN } from './constants'
-import { stripTagPattern } from './utils'
+import { stripTagPattern, splitInputIntoTerms } from './utils'
 
 describe('Overview search bar tests', () => {
     it('hashtag regexp should match desired patterns', () => {
@@ -134,6 +134,7 @@ describe('Overview search bar tests', () => {
                 input,
                 terms,
             ])
+            expect(splitInputIntoTerms(input)).toEqual(terms)
         }
     })
 

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@worldbrain/memex-common/lib/storage/constants'
 
 import { SEARCH_INPUT_SPLIT_PATTERN } from './constants'
+import { stripTagPattern } from './utils'
 
 describe('Overview search bar tests', () => {
     it('hashtag regexp should match desired patterns', () => {
@@ -133,6 +134,32 @@ describe('Overview search bar tests', () => {
                 input,
                 terms,
             ])
+        }
+    })
+
+    it('should be able to strip hashtag patterns from tags intending to be filtered', () => {
+        interface TestCase {
+            input: string
+            output: string
+        }
+
+        const testCases: TestCase[] = [
+            { input: '#tag', output: 'tag' },
+            { input: '#tag-tag', output: 'tag-tag' },
+            { input: '#"tag tag"', output: 'tag tag' },
+            { input: '#tag_tag', output: 'tag_tag' },
+            { input: '#tag.tag', output: 'tag.tag' },
+            { input: '#tag+tag', output: 'tag tag' },
+            { input: '#"tag+tag"', output: 'tag tag' },
+            { input: '#"tag tag.tag"', output: 'tag tag.tag' },
+            { input: '#"tag tag tag tag"', output: 'tag tag tag tag' },
+        ]
+
+        for (const { input, output } of testCases) {
+            expect(stripTagPattern(input)).toEqual(output)
+
+            // Also test their inverse negated hashtag syntax
+            expect(stripTagPattern('-' + input)).toEqual(output)
         }
     })
 })

--- a/src/overview/search-bar/index.test.ts
+++ b/src/overview/search-bar/index.test.ts
@@ -17,11 +17,14 @@ describe('Overview search bar tests', () => {
             { pattern: '#tag_tag', shouldPass: true },
             { pattern: '#tag_tag.tag-tag', shouldPass: true },
             { pattern: '#tag', shouldPass: true },
-            //{ pattern: '#"tag tag"', shouldPass: true },
-            //{ pattern: '#"tag tag tag"', shouldPass: true },
+            { pattern: '#"tag tag"', shouldPass: true },
+            { pattern: '#"tag tag tag"', shouldPass: true },
+            { pattern: '#"tag tag tag tag"', shouldPass: true },
             { pattern: '#tag tag"', shouldPass: false },
             { pattern: '#tag-', shouldPass: false },
             { pattern: '#tag.', shouldPass: false },
+            { pattern: '#tag"', shouldPass: false },
+            { pattern: '#"tag', shouldPass: false },
             { pattern: 'tag', shouldPass: false },
             { pattern: '#', shouldPass: false },
         ]
@@ -31,6 +34,15 @@ describe('Overview search bar tests', () => {
                 pattern,
                 shouldPass,
             ])
+
+            // For the valid patterns, also test their inverse negated hashtag syntax
+            if (shouldPass) {
+                const negatedPattern = `-${pattern}`
+                expect([
+                    negatedPattern,
+                    HASH_TAG_PATTERN.test(negatedPattern),
+                ]).toEqual([negatedPattern, shouldPass])
+            }
         }
     })
 
@@ -46,6 +58,7 @@ describe('Overview search bar tests', () => {
             { pattern: 'tag_tag.tag-tag', shouldPass: true },
             { pattern: 'tag tag', shouldPass: true },
             { pattern: 'tag tag tag', shouldPass: true },
+            { pattern: 'tag tag tag tag', shouldPass: true },
             { pattern: 'tag', shouldPass: true },
             { pattern: 'tag-', shouldPass: false },
             { pattern: 'tag.', shouldPass: false },
@@ -85,6 +98,29 @@ describe('Overview search bar tests', () => {
             {
                 input: 'term -#"tag tag tag" #"tag tag tag"',
                 terms: ['term', '-#"tag tag tag"', '#"tag tag tag"'],
+            },
+            // Missing prefixed quotation mark
+            {
+                input: 'term -#tag tag tag" #"tag tag tag tag"',
+                terms: ['term', '-#tag', 'tag', 'tag"', '#"tag tag tag tag"'],
+            },
+            // Missing postfixed quotation mark
+            {
+                input: 'term -#"tag tag tag #"tag tag tag tag"',
+                terms: ['term', '-#"tag', 'tag', 'tag', '#"tag tag tag tag"'],
+            },
+            {
+                input: 'term -#"tag tag tag" #"tag tag tag tag"',
+                terms: ['term', '-#"tag tag tag"', '#"tag tag tag tag"'],
+            },
+            {
+                input: 'term #"tag-tag tag" #"tag.tag tag" #"tag tag_tag"',
+                terms: [
+                    'term',
+                    '#"tag-tag tag"',
+                    '#"tag.tag tag"',
+                    '#"tag tag_tag"',
+                ],
             },
             {
                 input: 'term -#"tag" #"tag"',

--- a/src/overview/search-bar/utils.ts
+++ b/src/overview/search-bar/utils.ts
@@ -1,0 +1,13 @@
+import { TAG_CLEAN_PATTERN } from './constants'
+
+export const stripTagPattern = (tag: string) => {
+    if (!tag.length) {
+        return tag
+    }
+
+    if (tag[0] === '-') {
+        tag = tag.slice(1)
+    }
+
+    return tag.replace(TAG_CLEAN_PATTERN, '').split('+').join(' ')
+}

--- a/src/overview/search-bar/utils.ts
+++ b/src/overview/search-bar/utils.ts
@@ -1,6 +1,6 @@
-import { TAG_CLEAN_PATTERN } from './constants'
+import { SEARCH_INPUT_SPLIT_PATTERN, TAG_CLEAN_PATTERN } from './constants'
 
-export const stripTagPattern = (tag: string) => {
+export const stripTagPattern = (tag: string): string => {
     if (!tag.length) {
         return tag
     }
@@ -11,3 +11,6 @@ export const stripTagPattern = (tag: string) => {
 
     return tag.replace(TAG_CLEAN_PATTERN, '').split('+').join(' ')
 }
+
+export const splitInputIntoTerms = (input: string): string[] =>
+    input.toLowerCase().match(SEARCH_INPUT_SPLIT_PATTERN) || []

--- a/src/search/query-builder.js
+++ b/src/search/query-builder.js
@@ -2,6 +2,7 @@ import { HASH_TAG_PATTERN } from '@worldbrain/memex-common/lib/storage/constants
 
 import transformPageText from 'src/util/transform-page-text'
 import * as constants from '../overview/search-bar/constants'
+import { splitInputIntoTerms } from '../overview/search-bar/utils'
 import { DEFAULT_TERM_SEPARATOR } from './util'
 
 class QueryBuilder {
@@ -153,7 +154,7 @@ class QueryBuilder {
         }
 
         // STAGE 1: Filter out tags/domains
-        const terms = QueryBuilder.getTermsFromInput(input, /\s+/)
+        const terms = splitInputIntoTerms(input)
         const { include, exclude } = this._extractTermsPatterns(terms)
 
         // Short-circuit if all terms filtered out as tags/domains


### PR DESCRIPTION
This hotfix finishes the unfinished tasks from last hotfix #1071, adding support for tags with spaces in search bar filter hashtag syntax.

This is ready for testing 