### PR TITLE
Update page-metadata-parser to v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "normalize-url": "^4.3.0",
         "object-path": "^0.11.4",
         "openpgp": "^4.6.2",
-        "page-metadata-parser": "git+https://github.com/Treora/page-metadata-parser.git#npm-testable",
+        "page-metadata-parser": "^1.1.4",
         "pdfjs-dist": "^1.8.492",
         "polished": "^3.5.1",
         "postcss-modules-values": "^2.0.0",

--- a/src/page-analysis/page-metadata-rules.ts
+++ b/src/page-analysis/page-metadata-rules.ts
@@ -1,4 +1,4 @@
-import { metadataRules } from 'page-metadata-parser'
+import { metadataRuleSets } from 'page-metadata-parser'
 
 /**
  * Collection of fathom rules to tell `page-metadata-parser` where to extract certain metadata from
@@ -6,12 +6,12 @@ import { metadataRules } from 'page-metadata-parser'
 
 // We only want to fallback to the opengraph URL
 const canonicalUrl = {
-    ...metadataRules.url,
+    ...metadataRuleSets.url,
     rules: [
-        ['link[rel="canonical"]', node => node.element.getAttribute('href')],
+        ['link[rel="canonical"]', (node) => node.element.getAttribute('href')],
         [
             'meta[property="og:url"]',
-            node => node.element.getAttribute('content'),
+            (node) => node.element.getAttribute('content'),
         ],
     ],
 }
@@ -19,10 +19,10 @@ const canonicalUrl = {
 // We mainly want whatever the browser-facing title is, which can change - OG tags don't need to change
 const title = {
     rules: [
-        ['title', node => node.element.text],
+        ['title', (node) => node.element.text],
         [
             'meta[property="og:title"]',
-            node => node.element.getAttribute('content'),
+            (node) => node.element.getAttribute('content'),
         ],
     ],
 }
@@ -30,6 +30,6 @@ const title = {
 export default {
     canonicalUrl,
     title,
-    keywords: metadataRules.keywords,
-    description: metadataRules.description,
+    keywords: metadataRuleSets.keywords,
+    description: metadataRuleSets.description,
 }

--- a/src/page-analysis/page-metadata-rules.ts
+++ b/src/page-analysis/page-metadata-rules.ts
@@ -7,11 +7,12 @@ import { metadataRuleSets } from 'page-metadata-parser'
 // We only want to fallback to the opengraph URL
 const canonicalUrl = {
     ...metadataRuleSets.url,
+    defaultValue: undefined,
     rules: [
-        ['link[rel="canonical"]', (node) => node.element.getAttribute('href')],
+        ['link[rel="canonical"]', (element) => element.getAttribute('href')],
         [
             'meta[property="og:url"]',
-            (node) => node.element.getAttribute('content'),
+            (element) => element.getAttribute('content'),
         ],
     ],
 }
@@ -19,10 +20,10 @@ const canonicalUrl = {
 // We mainly want whatever the browser-facing title is, which can change - OG tags don't need to change
 const title = {
     rules: [
-        ['title', (node) => node.element.text],
+        ['title', (element) => element.text],
         [
             'meta[property="og:title"]',
-            (node) => node.element.getAttribute('content'),
+            (element) => element.getAttribute('content'),
         ],
     ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9547,13 +9547,6 @@ fathom-web@^2.1.0:
     jsdom "^11.2.0"
     wu "^2.1.0"
 
-"fathom-web@git://github.com/Treora/fathom.git#npm-testable":
-  version "1.1.2"
-  resolved "git://github.com/Treora/fathom.git#913009da10176f525274d0530d974a61cb6c93f2"
-  dependencies:
-    babel-runtime "^6.22.0"
-    wu "^2.1.0"
-
 fault@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.3.tgz#4da88cf979b6b792b4e13c7ec836767725170b7e"
@@ -15084,11 +15077,10 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-"page-metadata-parser@git+https://github.com/Treora/page-metadata-parser.git#npm-testable":
-  version "0.6.0"
-  resolved "git+https://github.com/Treora/page-metadata-parser.git#07fe4ebfdee0b6b3197a41eb2b90fea8e3f07bf5"
-  dependencies:
-    fathom-web "git://github.com/Treora/fathom.git#npm-testable"
+page-metadata-parser@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/page-metadata-parser/-/page-metadata-parser-1.1.4.tgz#52cea38eb6d084d1808a10abb659ee8e9233bd4d"
+  integrity sha512-TbPNw7GddbHs4c2DyYinFvh51BVsaMfdrweeylzGlg8qeuzALGxq2NF+6jbmeKc7DnU2BZRDOuWNnEjDwUSqRQ==
 
 pako@~1.0.2, pako@~1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Fixes #1096 

There were some API changes since v1.0.0, particularly commit mozilla/page-metadata-parser@920b786.