### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/backup-restore/background/procedures/restore/index.ts
+++ b/src/backup-restore/background/procedures/restore/index.ts
@@ -357,7 +357,7 @@ export class BackupRestoreProcedure {
 
     _blobFromPngString(s: string) {
         const prefix = 'data:'
-        if (s.substr(0, prefix.length) !== prefix) {
+        if (s.slice(0, prefix.length) !== prefix) {
             s = 'data:image/png;base64,' + s
         }
         return decodeBlob(s, {

--- a/src/common-ui/components/TextInputControlled.tsx
+++ b/src/common-ui/components/TextInputControlled.tsx
@@ -520,7 +520,7 @@ export class SelectionModifiers {
 
     static _lastWhitespace(current: SelectionState, cursorToMove: string) {
         const lastWhitespaces: RegExpMatchArray = matchAll(
-            current.text.substr(0, current.selection[cursorToMove] - 1),
+            current.text.substring(0, current.selection[cursorToMove] - 1),
             /(\s)/gm,
         )
         const lastWhitespaceArray = [...lastWhitespaces]
@@ -532,7 +532,7 @@ export class SelectionModifiers {
 
     static _nextWhitespace(current: SelectionState, cursorToMove: string) {
         const nextWhitespaces = matchAll(
-            current.text.substr(current.selection[cursorToMove] + 1),
+            current.text.slice(current.selection[cursorToMove] + 1),
             /(\s)/gm,
         )
         const nextWhitespaceArray = [...nextWhitespaces] as RegExpMatchArray
@@ -617,7 +617,7 @@ export class SelectionModifiers {
     static _distanceFromNewLine(current: SelectionState): number {
         // find either a newline or the start if no prev newline
         const lastNewline = current.text
-            .substr(0, current.selection.end)
+            .slice(0, current.selection.end)
             .lastIndexOf('\n')
         return lastNewline === -1
             ? current.selection.end
@@ -627,14 +627,14 @@ export class SelectionModifiers {
     static _indexOfPreviousLine(current: SelectionState): number {
         // find either a newline or the start if no prev newline
         let previousNewLine = current.text
-            .substr(0, current.selection.end)
+            .slice(0, current.selection.end)
             .lastIndexOf('\n')
         if (previousNewLine === -1) {
             return 0
         } else {
             // If we're on a newline boundary, actually find the one before
             previousNewLine = current.text
-                .substr(0, previousNewLine)
+                .slice(0, previousNewLine)
                 .lastIndexOf('\n')
         }
 

--- a/src/common-ui/containers/IndexDropdown.tsx
+++ b/src/common-ui/containers/IndexDropdown.tsx
@@ -205,7 +205,7 @@ class IndexDropdownContainer extends Component<Props, State> {
         const { hover, source } = this.props
 
         // Make first letter capital
-        const sourceType = source.charAt(0).toUpperCase() + source.substr(1)
+        const sourceType = source.charAt(0).toUpperCase() + source.slice(1)
     }
     /**
      * Selector for derived display tags state

--- a/src/common-ui/utils.ts
+++ b/src/common-ui/utils.ts
@@ -45,7 +45,7 @@ export function uninsertTab({ el, tabStr = '  ' }: InsertTabProps) {
 export function insertIndentedNewLine({ el }: InsertTabProps) {
     const { value, selectionStart, selectionEnd } = el
 
-    let lineNo = value.substr(0, selectionStart).split(/\r?\n|\r/).length
+    let lineNo = value.slice(0, selectionStart).split(/\r?\n|\r/).length
     let lineText = el.value.split(/\r?\n|\r/)[lineNo - 1]
     let indentationCount = 0
     let indentationString = ''

--- a/src/page-analysis/extract-page-content.test.ts
+++ b/src/page-analysis/extract-page-content.test.ts
@@ -7,7 +7,7 @@ import { transformPageHTML } from '@worldbrain/memex-stemmer/lib/transform-page-
 describe('Extract page content', () => {
     // beforeAll(() => {
     //     browser.extension = {
-    //         getURL: rel => path.resolve('extension/lib', rel.substr(1)),
+    //         getURL: rel => path.resolve('extension/lib', rel.slice(1)),
     //     }
     // })
 

--- a/src/search-injection/components/youtubeActionBar.tsx
+++ b/src/search-injection/components/youtubeActionBar.tsx
@@ -429,9 +429,9 @@ export default class YoutubeButtonMenu extends React.Component<Props, State> {
             const formatTimestamp = (seconds) => {
                 const date = new Date(0)
                 date.setSeconds(seconds)
-                const timeString = date.toISOString().substr(11, 8)
+                const timeString = date.toISOString().slice(11, 19)
                 return timeString.startsWith('00:')
-                    ? timeString.substr(3)
+                    ? timeString.slice(3)
                     : timeString
             }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.