### PR TITLE
Add in passive data deletion to existing-user cloud onboarding

### DIFF
--- a/src/backup-restore/background/index.ts
+++ b/src/backup-restore/background/index.ts
@@ -73,6 +73,13 @@ export class BackupBackgroundModule {
             disableAutomaticBackup: this.disableAutomaticBackup,
             isAutomaticBackupEnabled: this.isAutomaticBackupEnabled,
             isAutomaticBackupAllowed: this.isAutomaticBackupAllowed,
+            disableRecordingChanges: async () => {
+                this.storage.stopRecordingChanges()
+                await this.disableAutomaticBackup()
+
+                // This is needed so the recording of changes are not restarted on next ext setup
+                await this.backupInfoStorage.storeDate('lastBackup', null)
+            },
             getBackupTimes: async () => {
                 return this.getBackupTimes()
             },

--- a/src/backup-restore/background/types.ts
+++ b/src/backup-restore/background/types.ts
@@ -9,6 +9,7 @@ export interface BackupInterface<Role extends RemoteFunctionRole> {
     isAutomaticBackupAllowed: RemotePositionalFunction<Role, [], boolean>
     disableAutomaticBackup: RemotePositionalFunction<Role, [], void>
     enableAutomaticBackup: RemotePositionalFunction<Role, [], void>
+    disableRecordingChanges: RemotePositionalFunction<Role, [], void>
     getBackupTimes: RemotePositionalFunction<Role, [], BackupTimes>
     startBackup: RemotePositionalFunction<Role, [], void>
 }

--- a/src/common-ui/components/design-library/actions/PrimaryAction.tsx
+++ b/src/common-ui/components/design-library/actions/PrimaryAction.tsx
@@ -11,7 +11,7 @@ import {
 
 const StyledPrimaryAction = styled.div`
     padding: 8px 20px;
-    height: 36px;
+    height: 35px;
     overflow: visible;
     white-space: nowrap;
     display: flex;

--- a/src/personal-cloud/background/index.ts
+++ b/src/personal-cloud/background/index.ts
@@ -34,6 +34,7 @@ import {
     ActionPreprocessor,
 } from '@worldbrain/memex-common/lib/action-queue/types'
 import { STORAGE_VERSIONS } from 'src/storage/constants'
+import { wipePassiveData } from 'src/storage/passive-data-wipe'
 import { SettingStore } from 'src/util/settings'
 import { blobToString } from 'src/util/blob-utils'
 import * as Raven from 'src/util/raven'
@@ -78,7 +79,10 @@ export class PersonalCloudBackground {
 
         this.remoteFunctions = {
             isPassiveDataRemovalNeeded: this.isPassiveDataRemovalNeeded,
-            runPassiveDataClean: () => delay(2000),
+            runPassiveDataClean: () =>
+                wipePassiveData({
+                    db: options.storageManager.backend['dexie'],
+                }),
             runDataDump: () => delay(2000),
             runDataMigration: () => delay(2000),
             runDataMigrationPreparation: () => delay(2000),

--- a/src/personal-cloud/ui/components/data-dumper.tsx
+++ b/src/personal-cloud/ui/components/data-dumper.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 
 import { PrimaryAction } from 'src/common-ui/components/design-library/actions/PrimaryAction'
 import { SecondaryAction } from 'src/common-ui/components/design-library/actions/SecondaryAction'
@@ -25,11 +26,11 @@ export default class DataDumper extends React.PureComponent<Props> {
             return (
                 <>
                     <SecondaryAction
-                        label="Make backup of existing data"
+                        label="Backup existing data"
                         onClick={this.props.onStartClick}
                     />
                     <PrimaryAction
-                        label="Continue migration without backup"
+                        label="Continue migration"
                         onClick={this.props.onContinueClick}
                     />
                 </>
@@ -123,7 +124,7 @@ export default class DataDumper extends React.PureComponent<Props> {
                             clickable
                             onClick={this.props.onUseOldVersionClick}
                         >
-                            Migrate
+                            <u>Migrate</u>
                         </Text>{' '}
                         to the last version of Memex.
                     </Text>

--- a/src/personal-cloud/ui/components/data-migrator.tsx
+++ b/src/personal-cloud/ui/components/data-migrator.tsx
@@ -5,7 +5,7 @@ import { SecondaryAction } from 'src/common-ui/components/design-library/actions
 import { UITaskState } from '@worldbrain/memex-common/lib/main-ui/types'
 import LoadingIndicator from '@worldbrain/memex-common/lib/common-ui/components/loading-indicator'
 import Icon from '@worldbrain/memex-common/lib/common-ui/components/icon'
-import { Container, BtnBox, Header, Text } from './shared-components'
+import { Container, BtnBox, Header, Text, TopComponent } from './shared-components'
 
 export interface Props {
     isPrepping: boolean
@@ -57,7 +57,9 @@ export default class DataMigrator extends React.PureComponent<Props> {
         if (migrationState === 'running') {
             return isPrepping ? (
                 <>
-                    <LoadingIndicator />
+                    <TopComponent>
+                        <LoadingIndicator />
+                    </TopComponent>
                     <Header>Preparing Cloud Migration</Header>
                     <Text>
                         Don't close your browser or shut off your computer in
@@ -66,12 +68,14 @@ export default class DataMigrator extends React.PureComponent<Props> {
                 </>
             ) : (
                 <>
-                    <LoadingIndicator />
+                    <TopComponent>
+                        <LoadingIndicator />
+                    </TopComponent>
                     <Header>Cloud Migration in Progress</Header>
                     <Text>
                         This process with run and continue in the background.
-                    </Text>
-                    <Text>
+                        <br/>
+                        <br/>
                         It may take a while for all content to appear on all
                         your devices.
                     </Text>
@@ -81,7 +85,9 @@ export default class DataMigrator extends React.PureComponent<Props> {
         if (migrationState === 'error') {
             return (
                 <>
+                    <TopComponent>
                     <Icon icon="alertRound" height="20px" />
+                    </TopComponent>
                     <Header>
                         There was an error with migrating your data to the cloud
                     </Header>
@@ -94,7 +100,9 @@ export default class DataMigrator extends React.PureComponent<Props> {
         }
         return (
             <>
-                <Icon icon="checkRound" height="20px" />
+                <TopComponent>
+                    <Icon icon="checkRound" height="20px" />
+                </TopComponent>
                 <Header>Cloud Migration Complete</Header>
                 <Text>Login on other devices to sync them.</Text>
             </>

--- a/src/personal-cloud/ui/components/shared-components.tsx
+++ b/src/personal-cloud/ui/components/shared-components.tsx
@@ -4,13 +4,33 @@ export const Container = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: center;
+    width: 800px;
+    height: 400px;
+    align-items: center;
 `
 
 export const BtnBox = styled.div`
     display: flex;
-    justify-content: center;
+    justify-content: space-around;
+    width: 360px;
 `
 
-export const Header = styled.h1``
+export const Header = styled.div`
+	font-size: 24px;
+    color: ${(props) => props.theme.colors.primary};
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 15px;
+`
 
-export const Text = styled.span<{ dimmed: boolean; clickable: boolean }>``
+export const TopComponent = styled.div`
+	margin-bottom: 20px;
+`
+
+export const Text = styled.span<{ dimmed: boolean; clickable: boolean }>`
+	color: ${(props) => props.dimmed ? props.theme.colors.subText : props.theme.colors.primary};
+	margin-bottom: ${(props) => props.dimmed ? '0px' : '40px'};
+	margin-top: ${(props) => props.dimmed && '20px'};
+	font-size: ${(props) => !props.dimmed && '14px'};
+	text-align: center;
+`

--- a/src/personal-cloud/ui/components/shared-components.tsx
+++ b/src/personal-cloud/ui/components/shared-components.tsx
@@ -11,12 +11,12 @@ export const Container = styled.div`
 
 export const BtnBox = styled.div`
     display: flex;
-    justify-content: space-around;
-    width: 360px;
+    grid-auto-flow: column;
+    grid-column-gap: 10px;
 `
 
 export const Header = styled.div`
-	font-size: 24px;
+	font-size: 20px;
     color: ${(props) => props.theme.colors.primary};
     font-weight: bold;
     text-align: center;

--- a/src/personal-cloud/ui/onboarding/logic.test.ts
+++ b/src/personal-cloud/ui/onboarding/logic.test.ts
@@ -82,6 +82,20 @@ describe('Cloud onboarding UI logic', () => {
         ).toBe(true)
     })
 
+    it('should disable DB backup change recording before performing passive data wipe', async ({
+        device,
+    }) => {
+        let recordingChanges = true
+        device.backgroundModules.backupModule.remoteFunctions.disableRecordingChanges = async () => {
+            recordingChanges = false
+        }
+        const { logic } = await setupTest(device)
+
+        expect(recordingChanges).toBe(true)
+        await logic.processEvent('startDataClean', null)
+        expect(recordingChanges).toBe(false)
+    })
+
     it('should determine whether dump is needed, based on last backup time existence', async ({
         device,
     }) => {

--- a/src/personal-cloud/ui/onboarding/logic.ts
+++ b/src/personal-cloud/ui/onboarding/logic.ts
@@ -71,8 +71,11 @@ export default class CloudOnboardingModalLogic extends UILogic<State, Event> {
     }
 
     private async attemptPassiveDataClean(state: State) {
+        const { personalCloudBG, backupBG } = this.dependencies
+
         await executeUITask(this, 'dataCleaningState', async () => {
-            await this.dependencies.personalCloudBG.runPassiveDataClean()
+            await backupBG.disableRecordingChanges()
+            await personalCloudBG.runPassiveDataClean()
             // Uncomment this to show error state:
             // throw new Error()
         })

--- a/src/storage/passive-data-wipe.test.ts
+++ b/src/storage/passive-data-wipe.test.ts
@@ -1,0 +1,72 @@
+import type Dexie from 'dexie'
+import { makeSingleDeviceUILogicTestFactory } from 'src/tests/ui-logic-tests'
+import { wipePassiveData } from './passive-data-wipe'
+
+const ACTIVE_PAGE_URLS = ['a.com', 'b.com', 'c.com', 'd.com']
+const ORPHANED_PAGE_URLS = ['e.com', 'f.com', 'g.com', 'h.com']
+const ALL_PAGE_URLS = [...ACTIVE_PAGE_URLS, ...ORPHANED_PAGE_URLS]
+
+async function insertTestData({ db }: { db: Dexie }) {
+    for (const pageUrl of ALL_PAGE_URLS) {
+        await db.table('pages').put({ url: pageUrl, hostname: pageUrl })
+        await db.table('favIcons').put({ hostname: pageUrl })
+    }
+
+    await db.table('bookmarks').put({
+        url: ACTIVE_PAGE_URLS[0],
+    })
+    await db.table('annotations').put({
+        url: ACTIVE_PAGE_URLS[1] + '/#1234',
+        pageUrl: ACTIVE_PAGE_URLS[1],
+    })
+    await db.table('pageListEntries').put({
+        listId: 123,
+        pageUrl: ACTIVE_PAGE_URLS[2],
+    })
+    await db.table('tags').put({
+        url: ACTIVE_PAGE_URLS[3],
+        name: 'test-tag',
+    })
+}
+
+async function assertPageExists(args: {
+    db: Dexie
+    pageUrl: string
+    exists: boolean
+}) {
+    expect(await args.db.table('pages').get(args.pageUrl)).toEqual(
+        args.exists ? { url: args.pageUrl, hostname: args.pageUrl } : undefined,
+    )
+    expect(await args.db.table('favIcons').get(args.pageUrl)).toEqual(
+        args.exists ? { hostname: args.pageUrl } : undefined,
+    )
+}
+
+describe('passive data wipe tests', () => {
+    const it = makeSingleDeviceUILogicTestFactory()
+
+    it('should not delete pages with associated data', async ({ device }) => {
+        const db: Dexie = device.storageManager.backend['dexie']
+        await insertTestData({ db })
+
+        await Promise.all([
+            ...ACTIVE_PAGE_URLS.map((pageUrl) =>
+                assertPageExists({ db, pageUrl, exists: true }),
+            ),
+            ...ORPHANED_PAGE_URLS.map((pageUrl) =>
+                assertPageExists({ db, pageUrl, exists: true }),
+            ),
+        ])
+
+        await wipePassiveData({ db })
+
+        await Promise.all([
+            ...ACTIVE_PAGE_URLS.map((pageUrl) =>
+                assertPageExists({ db, pageUrl, exists: true }),
+            ),
+            ...ORPHANED_PAGE_URLS.map((pageUrl) =>
+                assertPageExists({ db, pageUrl, exists: false }),
+            ),
+        ])
+    })
+})

--- a/src/storage/passive-data-wipe.ts
+++ b/src/storage/passive-data-wipe.ts
@@ -1,0 +1,64 @@
+import type Dexie from 'dexie'
+
+const differenceSets = <T extends string | number>(
+    a: Set<T>,
+    b: Set<T>,
+): Set<T> => new Set([...a].filter((val) => !b.has(val)))
+
+export async function wipePassiveData(args: { db: Dexie }): Promise<void> {
+    // Adds urls and pageUrls from active data into an activeUrls set
+    const t_bookmarks = await args.db
+        .table('bookmarks')
+        .toCollection()
+        .primaryKeys()
+    const t_annotations = await args.db
+        .table('annotations')
+        .orderBy('pageUrl')
+        .uniqueKeys()
+    const t_collections = await args.db
+        .table('pageListEntries')
+        .orderBy('pageUrl')
+        .uniqueKeys()
+    const t_tags = await args.db.table('tags').orderBy('url').uniqueKeys()
+
+    const activePageUrls = new Set([
+        ...t_bookmarks,
+        ...t_annotations,
+        ...t_collections,
+        ...t_tags,
+    ] as string[])
+
+    // Adds stored pages to a set to find the difference - orphanPageUrls
+    const t_pages = await args.db.table('pages').toCollection().primaryKeys()
+    const allPageUrls = new Set(t_pages as string[])
+    const orphanPageUrls = differenceSets(allPageUrls, activePageUrls)
+
+    // Do the deletes
+    await args.db
+        .table('visits')
+        .where('url')
+        .anyOf([...orphanPageUrls])
+        .delete()
+    const numDeletedPages = await args.db
+        .table('pages')
+        .where('url')
+        .anyOf([...orphanPageUrls])
+        .delete()
+
+    if (numDeletedPages === 0) {
+        return
+    }
+
+    // After Pages have been deleted, check to see if any favIcons now can be deleted
+    const t_pageHostnames = await args.db
+        .table('pages')
+        .orderBy('hostname')
+        .uniqueKeys()
+    const pageHostnames = new Set(t_pageHostnames as string[])
+
+    await args.db
+        .table('favIcons')
+        .where('hostname')
+        .noneOf([...pageHostnames])
+        .delete()
+}

--- a/src/storage/passive-data-wipe.ts
+++ b/src/storage/passive-data-wipe.ts
@@ -5,7 +5,7 @@ const differenceSets = <T extends string | number>(
     b: Set<T>,
 ): Set<T> => new Set([...a].filter((val) => !b.has(val)))
 
-export async function wipePassiveData(args: { db: Dexie }): Promise<void> {
+const _wipePassiveData = (args: { db: Dexie }) => async (): Promise<void> => {
     // Adds urls and pageUrls from active data into an activeUrls set
     const t_bookmarks = await args.db
         .table('bookmarks')
@@ -62,3 +62,18 @@ export async function wipePassiveData(args: { db: Dexie }): Promise<void> {
         .noneOf([...pageHostnames])
         .delete()
 }
+
+export const wipePassiveData = (args: { db: Dexie }) =>
+    args.db.transaction(
+        'rw!',
+        [
+            'tags',
+            'pages',
+            'visits',
+            'favIcons',
+            'bookmarks',
+            'annotations',
+            'pageListEntries',
+        ],
+        _wipePassiveData(args),
+    )


### PR DESCRIPTION
Included:
- Passive data deletion logic adapted from @cdharris snippet on https://www.notion.so/worldbrain/Clean-existing-data-before-while-migrating-data-to-cloud-cc840cbca1b54c139b670a6710740a41
- DB change recording for backups disabled prior to executing passive data deletion

Not included, but part of the specs:
- Setting the extension install time key based on the oldest visit. Didn't do this as we still haven't gotten around to the move to the new settings collection. Unsure if this data should be moved to that collection or kept in local storage.