### PR TITLE
Skip application layer in tests

### DIFF
--- a/src/tests/background-integration-tests.ts
+++ b/src/tests/background-integration-tests.ts
@@ -229,22 +229,9 @@ export function registerBackgroundIntegrationTest(
     test: BackgroundIntegrationTest,
     options: BackgroundIntegrationTestSetupOpts = {},
 ) {
-    const skipSyncTests = process.env.SKIP_SYNC_TESTS === 'true'
-    if (skipSyncTests) {
-        it(test.description, async () => {
-            await runBackgroundIntegrationTest(test, options)
-        })
-    } else {
-        describe(test.description, () => {
-            it(
-                'should work on a single device' + (test.mark ? '!!!' : ''),
-                async () => {
-                    await runBackgroundIntegrationTest(test, options)
-                },
-            )
-            registerSyncBackgroundIntegrationTests(test, options)
-        })
-    }
+    it(test.description, async () => {
+        await runBackgroundIntegrationTest(test, options)
+    })
 }
 
 export async function runBackgroundIntegrationTest(


### PR DESCRIPTION
Due to wrong assumptions in how the tests set up the mocked server storage, the application layer was also used in the tests. Fixed here.