### PR TITLE
RPC Refactor - New Port based transport layer

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,10 @@ import { createSelfTests } from '@worldbrain/memex-common/lib/self-tests'
 import initStorex from './search/memex-storex'
 import getDb, { setStorex } from './search/get-db'
 import initSentry from './util/raven'
-import { setupRemoteFunctionsImplementations } from 'src/util/webextensionRPC'
+import {
+    setRpcConnection,
+    setupRemoteFunctionsImplementations,
+} from 'src/util/webextensionRPC'
 import { StorageChangesManager } from 'src/util/storage-changes'
 
 // Features that require manual instantiation to setup
@@ -35,6 +38,8 @@ import {
 import { createServices } from './services'
 
 export async function main() {
+    setRpcConnection('background').registerListenerForIncomingConnections()
+
     const localStorageChangesManager = new StorageChangesManager({
         storage: browser.storage,
     })

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,7 +6,7 @@ import initStorex from './search/memex-storex'
 import getDb, { setStorex } from './search/get-db'
 import initSentry from './util/raven'
 import {
-    setRpcConnection,
+    setupRpcConnection,
     setupRemoteFunctionsImplementations,
 } from 'src/util/webextensionRPC'
 import { StorageChangesManager } from 'src/util/storage-changes'
@@ -38,7 +38,7 @@ import {
 import { createServices } from './services'
 
 export async function main() {
-    setRpcConnection('background').registerListenerForIncomingConnections()
+    setupRpcConnection({ sideName: 'background', role: 'background' })
 
     const localStorageChangesManager = new StorageChangesManager({
         storage: browser.storage,

--- a/src/content-scripts/content_script/global.ts
+++ b/src/content-scripts/content_script/global.ts
@@ -14,7 +14,7 @@ import {
     runInBackground,
     RemoteFunctionRegistry,
     makeRemotelyCallableType,
-    setRpcConnection,
+    setupRpcConnection,
 } from 'src/util/webextensionRPC'
 import { Resolvable, resolvablePromise } from 'src/util/resolvable'
 import { ContentScriptRegistry } from './types'
@@ -45,7 +45,7 @@ import { browser } from 'webextension-polyfill-ts'
 // and dependencies of content scripts.
 
 export async function main({ loadRemotely } = { loadRemotely: true }) {
-    setRpcConnection('content-script-global').registerConnectionToBackground()
+    setupRpcConnection({ sideName: 'content-script-global', role: 'content' })
 
     setupPageContentRPC()
     runInBackground<PageIndexingInterface<'caller'>>().setTabAsIndexable()

--- a/src/content-scripts/content_script/global.ts
+++ b/src/content-scripts/content_script/global.ts
@@ -14,6 +14,7 @@ import {
     runInBackground,
     RemoteFunctionRegistry,
     makeRemotelyCallableType,
+    setRpcConnection,
 } from 'src/util/webextensionRPC'
 import { Resolvable, resolvablePromise } from 'src/util/resolvable'
 import { ContentScriptRegistry } from './types'
@@ -37,12 +38,15 @@ import analytics from 'src/analytics'
 import { main as highlightMain } from 'src/content-scripts/content_script/highlights'
 import { PageIndexingInterface } from 'src/page-indexing/background/types'
 import { copyToClipboard } from 'src/annotations/content_script/utils'
+import { browser } from 'webextension-polyfill-ts'
 
 // Content Scripts are separate bundles of javascript code that can be loaded
 // on demand by the browser, as needed. This main function manages the initialisation
 // and dependencies of content scripts.
 
-export async function main() {
+export async function main({ loadRemotely } = { loadRemotely: true }) {
+    setRpcConnection('content-script-global').registerConnectionToBackground()
+
     setupPageContentRPC()
     runInBackground<PageIndexingInterface<'caller'>>().setTabAsIndexable()
 

--- a/src/content-scripts/content_script/ribbon.ts
+++ b/src/content-scripts/content_script/ribbon.ts
@@ -5,8 +5,6 @@ import { ContentScriptRegistry, RibbonScriptMain } from './types'
 import { setupRibbonUI, destroyRibbonUI } from 'src/in-page-ui/ribbon/react'
 import { createInPageUI, destroyInPageUI } from 'src/in-page-ui/utils'
 import { setSidebarState, getSidebarState } from 'src/sidebar-overlay/utils'
-import { runInBackground } from 'src/util/webextensionRPC'
-import { ContentScriptsInterface } from '../background/types'
 
 export const main: RibbonScriptMain = async (options) => {
     const cssFile = browser.extension.getURL(`/content_script_ribbon.css`)

--- a/src/content-scripts/content_script/sidebar.ts
+++ b/src/content-scripts/content_script/sidebar.ts
@@ -7,8 +7,6 @@ import {
     setupInPageSidebarUI,
     destroyInPageSidebarUI,
 } from 'src/sidebar/annotations-sidebar/index'
-import { runInBackground } from 'src/util/webextensionRPC'
-import { ContentScriptsInterface } from '../background/types'
 import { InPageUIRootMount } from 'src/in-page-ui/types'
 
 export const main: SidebarScriptMain = async (dependencies) => {

--- a/src/options/options.jsx
+++ b/src/options/options.jsx
@@ -9,12 +9,16 @@ import Router from './router'
 import routes from './routes'
 import { ModalsContainer } from '../overview/modals/components/ModalsContainer'
 import { AuthContextProvider } from 'src/authentication/components/AuthContextProvider'
+import { setRpcConnection } from 'src/util/webextensionRPC'
+import { browser } from 'webextension-polyfill-ts/src/generated/index'
 
 // Include development tools if we are not building for production
 const ReduxDevTools = undefined
 // process.env.NODE_ENV !== 'production'
 //     ? require('src/dev/redux-devtools-component').default
 //     : undefined
+
+setRpcConnection('extension-page-options').registerConnectionToBackground()
 
 const store = configureStore({ ReduxDevTools })
 

--- a/src/options/options.jsx
+++ b/src/options/options.jsx
@@ -9,7 +9,7 @@ import Router from './router'
 import routes from './routes'
 import { ModalsContainer } from '../overview/modals/components/ModalsContainer'
 import { AuthContextProvider } from 'src/authentication/components/AuthContextProvider'
-import { setRpcConnection } from 'src/util/webextensionRPC'
+import { setupRpcConnection } from 'src/util/webextensionRPC'
 import { browser } from 'webextension-polyfill-ts/src/generated/index'
 
 // Include development tools if we are not building for production
@@ -18,7 +18,7 @@ const ReduxDevTools = undefined
 //     ? require('src/dev/redux-devtools-component').default
 //     : undefined
 
-setRpcConnection('extension-page-options').registerConnectionToBackground()
+setupRpcConnection({ sideName: 'extension-page-options', role: 'content' })
 
 const store = configureStore({ ReduxDevTools })
 

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -7,6 +7,9 @@ import ErrorBoundary from 'src/common-ui/components/ErrorBoundary'
 import RuntimeError from 'src/common-ui/components/RuntimeError'
 import Popup from './container'
 import configureStore from './store'
+import { setRpcConnection } from 'src/util/webextensionRPC'
+
+setRpcConnection('content-script-popup').registerConnectionToBackground()
 
 const store = configureStore()
 

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -7,9 +7,9 @@ import ErrorBoundary from 'src/common-ui/components/ErrorBoundary'
 import RuntimeError from 'src/common-ui/components/RuntimeError'
 import Popup from './container'
 import configureStore from './store'
-import { setRpcConnection } from 'src/util/webextensionRPC'
+import { setupRpcConnection } from 'src/util/webextensionRPC'
 
-setRpcConnection('content-script-popup').registerConnectionToBackground()
+setupRpcConnection({ sideName: 'content-script-popup', role: 'content' })
 
 const store = configureStore()
 

--- a/src/util/rpc/rpc.ts
+++ b/src/util/rpc/rpc.ts
@@ -1,0 +1,224 @@
+import uuid from 'uuid/v1'
+import { Events } from 'webextension-polyfill-ts/src/generated/events'
+import { Runtime } from 'webextension-polyfill-ts'
+
+interface RPCObject {
+    headers: {
+        type: 'RPC_RESPONSE' | 'RPC_REQUEST'
+        id: string
+        name: string
+    }
+    payload: any
+}
+
+interface PendingRequest {
+    request: RPCObject
+    promise: { resolve: any; reject: any }
+}
+
+type RuntimeConnect = (
+    extensionId?: string,
+    connectInfo?: { name?: string },
+) => Runtime.Port
+type RuntimeOnConnect = Events.Event<(port: Runtime.Port) => void>
+
+export class PortBasedRPCManager {
+    private ports = new Map<string, Runtime.Port>()
+    private pendingRequests = new Map<string, PendingRequest>()
+
+    static createRPCResponseObject = ({ packet, payload }): RPCObject => ({
+        headers: {
+            type: 'RPC_RESPONSE',
+            id: packet.headers.id,
+            name: packet.headers.name,
+        },
+        payload,
+    })
+
+    static createRPCRequestObject = ({ name, payload }): RPCObject => ({
+        headers: {
+            type: 'RPC_REQUEST',
+            id: uuid(),
+            name: `${name}`,
+        },
+        payload,
+    })
+
+    getPortIdForExtBg = () => `${this.sideName}-background`
+    getPortIdForTab = (tabId: number) => `content-script-background|t:${tabId}`
+
+    getPortId = (port: Runtime.Port) => {
+        if (port.sender?.tab) {
+            return this.getPortIdForTab(port.sender.tab.id)
+        }
+
+        if (port.sender?.url) {
+            return `n:${port.name}|url:${port.sender?.url}`
+        }
+
+        if (port.name) {
+            return `n:${port.name}`
+        }
+
+        console.error({ port })
+        throw new Error(
+            `Port has neither Sender or a name, something went wrong`,
+        )
+    }
+
+    constructor(
+        private sideName,
+        private getRegisteredRemoteFunction,
+        private connect: RuntimeConnect,
+        private onConnect: RuntimeOnConnect,
+        private debug: boolean = false,
+    ) {}
+
+    log = (msg: string, obj?: any) => {
+        if (this.debug === true || window['memex-rpc-debug']) {
+            console['log'](msg, obj ?? {})
+        }
+    }
+
+    registerConnectionToBackground() {
+        const pid = `${this.sideName}-bg`
+        this.log(`RPC::registerConnectionToBackground::from ${this.sideName}`)
+        const port = this.connect(undefined, { name: pid })
+        this.ports.set(this.getPortIdForExtBg(), port)
+
+        const RPCResponder = this.messageResponder
+        port.onMessage.addListener(RPCResponder)
+    }
+
+    registerListenerForIncomingConnections() {
+        const connected = (port: Runtime.Port) => {
+            this.log(
+                `RPC::onConnect::Side:${
+                    this.sideName
+                } got a connection from ${this.getPortId(port)}`,
+            )
+            this.ports.set(this.getPortId(port), port)
+            port.onMessage.addListener(this.messageResponder)
+            port.onDisconnect.addListener((_port) =>
+                this.ports.delete(this.getPortId(_port)),
+            )
+        }
+
+        this.onConnect.addListener(connected)
+    }
+
+    public postMessageRequestToExtension(name, payload) {
+        const port = this.ports.get(this.getPortIdForExtBg())
+        if (!port) {
+            console.error({ ports: this.ports })
+            throw new Error(
+                `Could not get a port to message the extension [${this.getPortIdForExtBg()}] (when trying to call [${name}] )`,
+            )
+        }
+        return this.postMessageRequestToRPC(port, name, payload)
+    }
+
+    public postMessageRequestToTab(tabId, name, payload) {
+        const port = this.ports.get(this.getPortIdForTab(tabId))
+        if (!port) {
+            console.error({ ports: this.ports })
+            throw new Error(
+                `Could not get a port to ${this.getPortIdForTab(
+                    tabId,
+                )} (when trying to call [${name}]`,
+            )
+        }
+        return this.postMessageRequestToRPC(port, name, payload)
+    }
+
+    private postMessageRequestToRPC = async (
+        port: Runtime.Port,
+        name: string,
+        payload: any,
+    ) => {
+        const request = PortBasedRPCManager.createRPCRequestObject({
+            name,
+            payload,
+        })
+
+        // Return the promise for to await for and allow the promise to be resolved by
+        // incoming messages
+        const pendingRequest = new Promise((resolve, reject) => {
+            this.addPendingRequest(request.headers.id, {
+                request,
+                promise: { resolve, reject },
+            })
+        })
+
+        port.postMessage(request)
+        this.log(
+            `RPC::messageRequester::to-PortName(${port.name}):: Requested for [${name}]`,
+            { request },
+        )
+        const ret = await pendingRequest
+        this.log(
+            `RPC::messageRequester::to-PortName(${port.name}):: Response for [${name}]`,
+            { ret },
+        )
+        return ret
+    }
+
+    private addPendingRequest = (id, request) => {
+        this.pendingRequests.set(id, request)
+    }
+
+    private messageResponder = (packet, port) => {
+        const { headers, payload } = packet
+        const { id, name, type } = headers
+
+        if (type === 'RPC_RESPONSE') {
+            this.log(
+                `RPC::messageResponder::PortName(${port.name}):: RESPONSE received for [${name}]`,
+            )
+            this.resolvePendingRequest(id, payload)
+        } else if (type === 'RPC_REQUEST') {
+            this.log(
+                `RPC::messageResponder::PortName(${port.name}):: REQUEST received for [${name}]`,
+            )
+            const f = this.getRegisteredRemoteFunction(name)
+
+            if (!f) {
+                console.error({ side: this.sideName, packet, port })
+                throw Error(`No registered remote function called ${name}`)
+            }
+            Object.defineProperty(f, 'name', { value: name })
+
+            this.log(
+                `RPC::messageResponder::PortName(${port.name}):: RUNNING Function [${name}]`,
+            )
+            const returnPromise = Promise.resolve(
+                f({ tab: port?.sender?.tab }, ...payload),
+            )
+            returnPromise.then((value) => {
+                port.postMessage(
+                    PortBasedRPCManager.createRPCResponseObject({
+                        packet,
+                        payload: value,
+                    }),
+                )
+                this.log(
+                    `RPC::messageResponder::PortName(${port.name}):: RETURNED Function [${name}]`,
+                )
+            })
+        }
+    }
+
+    private resolvePendingRequest = (id, payload) => {
+        const request = this.pendingRequests.get(id)
+
+        if (!request) {
+            console.error({ sideName: this.sideName, id, payload })
+            throw new Error(
+                `Tried to resolve a request that does not exist (may have already been resolved) id:${id}`,
+            )
+        }
+
+        request.promise.resolve(payload)
+        this.pendingRequests.delete(id)
+    }
+}

--- a/src/util/webextensionRPC.ts
+++ b/src/util/webextensionRPC.ts
@@ -346,13 +346,24 @@ export function getRemoteEventEmitter<EventType extends keyof RemoteEvents>(
 
 // Containing the evil globals here
 let rpcConnection: PortBasedRPCManager
-export const setRpcConnection = (sideName) => {
+export const setupRpcConnection = (options: {
+    sideName: string
+    role: 'content' | 'background'
+}) => {
     rpcConnection = new PortBasedRPCManager(
-        sideName,
+        options.sideName,
         (name) => remotelyCallableFunctions[name],
         browser.runtime.connect,
         browser.runtime.onConnect,
     )
+
+    if (options.role === 'content') {
+        rpcConnection.registerConnectionToBackground()
+    }
+
+    if (options.role === 'background') {
+        rpcConnection.registerListenerForIncomingConnections()
+    }
 
     return rpcConnection
 }


### PR DESCRIPTION
Switched out the underlying message pasing mechanism between content
scripts and background page to use Runtime.onConnect and exchange
messages over specific ports rather than one global channel.

Was needed to fix issues when using multiple extension pages, like for
the PDF Viewer. Also should improve understandability and extensibility
in the long term.

some global state and much legacy still remains in the approach to
remote functions. It's not within this scope to refactor it all at this
time, but is hopefully another step in the right direction.