### PR TITLE
Fix bug in creating annotations where url ids would not be normalised.

### DIFF
--- a/src/annotations/background/index.ts
+++ b/src/annotations/background/index.ts
@@ -355,6 +355,8 @@ export default class DirectLinkingBackground {
         }
 
         let normalizedPageUrl = this._normalizeUrl(fullPageUrl)
+        toCreate.url = this._normalizeUrl(normalizedPageUrl)
+
         if (toCreate.isSocialPost) {
             normalizedPageUrl = await this.lookupSocialId(normalizedPageUrl)
         }
@@ -374,6 +376,18 @@ export default class DirectLinkingBackground {
                 { addInboxEntryOnCreate: true },
             )
         }
+
+        if (isFullUrl(normalizedPageUrl) || isFullUrl(annotationUrl)) {
+            console.error(
+                `Tried to create annotation with non-normalised url`,
+                {
+                    normalizedPageUrl,
+                    annotationUrl,
+                },
+            )
+            throw new Error(`Cannot create annotation with non-normalised url`)
+        }
+
         await this.annotationStorage.createAnnotation({
             pageUrl: normalizedPageUrl,
             url: annotationUrl,

--- a/src/background-script/quick-and-dirty-migrations.ts
+++ b/src/background-script/quick-and-dirty-migrations.ts
@@ -55,11 +55,7 @@ export const migrations: Migrations = {
             .table('annotBookmarks')
             .where('url')
             .anyOf([...annotations.keys()])
-            .modify((a) => {
-                console.log({ a, url: annotations.get(a.url).url })
-                return (a.url = annotations.get(a.url).url)
-            })
-
+            .modify((a) => (a.url = annotations.get(a.url).url))
         await db
             .table('tags')
             .where('url')

--- a/src/content-scripts/content_script/global.ts
+++ b/src/content-scripts/content_script/global.ts
@@ -104,7 +104,7 @@ export async function main() {
         getSelection: () => document.getSelection(),
         getUrlAndTitle: () => ({
             title: getPageTitle(),
-            pageUrl: getPageUrl(),
+            pageUrl: getNormalizedPageUrl(),
         }),
     }
 


### PR DESCRIPTION
In researching refactoring approaches for multi-content IDs and `normalizedURL` I came across an issue here where annotations were not beings saved with their normalisedUrl (instead using their full url). 

Annotations used to be saved using their normalised url so I'm assuming that's the desired affect here, although this isn't documented.

Seemed to have been introduced with recent clean up to some of the old annotation code, and missed due the the multiple code paths. Postmortom of the bug: mainly due to the known normalisedUrl inconsistencies, exasberated by the lack of types and tests in this part of the code.

In this PR I've fixed it in two places
- Supplying the `getNormalizedPageUrl()` to the pageUrl instead of the fullUrl, it doesn't seem like the fullUrl is wanted here. 
- Making sure to run the normalizeURL function again on the `toCreate.url` anyway, since we do that in other places, it seems idempotent.

And also tried to check if a fullUrl somehow got through and throw an error rather than integrity loss of the data.

I haven't created a Memex migration before so I'd also like @poltak and @ShishKabab eyes on the migration I made. It's not the most performance oriented query, and did make my laptop fan spin for a second on extension reload. Seems to follow the previous convention though. Not sure the importance of optimising it.

Really looking forward to refactoring the whole normalizedUrl pipeline ASAP

Specific review requested:
- Passing `getNormalizedPageUrl()` to the pageUrl instead of the fullUrl - No reason not to?
- Migration performance, any quick suggestions to change it or good enough?
- Sharing implications, anything we have to for annotations that might have already been shared? If so do we know how many have been shared with the full URL rather than normalisedURL, whether it's important to fix them, and how/when to run a FS query to do so. 

