### PR TITLE
Fix broken MDN links

### DIFF
--- a/Codetour.md
+++ b/Codetour.md
@@ -4,7 +4,7 @@ A quick introduction to the folders and files in this repo.
 
 ## WebExtension anatomy
 
-To comply with the [anatomy of a WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension),
+To comply with the [anatomy of a WebExtension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension),
 this extension consists of the following parts (found in
 `extension/` after compilation):
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -222,7 +222,7 @@ provides support for the `WebExtension/BrowserExt API` in order to make the same
 
 This API is available in Chrome/Chromium by default (under `window.chrome`) but is meant to be developed and standardized as it's own thing.
 
-**For more info please see [Anatomy of a WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension)**
+**For more info please see [Anatomy of a WebExtension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension)**
 
 ## Application Structure
 
@@ -323,7 +323,7 @@ This just wraps the content scripts of activity-logger and page analysis for use
 
 Allows a user to type `w` + `space_bar` to search through worldbrain without leaving the search bar.
 
-See [Mozilla Omnibox Docs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/omnibox) for more details
+See [Mozilla Omnibox Docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/omnibox) for more details
 
 #### **[src/pouchdb.js](./src/omnibar.js)**: Our Persistent Browser Database
 

--- a/src/imports/Readme.md
+++ b/src/imports/Readme.md
@@ -24,7 +24,7 @@ to handle deriving new import items from given `DataSource` instance (wraps the 
 
 An instance of `ConnectionHandler` will be created whenever the UI script creates a connection
 (user first installs or goes to imports page). This will handle a number of special commands that
-are sent over a [`runtime.connect()` connection](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/connect) to afford control over
+are sent over a [`runtime.connect()` connection](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect) to afford control over
 imports progress and various options.
 
 `ConnectionHandler` delegates control to its `ProgressManager` instance to handle the


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This updates the old Add-ons URL to the new format.

Old: https://developer.mozilla.org/en-US/Add-ons/...
New: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/...