### PR TITLE
Hotfix/2.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "core-js": "^3.6.4",
         "countly-sdk-web": "^19.8.0",
         "dataurl-to-blob": "^0.0.1",
-        "dexie": "3.0.0-beta.1",
+        "dexie": "^3.0.1",
         "dexie-mongoify": "^1.3.0",
         "diff-match-patch": "^1.0.0",
         "dom-anchor-fragment": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldbrain-extension",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "homepage": "https://worldbrain.io",
     "license": "MIT",
     "repository": "https://github.com/WorldBrain/Memex",

--- a/src/background-script/quick-and-dirty-migrations.ts
+++ b/src/background-script/quick-and-dirty-migrations.ts
@@ -15,6 +15,20 @@ export interface Migrations {
 
 export const migrations: Migrations = {
     /*
+     * We want to add indicies on two currently optional fields.
+     * Add an index on an optional field is fine, it simply results in a sparse index.
+     * Though we want to be able to query the entire dataset, hence the need for this migration.
+     */
+    'fill-out-empty-sync-log-fields': async ({ db }) => {
+        await db
+            .table('clientSyncLogEntry')
+            .toCollection()
+            .modify((entry) => {
+                entry.sharedOn = entry.sharedOn ?? 0
+                entry.needsIntegration = entry.needsIntegration ? 1 : 0
+            })
+    },
+    /*
      * There was a bug in the ext where collection renames weren't also updating
      * the cache, resulting in out-of-sync cache to DB. Therefore seed the
      * collections suggestion cache with entries from the DB.

--- a/src/background-script/setup.ts
+++ b/src/background-script/setup.ts
@@ -319,6 +319,8 @@ export async function setupBackgroundModules(
     backgroundModules: BackgroundModules,
     storageManager: StorageManager,
 ) {
+    backgroundModules.bgScript.setupWebExtAPIHandlers()
+
     setImportStateManager(
         new ImportStateManager({
             storageManager,
@@ -346,7 +348,6 @@ export async function setupBackgroundModules(
     backgroundModules.bgScript.setupRemoteFunctions()
     backgroundModules.contentScripts.setupRemoteFunctions()
     backgroundModules.inPageUI.setupRemoteFunctions()
-    backgroundModules.bgScript.setupWebExtAPIHandlers()
     backgroundModules.bgScript.setupAlarms(alarms)
     backgroundModules.pageFetchBacklog.setupBacklogProcessing()
     setupNotificationClickListener()

--- a/src/background.ts
+++ b/src/background.ts
@@ -72,13 +72,14 @@ export async function main() {
     registerBackgroundModuleCollections(storageManager, backgroundModules)
 
     await storageManager.finishInitialization()
-    await setupBackgroundModules(backgroundModules, storageManager)
-    await navigator?.storage?.persist?.()
 
     await setStorageMiddleware(storageManager, {
         syncService: backgroundModules.sync,
         storexHub: backgroundModules.storexHub,
     })
+    await setupBackgroundModules(backgroundModules, storageManager)
+
+    await navigator?.storage?.persist?.()
 
     setStorex(storageManager)
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -72,6 +72,7 @@ export async function main() {
     registerBackgroundModuleCollections(storageManager, backgroundModules)
 
     await storageManager.finishInitialization()
+    await setupBackgroundModules(backgroundModules, storageManager)
     await navigator?.storage?.persist?.()
 
     await setStorageMiddleware(storageManager, {
@@ -80,8 +81,6 @@ export async function main() {
     })
 
     setStorex(storageManager)
-
-    await setupBackgroundModules(backgroundModules, storageManager)
 
     // Gradually moving all remote function registrations here
     setupRemoteFunctionsImplementations({

--- a/src/background.ts
+++ b/src/background.ts
@@ -33,6 +33,7 @@ import pipeline from 'src/search/pipeline'
 import { setStorageMiddleware } from './storage/middleware'
 import { getFirebase } from './util/firebase-app-initialized'
 import { FeaturesBeta } from './features/background/feature-beta'
+import setupDataSeeders from 'src/util/tests/seed-data'
 
 export async function main() {
     const localStorageChangesManager = new StorageChangesManager({
@@ -109,6 +110,7 @@ export async function main() {
     window['bgModules'] = backgroundModules
     window['analytics'] = analytics
     window['tabMan'] = backgroundModules.activityLogger.tabManager
+    window['dataSeeders'] = setupDataSeeders(storageManager)
 
     window['selfTests'] = await createSelfTests({
         storage: {

--- a/src/backup-restore/ui/backup-pane/components/provider-list.jsx
+++ b/src/backup-restore/ui/backup-pane/components/provider-list.jsx
@@ -18,12 +18,11 @@ export function ProviderList({ onChange, backupPath, handleChangeBackupPath }) {
                         />
                         <div className={Styles.textBlock}>
                             <div className={Styles.providerTitle}>
-                                Any cloud provider via local hard drive
+                                To your local hard drive
                             </div>
                             <p className={settingsStyle.infoText}>
-                                Use cloud providers that have a syncing folder
-                                on your computer (e.g. Dropbox, Spideroak,
-                                GDrive){' '}
+                                Also use any cloud provider with sync folders
+                                (e.g. Dropbox, Spideroak, GDrive){' '}
                                 <a
                                     className={Styles.link}
                                     target="_blank"
@@ -77,15 +76,14 @@ export function ProviderList({ onChange, backupPath, handleChangeBackupPath }) {
                                 </span>
                             </div>
                             <p className={settingsStyle.infoText}>
-                                Make sure you are trying to backup your data to
-                                the same Google Account as the one logged into
-                                your browser profile.
+                                Use the same Google Account as the one logged into
+                                your browser profile. (creates a hidden folder)
                                 <a
                                     className={Styles.link}
                                     target="_blank"
                                     href="https://worldbrain.io/tutorials/backups"
                                 >
-                                    Learn More ▸
+                                    {' '}Learn More ▸
                                 </a>
                             </p>
                         </div>

--- a/src/backup-restore/ui/backup-pane/panes/restore-where.tsx
+++ b/src/backup-restore/ui/backup-pane/panes/restore-where.tsx
@@ -64,6 +64,9 @@ export default class RestoreWhere extends React.Component<Props> {
                     <strong>STEP 1/2: </strong>
                     FROM WHERE?
                 </div>
+                <div className={settingsStyle.subname}>
+                    <strong>Important:</strong> To restore, pick the parent folder of '/backup'
+                </div>
                 <ProviderList
                     backupPath={
                         this.state.provider === 'local'

--- a/src/backup-restore/ui/backup-pane/panes/running-process.tsx
+++ b/src/backup-restore/ui/backup-pane/panes/running-process.tsx
@@ -147,6 +147,9 @@ export default class RunningProcess extends React.Component<Props> {
 
     async handleCancel() {
         this.setState({ canceling: true })
+        await localStorage.removeItem(
+            'backup.restore.restore-running',
+        )
         await remoteFunction(this.props.functionNames.cancel)()
         this.props.onFinish()
     }
@@ -161,13 +164,17 @@ export default class RunningProcess extends React.Component<Props> {
             <div>
                 {this.props.renderHeader()}
                 <WhiteSpacer10 />
-                <div className={overviewStyles.showWarning}>
-                    <span className={overviewStyles.WarningIcon} />
-                    <span className={overviewStyles.showWarningText}>
-                        With a lot of data (> 25.000 pages) it is recommended
-                        running this over night.
-                    </span>
-                </div>
+                {localStorage.getItem(
+                        'backup.restore.restore-running',
+                        ) === 'false' &&(
+                            <div className={overviewStyles.showWarning}>
+                                <span className={overviewStyles.WarningIcon} />
+                                <span className={overviewStyles.showWarningText}>
+                                    With a lot of data (> 25.000 pages) it is recommended
+                                    running this over night.
+                                </span>
+                            </div>
+                )}
                 <WhiteSpacer30 />
                 <div className={localStyles.steps}>
                     {this.renderSteps(info)}

--- a/src/options/imports/components/EstimatesTable.jsx
+++ b/src/options/imports/components/EstimatesTable.jsx
@@ -55,9 +55,6 @@ const EstimatesTable = ({
                             <span className={localStyles.checkboxText}>
                                 Browser History
                             </span>
-                            <span className={localStyles.checkboxSubText}>
-                                from last 90 days
-                            </span>
                         </div>
                     </Checkbox>
                 </td>

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -77,6 +77,25 @@
     }
 }
 
+.resultsBox {
+    height: 500px;
+    overflow-y: scroll;
+}
+
+.resultsBoxHidden {
+    height: 0px;
+    overflow-y: hidden;
+}
+
+.loadingBox {
+    border-radius: 3px;
+    margin-bottom: 30px;
+    height: 300px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .resultsText {
     composes: darkBlue from '../../common-ui/colors.css';
     display: inline-block;

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -187,7 +187,7 @@
 .duckduckgo_above {
     margin-top: 7px;
     margin-bottom: 15px;
-    
+
     & .resultsText {
         width: 73%;
         padding-left: 11px;

--- a/src/search-injection/components/Results.css
+++ b/src/search-injection/components/Results.css
@@ -17,14 +17,24 @@
     flex-direction: column;
     border-bottom: #dedede solid 1px;
     margin-bottom: 20px;
-    padding-bottom: 10px;
     margin-right: 20px;
+    background: #fff;
+    padding: 0px 5px 20px 5px;
 }
 
 .header {
     display: flex;
     align-items: center;
-    margin-bottom: 6px;
+    height: 40px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.MEMEX_CONTAINER_SMALL {
+    padding: 0px 5px 0px 5px;
+
+    & .header {
+        border: none;
+    }
 }
 
 .resultLength {
@@ -103,6 +113,7 @@
     font-weight: 600;
     width: 71%;
     margin-right: 10px;
+    padding-left: 11px;
 }
 
 .resultsText > a {
@@ -176,18 +187,15 @@
 .duckduckgo_above {
     margin-top: 7px;
     margin-bottom: 15px;
-
-    & .linksContainer {
-        margin-top: 4px;
-        margin-bottom: 8px;
-    }
-
+    
     & .resultsText {
-        width: 76%;
+        width: 73%;
+        padding-left: 11px;
     }
 
     & .settingsButton {
-        top: 6px;
+        right: 5px;
+        top: 9px;
     }
 
     & .dropdown {
@@ -201,6 +209,7 @@
 
     & .resultsText {
         font-size: 1.05em;
+        width: 65%;
     }
 
     & .links {
@@ -208,8 +217,8 @@
     }
 
     & .settingsButton {
-        right: -4px;
-        top: 9px;
+        right: 5px;
+        top: 8px;
     }
 
     & .dropdown {

--- a/src/search-injection/components/Results.js
+++ b/src/search-injection/components/Results.js
@@ -8,12 +8,13 @@ import LoadingIndicator from 'src/common-ui/components/LoadingIndicator'
 
 const Results = props => {
     const searchEngineClass = `${props.searchEngine}_${props.position}`
-    
+
     return (
         <div
             className={classNames(
                 styles.MEMEX_CONTAINER,
                 styles[searchEngineClass],
+                styles.MEMEX_CONTAINER_SMALL: props.hideResults,
             )}
         >
             <div className={styles.header}>

--- a/src/search-injection/components/Results.js
+++ b/src/search-injection/components/Results.js
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import Dropdown from './Dropdown'
 import styles from './Results.css'
+import LoadingIndicator from 'src/common-ui/components/LoadingIndicator'
+
 
 const Results = props => {
     const searchEngineClass = `${props.searchEngine}_${props.position}`
+    
     return (
         <div
             className={classNames(
@@ -53,9 +56,11 @@ const Results = props => {
             </div>
             <div className={classNames(styles.resultsBox, {
                 [styles.isBlurred]: props.renderNotification,
+                [styles.resultsBoxHidden]: props.hideResults,
             })}>
                 {// Render only if hideResults is false
-                props.hideResults ? '' : props.renderResultItems()}
+                props.hideResults ? ('') : (props.renderResultItems().length > 0 ? (props.renderResultItems()):(<div className={styles.loadingBox}><LoadingIndicator/></div>))
+                }
             </div>
         </div>
     )

--- a/src/search-injection/components/Results.js
+++ b/src/search-injection/components/Results.js
@@ -60,7 +60,7 @@ const Results = props => {
                 [styles.resultsBoxHidden]: props.hideResults,
             })}>
                 {// Render only if hideResults is false
-                props.hideResults ? ('') : (props.renderResultItems().length > 0 ? (props.renderResultItems()):(<div className={styles.loadingBox}><LoadingIndicator/></div>))
+                props.hideResults ? ('') : (props.renderResultItems().length >= 0 ? (props.renderResultItems()):(<div className={styles.loadingBox}><LoadingIndicator/></div>))
                 }
             </div>
         </div>

--- a/src/search-injection/components/Results.js
+++ b/src/search-injection/components/Results.js
@@ -13,8 +13,8 @@ const Results = props => {
         <div
             className={classNames(
                 styles.MEMEX_CONTAINER,
-                styles[searchEngineClass],
-                styles.MEMEX_CONTAINER_SMALL: props.hideResults,
+                styles[searchEngineClass], {
+                [styles.MEMEX_CONTAINER_SMALL]: props.hideResults }
             )}
         >
             <div className={styles.header}>

--- a/src/search-injection/components/container.tsx
+++ b/src/search-injection/components/container.tsx
@@ -16,6 +16,8 @@ import ActionButton from '../../notifications/components/ActionButton'
 import OptIn from '../../notifications/components/OptIn'
 import ToggleSwitch from '../../common-ui/components/ToggleSwitch'
 import { EVENT_NAMES } from '../../analytics/internal/constants'
+import LoadingIndicator from 'src/common-ui/components/LoadingIndicator'
+
 
 class Container extends React.Component<any, any> {
     static propTypes = {

--- a/src/search-injection/constants.ts
+++ b/src/search-injection/constants.ts
@@ -2,8 +2,8 @@ import { SearchEngineName, SearchEngineInfo } from './types'
 
 // Limit for the number of search results to be fetched
 export const LIMIT = {
-    above: 4,
-    side: 15,
+    above: 20,
+    side: 20,
 }
 
 // regex - Regular Expression to match the url

--- a/src/search-injection/content_script.js
+++ b/src/search-injection/content_script.js
@@ -20,7 +20,7 @@ export async function initSearchInjection() {
     if (matched && searchInjection[matched]) {
         try {
             const query = utils.fetchQuery(url)
-            const searchRes = await requestSearch({ query, limit: 5 })
+            const searchRes = await requestSearch({ query, limit: 21 })
 
             if (searchRes.docs.length || searchRes.requiresMigration) {
                 await handleRender(searchRes, matched)

--- a/src/search-injection/dom.tsx
+++ b/src/search-injection/dom.tsx
@@ -9,6 +9,8 @@ import Container from './components/container'
 import * as utils from './utils'
 import * as constants from './constants'
 import { injectCSS } from '../util/content-injection'
+import LoadingIndicator from 'src/common-ui/components/LoadingIndicator'
+
 
 export const handleRender = async (
     { docs, totalCount, requiresMigration },
@@ -55,9 +57,10 @@ export const handleRender = async (
 
         // Render the React component on the target element
         // Passing this same function so that it can change position
+
         ReactDOM.render(
             <Container
-                results={docs.slice(0, limit)}
+                results={docs.slice(1, limit)}
                 len={totalCount}
                 rerender={renderComponent}
                 searchEngine={searchEngine}
@@ -67,20 +70,60 @@ export const handleRender = async (
         )
     }
 
+
+    const renderLoading = async () => {
+            const position = await utils.getLocalStorage(
+                constants.POSITION_KEY,
+                'side',
+            )
+
+            const searchEngineObj = constants.SEARCH_ENGINES[searchEngine]
+            if (!searchEngineObj) {
+                return false
+            }
+            const containerType = searchEngineObj.containerType
+            const containerIdentifier = searchEngineObj.container[position]
+            const container =
+                containerType === 'class'
+                    ? document.getElementsByClassName(containerIdentifier)[0]
+                    : document.getElementById(containerIdentifier)
+
+            // If re-rendering remove the already present component
+            const component = document.getElementById('memexResults')
+            if (component) {
+                component.parentNode.removeChild(component)
+            }
+
+            const target = document.createElement('div')
+            target.setAttribute('id', 'memexResults')
+            container.insertBefore(target, container.firstChild)
+
+            // Number of results to limit
+            const limit = constants.LIMIT[position]
+
+            // Render the React component on the target element
+            // Passing this same function so that it can change position
+            ReactDOM.render(<div><LoadingIndicator/></div>,target,)
+    }
+
     const cssFile = browser.extension.getURL(
         '/content_script_search_injection.css',
     )
     await injectCSS(cssFile)
 
+    // if (!(document.readyState === 'complete'  ||
+    //     document.readyState === 'interactive')) {
+    //     renderLoading()
+    // }
     // Check if the document has completed loading,
     // if it has, execute the rendering function immediately
     // else attach it to the DOMContentLoaded event listener
+    renderComponent()
     if (
-        document.readyState === 'complete' ||
-        document.readyState === 'interactive'
+        !(document.readyState === 'complete'  ||
+        document.readyState === 'interactive' ||
+        document.readyState === 'loading')
     ) {
-        renderComponent()
-    } else {
         document.addEventListener('DOMContentLoaded', renderComponent, true)
     }
 }

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -20,4 +20,5 @@ export const STORAGE_VERSIONS = {
     17: { version: new Date('2019-08-29') },
     18: { version: new Date('2019-09-13') },
     19: { version: new Date('2020-06-03') },
+    20: { version: new Date('2020-07-15') },
 }

--- a/src/storage/index.test.ts
+++ b/src/storage/index.test.ts
@@ -502,6 +502,41 @@ describe('Storage initialization', () => {
                     dexieSchemaVersion: 20,
                     storexSchemaVersion: STORAGE_VERSIONS[19].version,
                 },
+                {
+                    schema: {
+                        annotBookmarks: 'url, createdAt',
+                        annotListEntries: '[listId+url], listId, url',
+                        annotations:
+                            'url, *_body_terms, *_comment_terms, *_pageTitle_terms, createdWhen, lastEdited, pageUrl',
+                        backupChanges: 'timestamp, collection',
+                        bookmarks: 'url, time',
+                        clientSyncLogEntry:
+                            '[deviceId+createdOn], [collection+pk], createdOn, needsIntegration, sharedOn',
+                        customLists:
+                            'id, createdAt, isDeletable, isNestable, name',
+                        directLinks:
+                            'url, *_body_terms, *_comment_terms, *_pageTitle_terms, createdWhen, pageUrl',
+                        eventLog: '[time+type], time, type',
+                        favIcons: 'hostname',
+                        notifications: 'id',
+                        pageFetchBacklog: '++id, createdAt',
+                        pageListEntries: '[listId+pageUrl], listId, pageUrl',
+                        pages:
+                            'url, *terms, *titleTerms, *urlTerms, domain, hostname',
+                        socialBookmarks: '++id, createdAt, postId',
+                        socialPostListEntries: '++id, listId, postId',
+                        socialPosts:
+                            '++id, *_text_terms, createdAt, serviceId, userId',
+                        socialTags: '++id, name, postId',
+                        socialUsers: '++id, name, serviceId, username',
+                        syncDeviceInfo: 'deviceId',
+                        tags: '[name+url], name, url',
+                        templates: 'id, code, isFavourite, title',
+                        visits: '[time+url], url',
+                    },
+                    dexieSchemaVersion: 21,
+                    storexSchemaVersion: STORAGE_VERSIONS[20].version,
+                },
             ]),
         )
     })

--- a/src/sync/background/storage.ts
+++ b/src/sync/background/storage.ts
@@ -14,10 +14,19 @@ export class MemexExtClientSyncLogStorage extends ClientSyncLogStorage {
                     moduleVersion: new Date('2019-02-05'),
                     applicationVersion: STORAGE_VERSIONS[18].version,
                 },
+                {
+                    moduleVersion: new Date('2020-07-15'),
+                    applicationVersion: STORAGE_VERSIONS[20].version,
+                },
             ],
         })
-        config.collections!.clientSyncLogEntry.backup = false
-        config.collections!.clientSyncLogEntry.watch = false
+        for (const collectionDefinition of [
+            config.collections!.clientSyncLogEntry,
+            ...config.collections!.clientSyncLogEntry.history,
+        ]) {
+            collectionDefinition.backup = false
+            collectionDefinition.watch = false
+        }
         return config
     }
 }
@@ -34,8 +43,13 @@ export class MemexExtSyncInfoStorage extends SyncInfoStorage {
                 },
             ],
         })
-        config.collections!.syncDeviceInfo.backup = false
-        config.collections!.syncDeviceInfo.watch = false
+        for (const collectionDefinition of [
+            config.collections!.syncDeviceInfo,
+            ...(config.collections!.syncDeviceInfo.history ?? []),
+        ]) {
+            collectionDefinition.backup = false
+            collectionDefinition.watch = false
+        }
         return config
     }
 }

--- a/src/util/tests/seed-data.ts
+++ b/src/util/tests/seed-data.ts
@@ -1,0 +1,35 @@
+import Storex from '@worldbrain/storex'
+import { ClientSyncLogEntry } from '@worldbrain/storex-sync/lib/client-sync-log/types'
+
+export const seedClientSyncLogEntries = (db: Storex) => async ({
+    amount = 100,
+    sharedOnChance = 0.5,
+    needsIntegrationChance = 0.5,
+}: {
+    amount?: number
+    sharedOnChance?: number
+    needsIntegrationChance?: number
+}) => {
+    const time = Date.now()
+
+    const data: ClientSyncLogEntry[] = [...Array(amount)].map((a, index) => ({
+        needsIntegration: Math.random() > needsIntegrationChance,
+        sharedOn: Math.random() > sharedOnChance ? time - index : undefined,
+        collection: 'testCollection',
+        operation: 'create',
+        createdOn: time - index,
+        deviceId: 'test',
+        value: {},
+        pk: index,
+    }))
+
+    for (const entry of data) {
+        await db.collection('clientSyncLogEntry').createObject(entry)
+    }
+}
+
+const setup = (db: Storex) => ({
+    seedClientSyncLogEntries: seedClientSyncLogEntries(db),
+})
+
+export default setup

--- a/src/util/tests/seed-data.ts
+++ b/src/util/tests/seed-data.ts
@@ -1,5 +1,4 @@
 import Storex from '@worldbrain/storex'
-import { ClientSyncLogEntry } from '@worldbrain/storex-sync/lib/client-sync-log/types'
 
 export const seedClientSyncLogEntries = (db: Storex) => async ({
     amount = 100,
@@ -12,7 +11,7 @@ export const seedClientSyncLogEntries = (db: Storex) => async ({
 }) => {
     const time = Date.now()
 
-    const data: ClientSyncLogEntry[] = [...Array(amount)].map((a, index) => ({
+    const data = [...Array(amount)].map((a, index) => ({
         needsIntegration: Math.random() > needsIntegrationChance,
         sharedOn: Math.random() > sharedOnChance ? time - index : undefined,
         collection: 'testCollection',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,10 +8089,10 @@ dexie-mongoify@^1.3.0:
     object-assign "^4.1.0"
     only "^0.0.2"
 
-dexie@3.0.0-beta.1:
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.0.0-beta.1.tgz#fcd75ca08c8be2c34b25b563b7617d9cf97a3c96"
-  integrity sha512-gT65LlB31mVMsGFoTQyS+A/osPQMvICzwy/kySVcabNnGYNU0RVtx8TR5tCWm6qvF76QBt/NNcwS4Iju4tRCYw==
+dexie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.0.1.tgz#faafeb94be0d5e18b25d700546a2c05725511cfc"
+  integrity sha512-/s4KzlaerQnCad/uY1ZNdFckTrbdMVhLlziYQzz62Ff9Ick1lHGomvTXNfwh4ApEZATyXRyVk5F6/y8UU84B0w==
 
 dialog-polyfill@^0.4.7:
   version "0.4.10"


### PR DESCRIPTION
This contains:
- update to `syncClientLogEntry` schemas to add indices (assoc commit in `storex-sync`: https://github.com/WorldBrain/storex-sync/commit/471d82e75f9e80cf1deca86598ea34ef7778090e )
- quick-n-dirty migration to update newly indexed fields to ensure they always have a value
- moving the `runtime.onInstall` event set-up to happen earlier in the BG script setup (runs our on-install + update logic, like quick-n-dirty migrations). This one was really interesting. It indeed did not run all the time! I seem to have found the, recently introduced, spot that is responsible for stopping it running. More info in 8aca7da 
- update to Dexie. the intention is to see if this stops a bunch of `createObjectStore` errors many of our users are stuck with whenever interacting with their DBs

TODOs:

- [ ] test manual upgrades from a current `master` builds with **sync data** (@blackforestboi @ShishKabab could you assist here if you have some time today? Instructions are: https://github.com/WorldBrain/Memex/blob/master/docs/Testing-Ext-Updates.md)